### PR TITLE
feat: add scheduler status indicator widget

### DIFF
--- a/src/app/test/scheduler-demo/page.tsx
+++ b/src/app/test/scheduler-demo/page.tsx
@@ -7,7 +7,8 @@ export default function ScreenA() {
       <h1 className="text-6xl font-bold">Calendar</h1>
       <p className="mt-6 max-w-md text-center text-blue-200">
         This page auto-rotates every 10 seconds. Move your mouse to pause for
-        30s. Use the floating controls at the bottom to navigate manually.
+        30s. Use the floating controls at the bottom to navigate manually. The
+        status indicator in the bottom-left shows countdown progress.
       </p>
     </div>
   );

--- a/src/components/scheduler/__tests__/scheduler-status-indicator.test.tsx
+++ b/src/components/scheduler/__tests__/scheduler-status-indicator.test.tsx
@@ -1,0 +1,170 @@
+/**
+ * Tests for SchedulerStatusIndicator component
+ *
+ * Tests rendering in rotating/paused states, countdown display,
+ * progress ring calculations, and accessibility attributes.
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { SchedulerStatusIndicator } from "../scheduler-status-indicator";
+
+describe("SchedulerStatusIndicator", () => {
+  const defaultProps = {
+    isRotating: true,
+    isPaused: false,
+    timeUntilNextNav: 45,
+    intervalSeconds: 60,
+  };
+
+  describe("rotating state", () => {
+    it("renders with role='status'", () => {
+      render(<SchedulerStatusIndicator {...defaultProps} />);
+      expect(screen.getByRole("status")).toBeInTheDocument();
+    });
+
+    it("displays countdown seconds using Math.ceil", () => {
+      render(<SchedulerStatusIndicator {...defaultProps} />);
+      expect(screen.getByText("45")).toBeInTheDocument();
+    });
+
+    it("displays aria-label describing rotating state", () => {
+      render(<SchedulerStatusIndicator {...defaultProps} />);
+      const el = screen.getByRole("status");
+      expect(el).toHaveAttribute(
+        "aria-label",
+        expect.stringContaining("45 seconds")
+      );
+    });
+
+    it("renders progress ring at correct angle for 25% elapsed", () => {
+      // 60s interval, 45s remaining => 15s elapsed => 25% => 90deg
+      const { container } = render(
+        <SchedulerStatusIndicator {...defaultProps} />
+      );
+      const ring = container.querySelector("[data-testid='progress-ring']");
+      expect(ring).toBeInTheDocument();
+      const style = ring!.getAttribute("style");
+      expect(style).toContain("90deg");
+    });
+
+    it("renders progress ring at 0deg when full time remaining", () => {
+      const { container } = render(
+        <SchedulerStatusIndicator
+          {...defaultProps}
+          timeUntilNextNav={60}
+          intervalSeconds={60}
+        />
+      );
+      const ring = container.querySelector("[data-testid='progress-ring']");
+      const style = ring!.getAttribute("style");
+      expect(style).toContain("0deg");
+    });
+
+    it("renders progress ring at 360deg when 0 time remaining", () => {
+      const { container } = render(
+        <SchedulerStatusIndicator
+          {...defaultProps}
+          timeUntilNextNav={0}
+          intervalSeconds={60}
+        />
+      );
+      const ring = container.querySelector("[data-testid='progress-ring']");
+      const style = ring!.getAttribute("style");
+      expect(style).toContain("360deg");
+    });
+
+    it("renders progress ring at 180deg for midpoint", () => {
+      const { container } = render(
+        <SchedulerStatusIndicator
+          {...defaultProps}
+          timeUntilNextNav={30}
+          intervalSeconds={60}
+        />
+      );
+      const ring = container.querySelector("[data-testid='progress-ring']");
+      const style = ring!.getAttribute("style");
+      expect(style).toContain("180deg");
+    });
+  });
+
+  describe("paused state", () => {
+    it("shows pause icon when paused", () => {
+      render(<SchedulerStatusIndicator {...defaultProps} isPaused={true} />);
+      expect(screen.getByText("❚❚")).toBeInTheDocument();
+    });
+
+    it("does not show countdown when paused", () => {
+      render(<SchedulerStatusIndicator {...defaultProps} isPaused={true} />);
+      expect(screen.queryByText("45")).not.toBeInTheDocument();
+    });
+
+    it("displays aria-label describing paused state", () => {
+      render(<SchedulerStatusIndicator {...defaultProps} isPaused={true} />);
+      const el = screen.getByRole("status");
+      expect(el).toHaveAttribute(
+        "aria-label",
+        expect.stringContaining("paused")
+      );
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles intervalSeconds === 0 without division by zero", () => {
+      expect(() =>
+        render(
+          <SchedulerStatusIndicator
+            {...defaultProps}
+            intervalSeconds={0}
+            timeUntilNextNav={0}
+          />
+        )
+      ).not.toThrow();
+    });
+
+    it("does not render when not rotating and not paused", () => {
+      const { container } = render(
+        <SchedulerStatusIndicator
+          {...defaultProps}
+          isRotating={false}
+          isPaused={false}
+        />
+      );
+      expect(screen.queryByRole("status")).not.toBeInTheDocument();
+      expect(container.firstChild).toBeNull();
+    });
+
+    it("renders when paused even if isRotating is false", () => {
+      render(
+        <SchedulerStatusIndicator
+          {...defaultProps}
+          isRotating={false}
+          isPaused={true}
+        />
+      );
+      expect(screen.getByRole("status")).toBeInTheDocument();
+    });
+  });
+
+  describe("composable positioning", () => {
+    it("applies custom className for positioning", () => {
+      render(
+        <SchedulerStatusIndicator
+          {...defaultProps}
+          className="absolute bottom-2 left-2"
+        />
+      );
+      const el = screen.getByRole("status");
+      expect(el.className).toContain("absolute");
+      expect(el.className).toContain("bottom-2");
+      expect(el.className).toContain("left-2");
+    });
+
+    it("uses default positioning when no className provided", () => {
+      render(<SchedulerStatusIndicator {...defaultProps} />);
+      const el = screen.getByRole("status");
+      expect(el.className).toContain("fixed");
+      expect(el.className).toContain("bottom-6");
+      expect(el.className).toContain("left-6");
+    });
+  });
+});

--- a/src/components/scheduler/__tests__/screen-scheduler.test.tsx
+++ b/src/components/scheduler/__tests__/screen-scheduler.test.tsx
@@ -82,4 +82,24 @@ describe("ScreenScheduler", () => {
       screen.queryByRole("navigation", { name: /screen rotation controls/i })
     ).not.toBeInTheDocument();
   });
+
+  it("renders status indicator when scheduler is active", () => {
+    render(
+      <ScreenScheduler config={defaultConfig} autoStart>
+        <div>Content</div>
+      </ScreenScheduler>
+    );
+
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
+
+  it("does not render status indicator when scheduler is inactive", () => {
+    render(
+      <ScreenScheduler config={emptyConfig}>
+        <div>Content</div>
+      </ScreenScheduler>
+    );
+
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
 });

--- a/src/components/scheduler/scheduler-status-indicator.tsx
+++ b/src/components/scheduler/scheduler-status-indicator.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+/**
+ * Scheduler Status Indicator
+ *
+ * A small circular progress ring that shows the countdown until the next
+ * screen rotation. Displays remaining seconds when rotating, and a pause
+ * icon when paused. Always visible while the scheduler is active.
+ *
+ * Accepts a className prop for composable positioning — the default places
+ * it fixed at bottom-left, but it can be repositioned (e.g. inside a sidebar).
+ */
+
+interface SchedulerStatusIndicatorProps {
+  /** Whether the scheduler is actively counting down */
+  isRotating: boolean;
+  /** Whether the scheduler is paused (manual or interaction) */
+  isPaused: boolean;
+  /** Seconds remaining until next navigation */
+  timeUntilNextNav: number;
+  /** Total interval in seconds (for progress calculation) */
+  intervalSeconds: number;
+  /** Optional className override for positioning (default: fixed bottom-left) */
+  className?: string;
+}
+
+const SIZE = 44;
+const INNER_SIZE = 36;
+const ACTIVE_COLOR = "rgb(59, 130, 246)"; // blue-500
+const PAUSED_COLOR = "rgb(75, 85, 99)"; // gray-600
+const TRACK_COLOR = "rgb(55, 65, 81)"; // gray-700
+const BG_COLOR = "rgb(31, 41, 55)"; // gray-800
+
+export function SchedulerStatusIndicator({
+  isRotating,
+  isPaused,
+  timeUntilNextNav,
+  intervalSeconds,
+  className,
+}: SchedulerStatusIndicatorProps) {
+  // Don't render if neither rotating nor paused
+  if (!isRotating && !isPaused) {
+    return null;
+  }
+
+  // Calculate progress angle (0-360)
+  const elapsed = intervalSeconds - timeUntilNextNav;
+  const progress =
+    intervalSeconds > 0
+      ? Math.min(Math.max(elapsed / intervalSeconds, 0), 1)
+      : 0;
+  const angle = Math.round(progress * 360);
+
+  const fillColor = isPaused ? PAUSED_COLOR : ACTIVE_COLOR;
+
+  const ringStyle = {
+    width: SIZE,
+    height: SIZE,
+    borderRadius: "50%",
+    background: `conic-gradient(from 0deg, ${fillColor} ${angle}deg, ${TRACK_COLOR} ${angle}deg)`,
+  };
+
+  const innerStyle = {
+    width: INNER_SIZE,
+    height: INNER_SIZE,
+    borderRadius: "50%",
+    backgroundColor: BG_COLOR,
+  };
+
+  const ariaLabel = isPaused
+    ? "Screen rotation paused"
+    : `Next screen in ${Math.ceil(timeUntilNextNav)} seconds`;
+
+  const positionClass = className ?? "fixed bottom-6 left-6";
+
+  return (
+    <div
+      role="status"
+      aria-label={ariaLabel}
+      aria-live="polite"
+      className={`${positionClass} z-50 shadow-lg`}
+    >
+      <div
+        data-testid="progress-ring"
+        className="flex items-center justify-center"
+        style={ringStyle}
+      >
+        <div className="flex items-center justify-center" style={innerStyle}>
+          {isPaused ? (
+            <span className="text-xs text-gray-400">&#10074;&#10074;</span>
+          ) : (
+            <span className="text-xs font-medium text-gray-200">
+              {Math.ceil(timeUntilNextNav)}
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/scheduler/screen-scheduler.tsx
+++ b/src/components/scheduler/screen-scheduler.tsx
@@ -11,6 +11,7 @@
 import type { ReactNode } from "react";
 import { useEffect, useRef, useState } from "react";
 import { NavigationControls } from "./navigation-controls";
+import { SchedulerStatusIndicator } from "./scheduler-status-indicator";
 import type { ScheduleConfig } from "./types";
 import { useInteractionDetector } from "./use-interaction-detector";
 import { useScreenScheduler } from "./use-screen-scheduler";
@@ -60,6 +61,12 @@ export function ScreenScheduler({
   });
 
   const { state, controls } = useScreenScheduler(config, isInteractionPaused);
+
+  const totalScreens = enabledSequence ? enabledSequence.screens.length : 0;
+  const effectivelyPaused = state.isPaused || isInteractionPaused;
+  const isRotating =
+    state.isActive && !effectivelyPaused && !state.activeTimeSpecific;
+  const intervalSeconds = enabledSequence?.intervalSeconds ?? 0;
 
   // Auto-start on mount if requested
   useEffect(() => {
@@ -113,7 +120,7 @@ export function ScreenScheduler({
           break;
         case " ":
           e.preventDefault();
-          if (state.isPaused || isInteractionPaused) {
+          if (effectivelyPaused) {
             controls.resume();
           } else {
             controls.pause();
@@ -127,29 +134,35 @@ export function ScreenScheduler({
     return () => {
       window.removeEventListener("keydown", handleKeyDown);
     };
-  }, [state.isActive, state.isPaused, isInteractionPaused, controls]);
-
-  const totalScreens = enabledSequence ? enabledSequence.screens.length : 0;
+  }, [state.isActive, effectivelyPaused, controls]);
 
   return (
     <>
       {children}
       {state.isActive && totalScreens > 0 && (
-        <NavigationControls
-          currentIndex={state.currentIndex}
-          totalScreens={totalScreens}
-          isPaused={state.isPaused || isInteractionPaused}
-          isVisible={controlsVisible}
-          onPrevious={controls.navigateToPrevious}
-          onNext={controls.navigateToNext}
-          onTogglePause={() => {
-            if (state.isPaused || isInteractionPaused) {
-              controls.resume();
-            } else {
-              controls.pause();
-            }
-          }}
-        />
+        <>
+          <NavigationControls
+            currentIndex={state.currentIndex}
+            totalScreens={totalScreens}
+            isPaused={effectivelyPaused}
+            isVisible={controlsVisible}
+            onPrevious={controls.navigateToPrevious}
+            onNext={controls.navigateToNext}
+            onTogglePause={() => {
+              if (effectivelyPaused) {
+                controls.resume();
+              } else {
+                controls.pause();
+              }
+            }}
+          />
+          <SchedulerStatusIndicator
+            isRotating={isRotating}
+            isPaused={effectivelyPaused}
+            timeUntilNextNav={state.timeUntilNextNav}
+            intervalSeconds={intervalSeconds}
+          />
+        </>
       )}
     </>
   );

--- a/src/components/scheduler/use-screen-scheduler.ts
+++ b/src/components/scheduler/use-screen-scheduler.ts
@@ -92,7 +92,6 @@ export function useScreenScheduler(
     useState<TimeSpecificNavigation | null>(null);
 
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const countdownRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const timeCheckRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const isVisibleRef = useRef(true);
   const currentIndexRef = useRef(currentIndex);
@@ -167,10 +166,6 @@ export function useScreenScheduler(
         clearInterval(intervalRef.current);
         intervalRef.current = null;
       }
-      if (countdownRef.current) {
-        clearInterval(countdownRef.current);
-        countdownRef.current = null;
-      }
       return;
     }
 
@@ -181,31 +176,27 @@ export function useScreenScheduler(
 
     const intervalSecs = activeSequence.intervalSeconds;
 
-    // Countdown timer (every second) — starts at full interval
+    // Single 1-second tick drives both countdown and navigation,
+    // keeping the progress indicator perfectly in sync with rotation.
     let countdown = intervalSecs;
-    countdownRef.current = setInterval(() => {
+
+    intervalRef.current = setInterval(() => {
       countdown -= 1;
-      if (countdown < 0) countdown = intervalSecs;
+      if (countdown <= 0) {
+        // Navigate to next screen
+        const screens = activeSequence.screens;
+        const nextIndex = (currentIndexRef.current + 1) % screens.length;
+        setCurrentIndex(nextIndex);
+        router.push(screens[nextIndex]);
+        countdown = intervalSecs;
+      }
       setTimeUntilNextNav(countdown);
     }, 1000);
-
-    // Navigation interval — router.push must be outside the state updater
-    // to avoid updating Router during React's render phase
-    intervalRef.current = setInterval(() => {
-      const screens = activeSequence.screens;
-      const nextIndex = (currentIndexRef.current + 1) % screens.length;
-      setCurrentIndex(nextIndex);
-      router.push(screens[nextIndex]);
-    }, activeSequence.intervalSeconds * 1000);
 
     return () => {
       if (intervalRef.current) {
         clearInterval(intervalRef.current);
         intervalRef.current = null;
-      }
-      if (countdownRef.current) {
-        clearInterval(countdownRef.current);
-        countdownRef.current = null;
       }
     };
   }, [


### PR DESCRIPTION
## Summary
- Adds an always-visible 44px circular progress ring (bottom-left corner) that shows countdown seconds during screen rotation and a pause icon when paused
- Uses `conic-gradient` for the progress ring fill, matching the NavigationControls dark theme aesthetic
- Supports composable positioning via `className` prop for future sidebar nav integration
- Refactors `ScreenScheduler` to extract `effectivelyPaused` for cleaner state management

## Test plan
- [x] 15 unit tests for `SchedulerStatusIndicator` (rotating/paused states, progress angles, edge cases, accessibility, composable positioning)
- [x] 2 integration tests in `ScreenScheduler` (renders when active, hidden when inactive)
- [x] All 800 tests passing
- [x] Visual validation at `/test/scheduler-demo` — indicator visible, ring fills, pauses on interaction
- [x] 0 console errors in browser
- [ ] Manual validation by reviewer

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)