### PR TITLE
fix: resolve 5 calendar technical debt bugs

### DIFF
--- a/.claude/technical-debt.md
+++ b/.claude/technical-debt.md
@@ -69,90 +69,27 @@ This document tracks known issues, limitations, technical debt, and improvements
 >
 > The application no longer requires frequent re-authentication.
 
-### 5. Calendar Event Colors Not Persisting After Refresh
+### ~~5. Calendar Event Colors Not Persisting After Refresh~~ ✅ RESOLVED
 
-**Issue:** When a user authenticates with Google and loads Google calendar events, events from different connected calendars initially load in their distinct colors. However, after refreshing the page or switching tabs and returning a few minutes later, all events display in only blue.
+> **Resolved in PR #48** (#62) — Color mappings now initialize synchronously from localStorage on mount before first event transformation, eliminating the race condition.
 
-**Impact:** Users lose visual distinction between different calendars, making it harder to identify event sources at a glance.
+### ~~6. Agenda View Date Offset Bug~~ ✅ RESOLVED
 
-**Action Required:** Investigate event color storage/retrieval logic and ensure calendar colors persist across page reloads.
-
-**Possible Causes:**
-
-- Calendar metadata not being cached properly
-- Color mapping being lost during deserialization
-- Race condition in event loading
-
-**Timeline:** High priority (impacts core calendar functionality)
-
-### 6. Agenda View Date Offset Bug
-
-**Issue:** Events show on the correct days in SimpleCalendar month view, but the agenda view shows events offset one day prior to when they are scheduled.
-
-**Impact:** Users see incorrect event dates in the agenda view, leading to confusion and potential missed appointments.
-
-**Action Required:** Debug date handling in agenda view component and ensure timezone/date conversion is consistent with month view.
-
-**Possible Causes:**
-
-- Timezone conversion inconsistency
-- UTC vs local time handling
-- Date parsing during event transformation for agenda view
-
-**Timeline:** High priority (data accuracy is critical)
+> **Resolved in PR #48** (#63) — Date-only strings now get `T00:00:00` appended to force local time interpretation, fixing the UTC midnight timezone shift.
 
 ## Medium Priority
 
-### 1. All-Day Event Detection Logic (PR #23 Feedback)
+### ~~1. All-Day Event Detection Logic (PR #23 Feedback)~~ ✅ RESOLVED
 
-**Issue:** The all-day event detection in `AgendaCalendar.tsx` uses duration-based logic (`>= 24 hours`) which is incorrect for multi-day events.
+> **Resolved in PR #48** (#64) — Added `isAllDay` field to `IEvent` interface. `transformGoogleEvent` sets it based on presence of `start.date` vs `start.dateTime`. `AgendaCalendar` now uses `event.isAllDay` directly.
 
-**Impact:** Events spanning multiple days are incorrectly marked as all-day events.
+### ~~2. Color Mappings Race Condition (PR #23 Feedback)~~ ✅ RESOLVED
 
-**Root Cause:** Google Calendar API provides an explicit all-day indicator via the `date` (vs `dateTime`) field, but the current implementation checks duration instead.
+> **Resolved in PR #48** (#65) — Color mappings now initialize synchronously from localStorage in the `useState` initializer, before any event transformation occurs.
 
-**Fix Required:**
+### ~~3. All-Day Event Timezone Parsing (PR #23 Feedback)~~ ✅ RESOLVED
 
-- Check for the presence of `event.start.date` (vs `event.start.dateTime`) to determine all-day status
-- Or check for exactly 24 hours rather than "24 hours or more"
-
-**Location:** `src/components/calendar/AgendaCalendar.tsx` (lines 44-49)
-
-**Timeline:** Next iteration
-
-### 2. Color Mappings Race Condition (PR #23 Feedback)
-
-**Issue:** Color mappings load asynchronously after event transformation, creating a race condition on initial mount.
-
-**Impact:** Cached events are transformed with empty `colorMappings` on mount, causing event colors to be incorrect until the next refresh.
-
-**Root Cause:** The `useEffect` that fetches color mappings runs after the initial render, but events are transformed immediately from cache.
-
-**Fix Required:**
-
-- Load `colorMappings` from localStorage synchronously before first transformation
-- Or defer event transformation until `colorMappings` are loaded
-
-**Location:** `src/components/providers/CalendarProvider.tsx` (lines 307-322)
-
-**Timeline:** Next iteration
-
-### 3. All-Day Event Timezone Parsing (PR #23 Feedback)
-
-**Issue:** All-day event dates stored without timezone indicators get misinterpreted by JavaScript.
-
-**Impact:** Events may appear on the wrong day depending on user's local timezone (dates like "2026-01-05" parse as UTC midnight, which shifts to the previous day in many local timezones).
-
-**Root Cause:** JavaScript's `Date` constructor interprets date-only strings as UTC, not local time.
-
-**Fix Required:**
-
-- Parse all-day event dates explicitly with local timezone handling
-- Or append 'T00:00:00' to force local time interpretation
-
-**Location:** `src/components/providers/CalendarProvider.tsx` (lines 89-97)
-
-**Timeline:** Next iteration
+> **Resolved in PR #48** (#66) — Date-only strings now get `T00:00:00` appended during event transformation to force local time interpretation.
 
 ### 4. Token Storage Security
 

--- a/e2e/fixtures/mock-events.ts
+++ b/e2e/fixtures/mock-events.ts
@@ -26,6 +26,8 @@ export function createMockEvent(
     endDate: getRelativeDate(0, 11, 0),
     color: "blue",
     description: "",
+    isAllDay: false,
+    calendarId: "primary",
     user: {
       id: "user-1",
       name: "Test User",

--- a/src/app/test/calendar/page.tsx
+++ b/src/app/test/calendar/page.tsx
@@ -36,6 +36,8 @@ function createMockEvent(overrides: Partial<IEvent> & { id: string }): IEvent {
     endDate: getRelativeDate(0, 11, 0),
     color: "blue",
     description: "",
+    isAllDay: false,
+    calendarId: "primary",
     user: {
       id: "user-1",
       name: "Test User",

--- a/src/components/calendar/AgendaCalendar.tsx
+++ b/src/components/calendar/AgendaCalendar.tsx
@@ -35,18 +35,13 @@ function sortEventsByStartTime(events: IEvent[]): IEvent[] {
 }
 
 /**
- * Check if event is all-day
+ * Check if event is all-day.
+ * Uses the isAllDay flag from Google Calendar API rather than duration calculation.
+ * Google marks all-day events with start.date (not start.dateTime), which is
+ * captured during transformation.
  */
 function isAllDayEvent(event: IEvent): boolean {
-  const start = new Date(event.startDate);
-  const end = new Date(event.endDate);
-
-  // Check if event starts at midnight and spans 24 hours or more
-  const isStartMidnight = start.getHours() === 0 && start.getMinutes() === 0;
-  const duration = end.getTime() - start.getTime();
-  const is24HoursOrMore = duration >= 24 * 60 * 60 * 1000;
-
-  return isStartMidnight && is24HoursOrMore;
+  return event.isAllDay;
 }
 
 /**

--- a/src/components/calendar/__tests__/AgendaCalendar.test.tsx
+++ b/src/components/calendar/__tests__/AgendaCalendar.test.tsx
@@ -1,0 +1,252 @@
+import {
+  CalendarContext,
+  type ICalendarContext,
+} from "@/components/providers/CalendarProvider";
+import type {
+  IEvent,
+  IUser,
+  TCalendarView,
+  TEventColor,
+} from "@/types/calendar";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { AgendaCalendar } from "../AgendaCalendar";
+
+/**
+ * Regression tests for AgendaCalendar component.
+ *
+ * Covers:
+ * - Bug 1: All-day event detection uses event.isAllDay (not duration)
+ * - Bug 4: Events show on correct dates in agenda view (no offset)
+ */
+
+// Helper to create mock events with required isAllDay and calendarId fields
+function createMockEvent(overrides: Partial<IEvent> = {}): IEvent {
+  return {
+    id: "test-event-1",
+    title: "Test Event",
+    startDate: new Date().toISOString(),
+    endDate: new Date().toISOString(),
+    color: "blue",
+    description: "",
+    isAllDay: false,
+    calendarId: "primary",
+    user: {
+      id: "user-1",
+      name: "Test User",
+      picturePath: null,
+    },
+    ...overrides,
+  };
+}
+
+// Helper to get a date string for N days from now at specific time
+function getFutureDate(daysFromNow: number, hours = 10, minutes = 0): string {
+  const date = new Date();
+  date.setDate(date.getDate() + daysFromNow);
+  date.setHours(hours, minutes, 0, 0);
+  return date.toISOString();
+}
+
+// Helper to get a date-only string for N days from now (local midnight)
+function getFutureDateLocal(daysFromNow: number): string {
+  const date = new Date();
+  date.setDate(date.getDate() + daysFromNow);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}T00:00:00`;
+}
+
+// Create a mock context value
+function createMockContext(
+  events: IEvent[],
+  overrides: Partial<ICalendarContext> = {}
+): ICalendarContext {
+  return {
+    selectedDate: new Date(),
+    view: "agenda" as TCalendarView,
+    setView: vi.fn(),
+    agendaModeGroupBy: "date",
+    setAgendaModeGroupBy: vi.fn(),
+    use24HourFormat: true,
+    toggleTimeFormat: vi.fn(),
+    setSelectedDate: vi.fn(),
+    selectedUserId: "all",
+    setSelectedUserId: vi.fn(),
+    badgeVariant: "colored",
+    setBadgeVariant: vi.fn(),
+    selectedColors: [] as TEventColor[],
+    filterEventsBySelectedColors: vi.fn(),
+    filterEventsBySelectedUser: vi.fn(),
+    users: [] as IUser[],
+    events,
+    addEvent: vi.fn(),
+    updateEvent: vi.fn(),
+    removeEvent: vi.fn(),
+    clearFilter: vi.fn(),
+    refreshEvents: vi.fn(),
+    isLoading: false,
+    isAuthenticated: true,
+    ...overrides,
+  };
+}
+
+// Wrapper to render AgendaCalendar with mock context
+function renderWithContext(
+  events: IEvent[],
+  contextOverrides: Partial<ICalendarContext> = {}
+) {
+  const contextValue = createMockContext(events, contextOverrides);
+
+  return render(
+    <CalendarContext.Provider value={contextValue}>
+      <AgendaCalendar />
+    </CalendarContext.Provider>
+  );
+}
+
+describe("AgendaCalendar", () => {
+  describe("Bug 1: All-day event detection uses isAllDay flag", () => {
+    it("shows 'All day' for events with isAllDay=true", () => {
+      const events = [
+        createMockEvent({
+          id: "allday-1",
+          title: "Team Offsite",
+          startDate: getFutureDateLocal(1),
+          endDate: getFutureDateLocal(2),
+          isAllDay: true,
+        }),
+      ];
+
+      renderWithContext(events);
+
+      expect(screen.getByText("All day")).toBeInTheDocument();
+      expect(screen.getByText("Team Offsite")).toBeInTheDocument();
+    });
+
+    it("shows time range for events with isAllDay=false (even if spans 24+ hours)", () => {
+      // This is the key regression test: a multi-day timed event (conference call
+      // from midnight to midnight) should NOT show "All day" because isAllDay=false
+      const events = [
+        createMockEvent({
+          id: "multiday-1",
+          title: "Conference",
+          startDate: getFutureDate(1, 0, 0),
+          endDate: getFutureDate(3, 0, 0),
+          isAllDay: false, // Explicitly not all-day despite spanning 48 hours
+        }),
+      ];
+
+      renderWithContext(events);
+
+      expect(screen.getByText("Conference")).toBeInTheDocument();
+      // Should show time range, not "All day"
+      expect(screen.queryByText("All day")).not.toBeInTheDocument();
+    });
+
+    it("shows time range for regular timed events", () => {
+      const events = [
+        createMockEvent({
+          id: "timed-1",
+          title: "Meeting",
+          startDate: getFutureDate(1, 14, 30),
+          endDate: getFutureDate(1, 15, 30),
+          isAllDay: false,
+        }),
+      ];
+
+      renderWithContext(events);
+
+      expect(screen.getByText("Meeting")).toBeInTheDocument();
+      // Should show time range
+      expect(screen.getByText("14:30 - 15:30")).toBeInTheDocument();
+    });
+  });
+
+  describe("Bug 4: Events group by correct date (no offset)", () => {
+    it("groups all-day events under the correct date header", () => {
+      // Create an all-day event for tomorrow with T00:00:00 suffix
+      // (which is what transformGoogleEvent now produces for date-only strings)
+      const tomorrow = new Date();
+      tomorrow.setDate(tomorrow.getDate() + 1);
+      const expectedDay = tomorrow.getDate();
+
+      const events = [
+        createMockEvent({
+          id: "allday-correct-date",
+          title: "Holiday",
+          startDate: getFutureDateLocal(1),
+          endDate: getFutureDateLocal(2),
+          isAllDay: true,
+        }),
+      ];
+
+      renderWithContext(events);
+
+      // The event should appear - verify it renders
+      expect(screen.getByText("Holiday")).toBeInTheDocument();
+
+      // The date header should contain tomorrow's date
+      // Using a regex to match the day number in the header
+      const dateHeaders = screen.getAllByRole("heading", { level: 3 });
+      const headerTexts = dateHeaders.map((h) => h.textContent);
+      const hasCorrectDate = headerTexts.some((text) =>
+        text?.includes(String(expectedDay))
+      );
+      expect(hasCorrectDate).toBe(true);
+    });
+
+    it("does not shift events to the previous day", () => {
+      // This specifically tests the bug where UTC interpretation caused
+      // events to appear on the wrong day
+      const events = [
+        createMockEvent({
+          id: "no-shift",
+          title: "Morning Standup",
+          startDate: getFutureDate(1, 9, 0),
+          endDate: getFutureDate(1, 9, 30),
+          isAllDay: false,
+        }),
+      ];
+
+      renderWithContext(events);
+
+      expect(screen.getByText("Morning Standup")).toBeInTheDocument();
+      expect(screen.getByText("09:00 - 09:30")).toBeInTheDocument();
+    });
+  });
+
+  describe("Loading and empty states", () => {
+    it("shows loading message when isLoading is true", () => {
+      renderWithContext([], { isLoading: true });
+      expect(screen.getByText("Loading events...")).toBeInTheDocument();
+    });
+
+    it("shows empty state when no events in next 7 days", () => {
+      renderWithContext([]);
+      expect(
+        screen.getByText("No upcoming events in the next 7 days")
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("Color rendering", () => {
+    it("renders event with correct color classes", () => {
+      const events = [
+        createMockEvent({
+          id: "green-event",
+          title: "Green Event",
+          startDate: getFutureDate(1, 10, 0),
+          endDate: getFutureDate(1, 11, 0),
+          color: "green",
+          isAllDay: false,
+        }),
+      ];
+
+      renderWithContext(events);
+
+      expect(screen.getByText("Green Event")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,42 +1,61 @@
-import { useState } from "react";
+import { useCallback, useSyncExternalStore } from "react";
+
+function getServerSnapshot<T>(initialValue: T): () => T {
+  return () => initialValue;
+}
 
 export function useLocalStorage<T>(
   key: string,
   initialValue: T
 ): [T, (value: T) => void] {
-  // State to store our value
-  // Pass initial state function to useState so logic is only executed once
-  const [storedValue, setStoredValue] = useState<T>(() => {
-    if (typeof window === "undefined") {
-      return initialValue;
-    }
+  // Subscribe to storage events so the hook re-renders when another tab writes
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      const handler = (e: StorageEvent) => {
+        if (e.key === key) onStoreChange();
+      };
+      window.addEventListener("storage", handler);
+      return () => window.removeEventListener("storage", handler);
+    },
+    [key]
+  );
+
+  const getSnapshot = useCallback(() => {
     try {
-      // Get from local storage by key
       const item = window.localStorage.getItem(key);
-      // Parse stored json or if none return initialValue
-      return item ? JSON.parse(item) : initialValue;
-    } catch (error) {
-      // If error also return initialValue
-      console.error("Error loading from localStorage:", error);
-      return initialValue;
+      return item ?? null;
+    } catch {
+      return null;
     }
-  });
+  }, [key]);
 
-  // Return a wrapped version of useState's setter function that
-  // persists the new value to localStorage.
-  const setValue = (value: T) => {
-    try {
-      // Save state
-      setStoredValue(value);
-      // Save to local storage
-      if (typeof window !== "undefined") {
-        window.localStorage.setItem(key, JSON.stringify(value));
+  // useSyncExternalStore handles hydration: server returns null,
+  // client reads localStorage — React reconciles without mismatch.
+  const raw = useSyncExternalStore(
+    subscribe,
+    getSnapshot,
+    getServerSnapshot(null)
+  );
+
+  const value: T = raw !== null ? JSON.parse(raw) : initialValue;
+
+  const setValue = useCallback(
+    (newValue: T) => {
+      try {
+        window.localStorage.setItem(key, JSON.stringify(newValue));
+        // Dispatch a storage event so useSyncExternalStore re-renders
+        window.dispatchEvent(
+          new StorageEvent("storage", {
+            key,
+            newValue: JSON.stringify(newValue),
+          })
+        );
+      } catch (error) {
+        console.error("Error saving to localStorage:", error);
       }
-    } catch (error) {
-      // A more advanced implementation would handle the error case
-      console.error("Error saving to localStorage:", error);
-    }
-  };
+    },
+    [key]
+  );
 
-  return [storedValue, setValue];
+  return [value, setValue];
 }

--- a/src/lib/__tests__/calendar-helpers.test.ts
+++ b/src/lib/__tests__/calendar-helpers.test.ts
@@ -26,6 +26,8 @@ const createMockEvent = (overrides: Partial<IEvent> = {}): IEvent => ({
   endDate: "2024-03-15T11:00:00",
   color: "blue",
   description: "Test description",
+  isAllDay: false,
+  calendarId: "primary",
   user: {
     id: "user-1",
     name: "Test User",

--- a/src/lib/__tests__/calendar-transform.test.ts
+++ b/src/lib/__tests__/calendar-transform.test.ts
@@ -1,0 +1,263 @@
+import type { CalendarColorMapping } from "@/lib/calendar-storage";
+import type { GoogleCalendarEvent } from "@/lib/google-calendar";
+import { describe, expect, it } from "vitest";
+import { transformGoogleEvent } from "../calendar-transform";
+
+/**
+ * Regression tests for calendar event transformation.
+ *
+ * Covers:
+ * - Bug 1: All-day event detection uses isAllDay flag from Google API
+ * - Bug 3: All-day event timezone parsing (date-only strings as local time)
+ * - Bug 5: CalendarId preservation and color mapping
+ */
+
+// Helper to create a minimal Google Calendar event
+function createGoogleEvent(
+  overrides: Partial<GoogleCalendarEvent> = {}
+): GoogleCalendarEvent {
+  return {
+    id: "test-event-1",
+    summary: "Test Event",
+    start: { dateTime: "2026-01-15T10:00:00-05:00" },
+    end: { dateTime: "2026-01-15T11:00:00-05:00" },
+    calendarId: "primary",
+    ...overrides,
+  };
+}
+
+describe("transformGoogleEvent", () => {
+  describe("Bug 1: All-day event detection", () => {
+    it("sets isAllDay=true when Google event uses start.date (not dateTime)", () => {
+      const googleEvent = createGoogleEvent({
+        start: { date: "2026-01-15" },
+        end: { date: "2026-01-16" },
+      });
+
+      const result = transformGoogleEvent(googleEvent, []);
+
+      expect(result.isAllDay).toBe(true);
+    });
+
+    it("sets isAllDay=false when Google event uses start.dateTime", () => {
+      const googleEvent = createGoogleEvent({
+        start: { dateTime: "2026-01-15T10:00:00-05:00" },
+        end: { dateTime: "2026-01-15T11:00:00-05:00" },
+      });
+
+      const result = transformGoogleEvent(googleEvent, []);
+
+      expect(result.isAllDay).toBe(false);
+    });
+
+    it("sets isAllDay=false for multi-day timed events (not all-day)", () => {
+      // A multi-day event with specific times is NOT all-day
+      const googleEvent = createGoogleEvent({
+        start: { dateTime: "2026-01-15T00:00:00-05:00" },
+        end: { dateTime: "2026-01-17T00:00:00-05:00" },
+      });
+
+      const result = transformGoogleEvent(googleEvent, []);
+
+      expect(result.isAllDay).toBe(false);
+    });
+
+    it("sets isAllDay=true for multi-day all-day events", () => {
+      // Multi-day all-day events use start.date
+      const googleEvent = createGoogleEvent({
+        start: { date: "2026-01-15" },
+        end: { date: "2026-01-18" },
+      });
+
+      const result = transformGoogleEvent(googleEvent, []);
+
+      expect(result.isAllDay).toBe(true);
+    });
+  });
+
+  describe("Bug 3: All-day event timezone parsing", () => {
+    it("appends T00:00:00 to date-only start strings for local time interpretation", () => {
+      const googleEvent = createGoogleEvent({
+        start: { date: "2026-01-15" },
+        end: { date: "2026-01-16" },
+      });
+
+      const result = transformGoogleEvent(googleEvent, []);
+
+      expect(result.startDate).toBe("2026-01-15T00:00:00");
+    });
+
+    it("appends T00:00:00 to date-only end strings for local time interpretation", () => {
+      const googleEvent = createGoogleEvent({
+        start: { date: "2026-01-15" },
+        end: { date: "2026-01-16" },
+      });
+
+      const result = transformGoogleEvent(googleEvent, []);
+
+      expect(result.endDate).toBe("2026-01-16T00:00:00");
+    });
+
+    it("preserves dateTime strings as-is (no T00:00:00 appending)", () => {
+      const googleEvent = createGoogleEvent({
+        start: { dateTime: "2026-01-15T14:30:00-05:00" },
+        end: { dateTime: "2026-01-15T15:30:00-05:00" },
+      });
+
+      const result = transformGoogleEvent(googleEvent, []);
+
+      expect(result.startDate).toBe("2026-01-15T14:30:00-05:00");
+      expect(result.endDate).toBe("2026-01-15T15:30:00-05:00");
+    });
+
+    it("parsed date-only string with T00:00:00 is interpreted as local midnight", () => {
+      const googleEvent = createGoogleEvent({
+        start: { date: "2026-01-15" },
+        end: { date: "2026-01-16" },
+      });
+
+      const result = transformGoogleEvent(googleEvent, []);
+
+      // "2026-01-15T00:00:00" should be local midnight on Jan 15
+      const parsed = new Date(result.startDate);
+      expect(parsed.getDate()).toBe(15);
+      expect(parsed.getMonth()).toBe(0); // January
+      expect(parsed.getFullYear()).toBe(2026);
+      expect(parsed.getHours()).toBe(0);
+      expect(parsed.getMinutes()).toBe(0);
+    });
+  });
+
+  describe("Bug 5: CalendarId preservation", () => {
+    it("preserves calendarId from the Google event", () => {
+      const googleEvent = createGoogleEvent({
+        calendarId: "family@group.calendar.google.com",
+      });
+
+      const result = transformGoogleEvent(googleEvent, []);
+
+      expect(result.calendarId).toBe("family@group.calendar.google.com");
+    });
+
+    it("preserves primary calendarId", () => {
+      const googleEvent = createGoogleEvent({
+        calendarId: "primary",
+      });
+
+      const result = transformGoogleEvent(googleEvent, []);
+
+      expect(result.calendarId).toBe("primary");
+    });
+  });
+
+  describe("Color mapping", () => {
+    it("uses calendarId-based color mapping when available", () => {
+      const mappings: CalendarColorMapping[] = [
+        {
+          calendarId: "family@group.calendar.google.com",
+          colorId: "",
+          hexColor: "#16a765",
+          tailwindColor: "green",
+        },
+      ];
+
+      const googleEvent = createGoogleEvent({
+        calendarId: "family@group.calendar.google.com",
+      });
+
+      const result = transformGoogleEvent(googleEvent, mappings);
+
+      expect(result.color).toBe("green");
+    });
+
+    it("falls back to colorId mapping when no calendarId match", () => {
+      const googleEvent = createGoogleEvent({
+        calendarId: "unknown-calendar",
+        colorId: "4", // Maps to "red" in the legacy color map
+      });
+
+      const result = transformGoogleEvent(googleEvent, []);
+
+      expect(result.color).toBe("red");
+    });
+
+    it("defaults to blue when no color mapping matches", () => {
+      const googleEvent = createGoogleEvent({
+        calendarId: "unknown-calendar",
+      });
+
+      const result = transformGoogleEvent(googleEvent, []);
+
+      expect(result.color).toBe("blue");
+    });
+
+    it("prioritizes calendarId mapping over colorId mapping", () => {
+      const mappings: CalendarColorMapping[] = [
+        {
+          calendarId: "primary",
+          colorId: "",
+          hexColor: "#d50000",
+          tailwindColor: "red",
+        },
+      ];
+
+      const googleEvent = createGoogleEvent({
+        calendarId: "primary",
+        colorId: "2", // Would map to "green" via colorId
+      });
+
+      const result = transformGoogleEvent(googleEvent, mappings);
+
+      // Should use calendarId mapping (red), not colorId mapping (green)
+      expect(result.color).toBe("red");
+    });
+
+    it("applies correct colors from empty mappings array", () => {
+      const googleEvent = createGoogleEvent({
+        calendarId: "primary",
+      });
+
+      const result = transformGoogleEvent(googleEvent, []);
+
+      // With empty mappings, should default to blue
+      expect(result.color).toBe("blue");
+    });
+  });
+
+  describe("Basic field mapping", () => {
+    it("maps summary to title", () => {
+      const googleEvent = createGoogleEvent({ summary: "My Meeting" });
+      const result = transformGoogleEvent(googleEvent, []);
+      expect(result.title).toBe("My Meeting");
+    });
+
+    it("uses 'Untitled Event' when summary is missing", () => {
+      const googleEvent = createGoogleEvent({ summary: "" });
+      const result = transformGoogleEvent(googleEvent, []);
+      expect(result.title).toBe("Untitled Event");
+    });
+
+    it("maps description correctly", () => {
+      const googleEvent = createGoogleEvent({
+        description: "Meeting notes",
+      });
+      const result = transformGoogleEvent(googleEvent, []);
+      expect(result.description).toBe("Meeting notes");
+    });
+
+    it("uses empty string when description is missing", () => {
+      const googleEvent = createGoogleEvent({ description: undefined });
+      const result = transformGoogleEvent(googleEvent, []);
+      expect(result.description).toBe("");
+    });
+
+    it("maps creator email to user.id", () => {
+      const googleEvent = createGoogleEvent({
+        creator: { email: "user@example.com", displayName: "User" },
+      });
+      const result = transformGoogleEvent(googleEvent, []);
+      expect(result.user.id).toBe("user@example.com");
+      expect(result.user.name).toBe("User");
+    });
+  });
+});

--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -30,6 +30,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       // Get the Google account for this user
       const [googleAccount] = await prisma.account.findMany({
         where: { userId: user.id, provider: "google" },
+        orderBy: { expires_at: "desc" },
       });
 
       if (!googleAccount) {

--- a/src/lib/calendar-transform.ts
+++ b/src/lib/calendar-transform.ts
@@ -1,0 +1,107 @@
+/**
+ * Google Calendar event transformation utilities
+ *
+ * Transforms Google Calendar API events into the internal IEvent format.
+ * Handles:
+ * - All-day event detection (via start.date vs start.dateTime)
+ * - Timezone-safe date parsing (appends T00:00:00 to date-only strings)
+ * - Calendar color mapping (from Google Calendar API color mappings)
+ * - CalendarId preservation for cache round-tripping
+ */
+import type { CalendarColorMapping } from "@/lib/calendar-storage";
+import type { GoogleCalendarEvent } from "@/lib/google-calendar";
+import type { IEvent, TEventColor } from "@/types/calendar";
+
+/**
+ * Transform a Google Calendar event to our IEvent format.
+ * Uses color mappings from Google Calendar API when available.
+ *
+ * Key behaviors:
+ * - Sets isAllDay based on presence of start.date (vs start.dateTime)
+ * - Appends T00:00:00 to date-only strings to force local time interpretation
+ * - Preserves calendarId from the Google event for cache round-tripping
+ * - Maps colors via calendarId lookup, then colorId fallback, then default blue
+ */
+export function transformGoogleEvent(
+  googleEvent: GoogleCalendarEvent,
+  colorMappings: CalendarColorMapping[]
+): IEvent {
+  // Determine if this is an all-day event based on Google API convention:
+  // All-day events use start.date (e.g., "2026-01-05")
+  // Timed events use start.dateTime (e.g., "2026-01-05T10:00:00-05:00")
+  const isAllDay = !googleEvent.start.dateTime && !!googleEvent.start.date;
+
+  // For date-only strings (all-day events), append T00:00:00 to force
+  // local time interpretation. Without this, new Date("2026-01-05")
+  // is interpreted as UTC midnight, which shifts to the previous day
+  // in negative-offset timezones.
+  const startDate = googleEvent.start.dateTime
+    ? googleEvent.start.dateTime
+    : googleEvent.start.date
+      ? `${googleEvent.start.date}T00:00:00`
+      : new Date().toISOString();
+
+  const endDate = googleEvent.end.dateTime
+    ? googleEvent.end.dateTime
+    : googleEvent.end.date
+      ? `${googleEvent.end.date}T00:00:00`
+      : new Date().toISOString();
+
+  const calendarId = googleEvent.calendarId;
+
+  const user = {
+    id: googleEvent.creator?.email || "unknown",
+    name: googleEvent.creator?.displayName || "Unknown",
+    picturePath: null,
+  };
+
+  const baseEvent = {
+    id: googleEvent.id,
+    startDate,
+    endDate,
+    title: googleEvent.summary || "Untitled Event",
+    description: googleEvent.description || "",
+    user,
+    isAllDay,
+    calendarId,
+  };
+
+  // Priority 1: Look up by calendarId in color mappings (from Google Calendar API)
+  const calendarMapping = colorMappings.find(
+    (m) => m.calendarId === googleEvent.calendarId
+  );
+  if (calendarMapping) {
+    return {
+      ...baseEvent,
+      color: calendarMapping.tailwindColor,
+    };
+  }
+
+  // Priority 2: Fall back to existing colorId mapping (legacy)
+  const colorMap: Record<string, TEventColor> = {
+    "1": "blue",
+    "2": "green",
+    "3": "purple",
+    "4": "red",
+    "5": "yellow",
+    "6": "orange",
+    "7": "blue",
+    "8": "blue",
+    "9": "blue",
+    "10": "green",
+    "11": "red",
+  };
+
+  if (googleEvent.colorId && colorMap[googleEvent.colorId]) {
+    return {
+      ...baseEvent,
+      color: colorMap[googleEvent.colorId],
+    };
+  }
+
+  // Priority 3: Default to blue
+  return {
+    ...baseEvent,
+    color: "blue",
+  };
+}

--- a/src/types/calendar.ts
+++ b/src/types/calendar.ts
@@ -26,6 +26,8 @@ export interface IEvent {
   color: TEventColor;
   description: string;
   user: IUser;
+  isAllDay: boolean;
+  calendarId: string;
 }
 
 export interface ICalendarCell {


### PR DESCRIPTION
## Summary

Fix 5 calendar technical debt bugs plus 2 additional bugs found during QA:

**Original 5 fixes:**
- Use explicit `isAllDay` flag from Google API instead of duration check
- Initialize color mappings synchronously from localStorage on mount
- Append `T00:00:00` to date-only strings for correct timezone parsing
- Preserve `calendarId` through event transformation and cache
- Add `calendarId` and `isAllDay` fields to `IEvent` interface

**Additional fixes found during QA:**
- Fix hydration mismatch in `useLocalStorage` by replacing `useState` with `useSyncExternalStore`
- Fix stale token selection when multiple Google accounts linked to same user (`orderBy: { expires_at: "desc" }`)

## Issues Resolved

Closes #62 — Calendar event colors not persisting after page refresh
Closes #63 — Agenda view shows events offset by one day
Closes #64 — All-day event detection uses duration heuristic
Closes #65 — Color mappings race condition on initial mount
Closes #66 — All-day event timezone parsing causes wrong-day display

Related: #61 — Multiple Google accounts linking to single user (mitigated)

## Test plan

- [x] `pnpm check-types` — zero errors
- [x] `pnpm lint` — zero errors
- [x] `pnpm test:run` — 646 tests passing
- [x] Playwright browser validation of `/test/calendar` (month, agenda, colors views)
- [ ] Manual QA with real Google Calendar account on `/calendar`