### PR TITLE
feat: add dark/light/system theme toggle (#90)

### DIFF
--- a/docs/issue-dependency-analysis.md
+++ b/docs/issue-dependency-analysis.md
@@ -1,6 +1,6 @@
 # Open Issue Dependency Analysis
 
-> Generated 2026-04-03 | Covers all 12 open issues at time of analysis
+> Generated 2026-04-03 | Updated 2026-04-12 | Covers all 12 open issues at time of analysis + newly completed issues
 
 ## Dependency Graph
 
@@ -101,6 +101,17 @@ TIER 3 — Highest Dependencies
 | **Synergy with** | #95   | Indicator must remain visible during page transitions                                                                                                                          |
 
 **Status: COMPLETE** — ScreenTransition component with slide/fade/slide-fade types, configurable duration (200-1000ms), prefers-reduced-motion support, TransitionSection settings UI, and direction-aware animations (forward/backward). Uses CSS transforms for GPU-composited 60fps performance.
+
+---
+
+### #90 — Add dark/light/system theme toggle ✅ IMPLEMENTED
+
+| Relationship     | Issue | Nature                                                                                           |
+| ---------------- | ----- | ------------------------------------------------------------------------------------------------ |
+| **Independent**  | —     | No blockers; uses existing `next-themes` dependency and shadcn/ui dark mode support              |
+| **Synergy with** | #86   | Calendar settings panel could integrate the ThemeToggle dropdown; shares settings infrastructure |
+
+**Status: COMPLETE** — ThemeProvider (next-themes), ThemeToggle dropdown (Sun/Moon/Monitor icons), complete shadcn/ui CSS variable definitions for light and dark themes (oklch, slate base), semantic color tokens throughout all major components (SimpleCalendar, AgendaCalendar, AccountManager, Home, Settings, Calendar page). DisplaySection wired to `setTheme()` for instant switching. Theme options changed from "auto" to "system" (next-themes standard). API accepts both "auto" and "system" for backward compatibility. localStorage persistence via next-themes.
 
 ---
 

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -91,15 +91,15 @@ test.describe("Settings Page (/test/settings)", () => {
     }) => {
       const lightRadio = page.getByRole("radio", { name: "light" });
       const darkRadio = page.getByRole("radio", { name: "dark" });
-      const autoRadio = page.getByRole("radio", { name: "auto" });
+      const systemRadio = page.getByRole("radio", { name: "system" });
 
       await expect(lightRadio).toBeVisible();
       await expect(darkRadio).toBeVisible();
-      await expect(autoRadio).toBeVisible();
+      await expect(systemRadio).toBeVisible();
 
       await expect(lightRadio).toBeChecked();
       await expect(darkRadio).not.toBeChecked();
-      await expect(autoRadio).not.toBeChecked();
+      await expect(systemRadio).not.toBeChecked();
     });
 
     test("can change theme selection", async ({ page }) => {

--- a/e2e/theme.spec.ts
+++ b/e2e/theme.spec.ts
@@ -1,0 +1,109 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Theme Toggle (/test/settings)", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/test/settings");
+  });
+
+  test.describe("Theme Radio Buttons", () => {
+    test("shows light, dark, and system options", async ({ page }) => {
+      await expect(page.getByRole("radio", { name: "light" })).toBeVisible();
+      await expect(page.getByRole("radio", { name: "dark" })).toBeVisible();
+      await expect(page.getByRole("radio", { name: "system" })).toBeVisible();
+    });
+
+    test("light is selected by default", async ({ page }) => {
+      await expect(page.getByRole("radio", { name: "light" })).toBeChecked();
+    });
+
+    test("selecting dark theme adds .dark class to html element", async ({
+      page,
+    }) => {
+      // Mock the settings API
+      await page.route("**/api/settings", (route) =>
+        route.fulfill({ status: 200, body: "{}" })
+      );
+
+      await page.getByRole("radio", { name: "dark" }).click();
+
+      // next-themes applies the .dark class to the html element
+      await expect(page.locator("html")).toHaveClass(/dark/);
+    });
+
+    test("selecting light theme removes .dark class from html element", async ({
+      page,
+    }) => {
+      await page.route("**/api/settings", (route) =>
+        route.fulfill({ status: 200, body: "{}" })
+      );
+
+      // Switch to dark first
+      await page.getByRole("radio", { name: "dark" }).click();
+      await expect(page.locator("html")).toHaveClass(/dark/);
+
+      // Switch back to light
+      await page.getByRole("radio", { name: "light" }).click();
+      await expect(page.locator("html")).not.toHaveClass(/dark/);
+    });
+
+    test("dark mode changes page background color", async ({ page }) => {
+      await page.route("**/api/settings", (route) =>
+        route.fulfill({ status: 200, body: "{}" })
+      );
+
+      // Get initial background color
+      const lightBg = await page.evaluate(
+        () => getComputedStyle(document.body).backgroundColor
+      );
+
+      // Switch to dark
+      await page.getByRole("radio", { name: "dark" }).click();
+      await page.waitForTimeout(100); // Wait for theme transition
+
+      const darkBg = await page.evaluate(
+        () => getComputedStyle(document.body).backgroundColor
+      );
+
+      // Background should be different in dark mode
+      expect(lightBg).not.toBe(darkBg);
+    });
+  });
+
+  test.describe("Theme Persistence", () => {
+    test("theme selection persists across page reload", async ({ page }) => {
+      await page.route("**/api/settings", (route) =>
+        route.fulfill({ status: 200, body: "{}" })
+      );
+
+      // Switch to dark
+      await page.getByRole("radio", { name: "dark" }).click();
+      await expect(page.locator("html")).toHaveClass(/dark/);
+
+      // Reload page
+      await page.reload();
+
+      // Theme should persist (next-themes uses localStorage)
+      await expect(page.locator("html")).toHaveClass(/dark/);
+    });
+  });
+
+  test.describe("Accessibility", () => {
+    test("theme radio buttons are keyboard navigable", async ({ page }) => {
+      const lightRadio = page.getByRole("radio", { name: "light" });
+      await lightRadio.focus();
+
+      // Tab through radio options
+      await page.keyboard.press("ArrowRight");
+      await expect(page.getByRole("radio", { name: "dark" })).toBeFocused();
+    });
+
+    test("theme radio group has proper fieldset structure", async ({
+      page,
+    }) => {
+      // Check fieldset/legend pattern for accessibility
+      await expect(
+        page.locator("legend").filter({ hasText: "Theme" })
+      ).toBeVisible();
+    });
+  });
+});

--- a/src/app/api/settings/__tests__/route.test.ts
+++ b/src/app/api/settings/__tests__/route.test.ts
@@ -165,6 +165,24 @@ describe("/api/settings", () => {
       expect(data.error).toContain("Invalid theme");
     });
 
+    it("accepts 'system' as a valid theme value", async () => {
+      vi.mocked(getSession).mockResolvedValue(mockSession);
+      const updatedSettings = { ...mockSettings, theme: "system" };
+      mockPrisma.userSettings.upsert.mockResolvedValue(updatedSettings);
+
+      const request = createMockRequest("/api/settings", {
+        method: "PUT",
+        body: { theme: "system" },
+      });
+
+      const response = await PUT(request);
+      const { status, data } =
+        await parseResponse<typeof mockSettings>(response);
+
+      expect(status).toBe(200);
+      expect(data.theme).toBe("system");
+    });
+
     it("validates defaultTaskPoints is positive", async () => {
       vi.mocked(getSession).mockResolvedValue(mockSession);
 

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -3,7 +3,7 @@ import { prisma } from "@/lib/db";
 import { logger } from "@/lib/logger";
 import { NextRequest, NextResponse } from "next/server";
 
-const VALID_THEMES = ["light", "dark", "auto"];
+const VALID_THEMES = ["light", "dark", "auto", "system"];
 const VALID_TIME_FORMATS = ["12h", "24h"];
 const VALID_DATE_FORMATS = ["MM/DD/YYYY", "DD/MM/YYYY", "YYYY-MM-DD"];
 
@@ -67,7 +67,7 @@ export async function PUT(request: NextRequest) {
     if (body.theme !== undefined) {
       if (!VALID_THEMES.includes(body.theme as string)) {
         return NextResponse.json(
-          { error: "Invalid theme. Must be one of: light, dark, auto" },
+          { error: "Invalid theme. Must be one of: light, dark, system" },
           { status: 400 }
         );
       }

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -8,6 +8,7 @@ import {
   CalendarProvider,
   useCalendar,
 } from "@/components/providers/CalendarProvider";
+import { ThemeToggle } from "@/components/theme/theme-toggle";
 import { Button } from "@/components/ui/button";
 import { Toaster } from "@/components/ui/sonner";
 import { useState } from "react";
@@ -22,29 +23,33 @@ function CalendarContent() {
   const [showSettings, setShowSettings] = useState(false);
 
   return (
-    <div className="min-h-screen bg-stone-50 p-4 sm:p-8">
+    <div className="bg-background min-h-screen p-4 sm:p-8">
       <div className="mx-auto max-w-7xl space-y-6">
         {/* Header */}
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-3xl font-bold text-stone-900">Wall Calendar</h1>
-            <p className="text-stone-600">
+            <h1 className="text-foreground text-3xl font-bold">
+              Wall Calendar
+            </h1>
+            <p className="text-muted-foreground">
               Your family&apos;s digital calendar
             </p>
           </div>
-          <Button
-            variant="outline"
-            size="icon"
-            onClick={() => setShowSettings(!showSettings)}
-            className="border-stone-200 hover:bg-stone-100"
-          >
-            <Settings className="h-5 w-5" />
-          </Button>
+          <div className="flex items-center gap-2">
+            <ThemeToggle />
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={() => setShowSettings(!showSettings)}
+            >
+              <Settings className="h-5 w-5" />
+            </Button>
+          </div>
         </div>
 
         {/* Settings panel */}
         {showSettings && (
-          <div className="rounded-lg border border-stone-200 bg-white p-6">
+          <div className="border-border bg-card rounded-lg border p-6">
             <AccountManager />
           </div>
         )}
@@ -53,7 +58,7 @@ function CalendarContent() {
         <ViewSwitcher />
 
         {/* Calendar - Conditional rendering based on view */}
-        <div className="rounded-lg border border-stone-200 bg-white p-6">
+        <div className="border-border bg-card rounded-lg border p-6">
           {view === "month" ? <SimpleCalendar /> : <AgendaCalendar />}
         </div>
       </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,6 +3,116 @@
 
 @custom-variant dark (&:where(.dark, .dark *));
 
+/* shadcn/ui semantic color tokens — light theme (slate base) */
+:root {
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.145 0.016 285.823);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.145 0.016 285.823);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.145 0.016 285.823);
+  --primary: oklch(0.205 0.019 285.823);
+  --primary-foreground: oklch(0.985 0.002 285.823);
+  --secondary: oklch(0.965 0.005 285.823);
+  --secondary-foreground: oklch(0.205 0.019 285.823);
+  --muted: oklch(0.965 0.005 285.823);
+  --muted-foreground: oklch(0.556 0.016 285.823);
+  --accent: oklch(0.965 0.005 285.823);
+  --accent-foreground: oklch(0.205 0.019 285.823);
+  --destructive: oklch(0.577 0.245 27.325);
+  --border: oklch(0.921 0.007 285.823);
+  --input: oklch(0.921 0.007 285.823);
+  --ring: oklch(0.87 0.012 285.823);
+  --radius: 0.625rem;
+  --sidebar-background: oklch(0.985 0.002 285.823);
+  --sidebar-foreground: oklch(0.145 0.016 285.823);
+  --sidebar-primary: oklch(0.205 0.019 285.823);
+  --sidebar-primary-foreground: oklch(0.985 0.002 285.823);
+  --sidebar-accent: oklch(0.965 0.005 285.823);
+  --sidebar-accent-foreground: oklch(0.205 0.019 285.823);
+  --sidebar-border: oklch(0.921 0.007 285.823);
+  --sidebar-ring: oklch(0.87 0.012 285.823);
+  --chart-1: oklch(0.646 0.222 41.116);
+  --chart-2: oklch(0.6 0.118 184.714);
+  --chart-3: oklch(0.398 0.07 227.392);
+  --chart-4: oklch(0.828 0.189 84.429);
+  --chart-5: oklch(0.769 0.188 70.08);
+}
+
+/* shadcn/ui semantic color tokens — dark theme */
+.dark {
+  --background: oklch(0.145 0.016 285.823);
+  --foreground: oklch(0.985 0.002 285.823);
+  --card: oklch(0.205 0.019 285.823);
+  --card-foreground: oklch(0.985 0.002 285.823);
+  --popover: oklch(0.205 0.019 285.823);
+  --popover-foreground: oklch(0.985 0.002 285.823);
+  --primary: oklch(0.985 0.002 285.823);
+  --primary-foreground: oklch(0.205 0.019 285.823);
+  --secondary: oklch(0.264 0.015 285.823);
+  --secondary-foreground: oklch(0.985 0.002 285.823);
+  --muted: oklch(0.264 0.015 285.823);
+  --muted-foreground: oklch(0.65 0.012 285.823);
+  --accent: oklch(0.264 0.015 285.823);
+  --accent-foreground: oklch(0.985 0.002 285.823);
+  --destructive: oklch(0.577 0.245 27.325);
+  --border: oklch(0.264 0.015 285.823);
+  --input: oklch(0.264 0.015 285.823);
+  --ring: oklch(0.439 0.01 285.823);
+  --chart-1: oklch(0.488 0.243 264.376);
+  --chart-2: oklch(0.696 0.17 162.48);
+  --chart-3: oklch(0.769 0.188 70.08);
+  --chart-4: oklch(0.627 0.265 303.9);
+  --chart-5: oklch(0.645 0.246 16.439);
+  --sidebar-background: oklch(0.205 0.019 285.823);
+  --sidebar-foreground: oklch(0.985 0.002 285.823);
+  --sidebar-primary: oklch(0.488 0.243 264.376);
+  --sidebar-primary-foreground: oklch(0.985 0.002 285.823);
+  --sidebar-accent: oklch(0.264 0.015 285.823);
+  --sidebar-accent-foreground: oklch(0.985 0.002 285.823);
+  --sidebar-border: oklch(0.264 0.015 285.823);
+  --sidebar-ring: oklch(0.439 0.01 285.823);
+}
+
+/* Register semantic tokens as Tailwind CSS v4 theme colors */
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-chart-1: var(--chart-1);
+  --color-chart-2: var(--chart-2);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--chart-4);
+  --color-chart-5: var(--chart-5);
+  --color-sidebar-background: var(--sidebar-background);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-ring: var(--sidebar-ring);
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+}
+
 @layer base {
   /* Tailwind v4 border color compatibility fix */
   *,
@@ -10,7 +120,7 @@
   ::before,
   ::backdrop,
   ::file-selector-button {
-    border-color: var(--stone-200, currentColor);
+    border-color: var(--color-border, var(--stone-200, currentColor));
   }
 
   button:not(:disabled),
@@ -44,7 +154,7 @@
   }
 
   h4 {
-    @apply text-xs font-extrabold tracking-wide text-stone-900/60 uppercase;
+    @apply text-foreground/60 text-xs font-extrabold tracking-wide uppercase;
   }
 
   h5 {
@@ -52,7 +162,7 @@
   }
 
   h6 {
-    @apply text-base font-bold text-stone-600;
+    @apply text-muted-foreground text-base font-bold;
   }
 
   ul {
@@ -64,16 +174,16 @@
   }
 
   li {
-    @apply text-base text-gray-900; /* Tailwind utility classes for list item text */
+    @apply text-foreground text-base; /* Tailwind utility classes for list item text */
   }
 }
 
 @layer base {
   * {
-    @apply border-gray-200 outline-blue-500/50;
+    @apply border-border outline-ring;
   }
   body {
-    @apply bg-white text-gray-900;
+    @apply bg-background text-foreground;
   }
 
   /* Hide scrollbar for Chrome, Safari and Opera */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import { AppInsightsProvider } from "@/components/providers/AppInsightsProvider";
 import { SessionProvider } from "@/components/providers/SessionProvider";
+import { ThemeProvider } from "@/components/providers/ThemeProvider";
 import type { Metadata } from "next";
 import "./globals.css";
 
@@ -20,10 +21,12 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body className="font-sans antialiased">
         <SessionProvider>
-          <AppInsightsProvider>{children}</AppInsightsProvider>
+          <ThemeProvider>
+            <AppInsightsProvider>{children}</AppInsightsProvider>
+          </ThemeProvider>
         </SessionProvider>
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,16 +5,16 @@ import nextLogo from "../../public/next.svg";
 export default function Home() {
   return (
     <div className="flex min-h-screen items-center justify-center font-sans">
-      <main className="flex w-full max-w-4xl flex-col bg-white px-8 py-16 sm:px-16 sm:py-24">
+      <main className="bg-background flex w-full max-w-4xl flex-col px-8 py-16 sm:px-16 sm:py-24">
         {/* Hero section with logo and buttons grouped together */}
         <div className="flex flex-col items-center justify-center gap-8 sm:items-start">
           {/* Logos container */}
           <div className="flex w-full flex-col items-center gap-4 sm:items-start">
-            <h1 className="text-4xl font-bold text-gray-900 sm:text-5xl">
+            <h1 className="text-foreground text-4xl font-bold sm:text-5xl">
               Digital Wall Calendar
             </h1>
             <div className="flex items-center gap-3 opacity-60">
-              <span className="text-sm text-gray-500">Powered by</span>
+              <span className="text-muted-foreground text-sm">Powered by</span>
               <Image
                 src={nextLogo}
                 alt="Next.js logo"
@@ -27,31 +27,31 @@ export default function Home() {
 
           <div className="flex w-full flex-col gap-4 text-base font-medium sm:flex-row sm:gap-3">
             <Link
-              className="bg-foreground text-background flex h-12 w-full items-center justify-center gap-2 rounded-full px-6 shadow-sm transition-all hover:scale-105 hover:bg-[#383838] hover:shadow-md sm:w-auto"
+              className="bg-foreground text-background flex h-12 w-full items-center justify-center gap-2 rounded-full px-6 shadow-sm transition-all hover:scale-105 hover:opacity-90 hover:shadow-md sm:w-auto"
               href="/calendar"
             >
               📅 Wall Calendar
             </Link>
             <Link
-              className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/8 px-6 shadow-sm transition-all hover:scale-105 hover:border-transparent hover:bg-black/4 hover:shadow-md sm:w-auto"
+              className="border-border hover:bg-accent flex h-12 w-full items-center justify-center rounded-full border px-6 shadow-sm transition-all hover:scale-105 hover:shadow-md sm:w-auto"
               href="/components"
             >
               Components
             </Link>
             <Link
-              className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/8 px-6 shadow-sm transition-all hover:scale-105 hover:border-transparent hover:bg-black/4 hover:shadow-md sm:w-auto"
+              className="border-border hover:bg-accent flex h-12 w-full items-center justify-center rounded-full border px-6 shadow-sm transition-all hover:scale-105 hover:shadow-md sm:w-auto"
               href="/typography"
             >
               Typography
             </Link>
             <Link
-              className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/8 px-6 shadow-sm transition-all hover:scale-105 hover:border-transparent hover:bg-black/4 hover:shadow-md sm:w-auto"
+              className="border-border hover:bg-accent flex h-12 w-full items-center justify-center rounded-full border px-6 shadow-sm transition-all hover:scale-105 hover:shadow-md sm:w-auto"
               href="/recipe"
             >
               Recipe Display
             </Link>
             <Link
-              className="flex h-12 w-full items-center justify-center gap-2 rounded-full border border-solid border-black/8 px-6 shadow-sm transition-all hover:scale-105 hover:border-transparent hover:bg-black/4 hover:shadow-md sm:w-auto"
+              className="border-border hover:bg-accent flex h-12 w-full items-center justify-center gap-2 rounded-full border px-6 shadow-sm transition-all hover:scale-105 hover:shadow-md sm:w-auto"
               href="/demo-logging"
             >
               <svg
@@ -66,7 +66,7 @@ export default function Home() {
               Logging Demo
             </Link>
             <a
-              className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/8 px-6 shadow-sm transition-all hover:scale-105 hover:border-transparent hover:bg-black/4 hover:shadow-md sm:w-auto"
+              className="border-border hover:bg-accent flex h-12 w-full items-center justify-center rounded-full border px-6 shadow-sm transition-all hover:scale-105 hover:shadow-md sm:w-auto"
               href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
               target="_blank"
               rel="noopener noreferrer"

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -32,7 +32,7 @@ export default async function SettingsPage() {
 
   return (
     <div className="container mx-auto max-w-2xl p-8">
-      <h1 className="mb-8 text-3xl font-bold text-gray-900">Settings</h1>
+      <h1 className="text-foreground mb-8 text-3xl font-bold">Settings</h1>
       <SettingsForm
         user={{
           name: session.user.name,

--- a/src/app/test/settings/page.tsx
+++ b/src/app/test/settings/page.tsx
@@ -11,13 +11,13 @@ import { Toaster } from "sonner";
  */
 export default function TestSettingsPage() {
   return (
-    <div className="min-h-screen bg-gray-50 p-8">
+    <div className="bg-background min-h-screen p-8">
       <div className="mx-auto max-w-2xl">
-        <div className="mb-6 rounded-lg border border-yellow-300 bg-yellow-50 p-3 text-sm text-yellow-800">
+        <div className="mb-6 rounded-lg border border-yellow-300 bg-yellow-50 p-3 text-sm text-yellow-800 dark:border-yellow-600 dark:bg-yellow-950 dark:text-yellow-200">
           Test page — rendering SettingsForm with mock data (no auth required)
         </div>
 
-        <h1 className="mb-6 text-3xl font-bold text-gray-900">Settings</h1>
+        <h1 className="text-foreground mb-6 text-3xl font-bold">Settings</h1>
 
         <SettingsForm
           user={{

--- a/src/components/calendar/AccountManager.tsx
+++ b/src/components/calendar/AccountManager.tsx
@@ -77,10 +77,12 @@ export function AccountManager() {
   // Show session error if refresh token failed
   if (session?.error === "RefreshTokenError") {
     return (
-      <Card className="border-yellow-200 bg-yellow-50">
+      <Card className="border-yellow-200 bg-yellow-50 dark:border-yellow-700 dark:bg-yellow-950">
         <CardHeader>
-          <CardTitle className="text-yellow-800">Session Expired</CardTitle>
-          <CardDescription className="text-yellow-700">
+          <CardTitle className="text-yellow-800 dark:text-yellow-200">
+            Session Expired
+          </CardTitle>
+          <CardDescription className="text-yellow-700 dark:text-yellow-300">
             Your Google session has expired. Please sign in again to continue
             viewing your calendar.
           </CardDescription>
@@ -99,21 +101,21 @@ export function AccountManager() {
   }
 
   return (
-    <Card className="border-gray-200">
+    <Card>
       <CardHeader>
-        <CardTitle className="text-gray-900">Calendar Accounts</CardTitle>
-        <CardDescription className="text-gray-600">
+        <CardTitle>Calendar Accounts</CardTitle>
+        <CardDescription>
           Connect your Google Calendar account to display events
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
         {status === "loading" ? (
           <div className="py-8 text-center">
-            <p className="text-gray-600">Loading...</p>
+            <p className="text-muted-foreground">Loading...</p>
           </div>
         ) : !isAuthenticated ? (
           <div className="py-8 text-center">
-            <p className="mb-4 text-gray-600">
+            <p className="text-muted-foreground mb-4">
               Sign in with your Google account to view your calendar events.
             </p>
             <Button
@@ -127,7 +129,7 @@ export function AccountManager() {
         ) : (
           <>
             <div className="space-y-3">
-              <div className="flex items-center justify-between rounded-lg border border-gray-200 bg-gray-50 p-3">
+              <div className="border-border bg-muted flex items-center justify-between rounded-lg border p-3">
                 <div className="flex items-center gap-3">
                   {session?.user?.image && (
                     <Image
@@ -139,14 +141,14 @@ export function AccountManager() {
                     />
                   )}
                   <div>
-                    <p className="font-medium text-gray-900">
+                    <p className="text-foreground font-medium">
                       {session?.user?.name || "Google Account"}
                     </p>
-                    <p className="text-sm text-gray-600">
+                    <p className="text-muted-foreground text-sm">
                       {session?.user?.email}
                     </p>
                     {accountInfo && (
-                      <p className="mt-1 text-xs text-gray-500">
+                      <p className="text-muted-foreground mt-1 text-xs">
                         {accountInfo.calendarIds.length} calendar(s) connected
                       </p>
                     )}
@@ -157,15 +159,15 @@ export function AccountManager() {
                   size="sm"
                   onClick={handleSignOut}
                   disabled={isSigningOut}
-                  className="border-red-200 text-red-600 hover:bg-red-50"
+                  className="border-red-200 text-red-600 hover:bg-red-50 dark:border-red-800 dark:text-red-400 dark:hover:bg-red-950"
                 >
                   {isSigningOut ? "Signing out..." : "Sign out"}
                 </Button>
               </div>
             </div>
 
-            <div className="rounded-lg border border-green-200 bg-green-50 p-3">
-              <p className="text-sm text-green-700">
+            <div className="rounded-lg border border-green-200 bg-green-50 p-3 dark:border-green-800 dark:bg-green-950">
+              <p className="text-sm text-green-700 dark:text-green-300">
                 Your Google Calendar is connected. Events will automatically
                 sync every 15 minutes.
               </p>

--- a/src/components/calendar/AgendaCalendar.tsx
+++ b/src/components/calendar/AgendaCalendar.tsx
@@ -81,12 +81,12 @@ function parseDateKeyAsLocal(dateKey: string): Date {
  */
 function getColorClasses(color: TEventColor): string {
   const classes: Record<TEventColor, string> = {
-    blue: "border-blue-500 bg-blue-50",
-    green: "border-green-500 bg-green-50",
-    red: "border-red-500 bg-red-50",
-    yellow: "border-yellow-500 bg-yellow-50",
-    purple: "border-purple-500 bg-purple-50",
-    orange: "border-orange-500 bg-orange-50",
+    blue: "border-blue-500 bg-blue-50 dark:bg-blue-950",
+    green: "border-green-500 bg-green-50 dark:bg-green-950",
+    red: "border-red-500 bg-red-50 dark:bg-red-950",
+    yellow: "border-yellow-500 bg-yellow-50 dark:bg-yellow-950",
+    purple: "border-purple-500 bg-purple-50 dark:bg-purple-950",
+    orange: "border-orange-500 bg-orange-50 dark:bg-orange-950",
   };
   return classes[color];
 }
@@ -132,12 +132,14 @@ function EventCard({
     >
       <div className="flex items-start justify-between">
         <div className="flex-1">
-          <h4 className="font-semibold text-gray-900">{event.title}</h4>
-          <p className="mt-1 text-sm text-gray-600">
+          <h4 className="text-foreground font-semibold">{event.title}</h4>
+          <p className="text-muted-foreground mt-1 text-sm">
             {isAllDay ? "All day" : `${startTime} - ${endTime}`}
           </p>
           {event.description && (
-            <p className="mt-2 text-sm text-gray-600">{event.description}</p>
+            <p className="text-muted-foreground mt-2 text-sm">
+              {event.description}
+            </p>
           )}
         </div>
         <div
@@ -173,27 +175,27 @@ export function AgendaCalendar() {
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-12">
-        <p className="text-gray-500">Loading events...</p>
+        <p className="text-muted-foreground">Loading events...</p>
       </div>
     );
   }
 
   return (
     <div className="w-full space-y-4">
-      <h2 className="text-2xl font-bold text-gray-900">Upcoming Events</h2>
+      <h2 className="text-foreground text-2xl font-bold">Upcoming Events</h2>
 
       {/* Scrollable container */}
-      <div className="max-h-[600px] overflow-y-auto rounded-lg border border-gray-200 bg-white">
+      <div className="border-border bg-card max-h-[600px] overflow-y-auto rounded-lg border">
         {sortedGroupedEvents.length > 0 ? (
           <div className="space-y-6 p-4">
             {sortedGroupedEvents.map(([dateKey, dayEvents]) => (
               <div key={dateKey} className="space-y-3">
                 {/* Date Header - Sticky */}
-                <div className="sticky top-0 z-10 border-b border-gray-200 bg-white pt-2 pb-2">
-                  <h3 className="text-lg font-semibold text-gray-900">
+                <div className="border-border bg-card sticky top-0 z-10 border-b pt-2 pb-2">
+                  <h3 className="text-foreground text-lg font-semibold">
                     {format(parseDateKeyAsLocal(dateKey), "EEEE, MMMM d")}
                   </h3>
-                  <p className="text-sm text-gray-600">
+                  <p className="text-muted-foreground text-sm">
                     {dayEvents.length}{" "}
                     {dayEvents.length === 1 ? "event" : "events"}
                   </p>
@@ -214,7 +216,7 @@ export function AgendaCalendar() {
           </div>
         ) : (
           /* Empty state */
-          <div className="py-12 text-center text-gray-500">
+          <div className="text-muted-foreground py-12 text-center">
             <p>No upcoming events in the next 7 days</p>
           </div>
         )}

--- a/src/components/calendar/SimpleCalendar.tsx
+++ b/src/components/calendar/SimpleCalendar.tsx
@@ -71,18 +71,18 @@ export function SimpleCalendar() {
       <div className="flex items-center justify-between">
         <div>
           <div className="flex items-center gap-3">
-            <h2 className="text-2xl font-bold text-gray-900">
+            <h2 className="text-foreground text-2xl font-bold">
               {format(selectedDate, "MMMM yyyy")}
             </h2>
             <span
-              className="text-sm text-gray-500"
+              className="text-muted-foreground text-sm"
               data-testid="calendar-event-count"
             >
               {monthEventCount} {monthEventCount === 1 ? "event" : "events"}
             </span>
           </div>
           <p
-            className="text-sm text-gray-500"
+            className="text-muted-foreground text-sm"
             data-testid="calendar-date-range"
           >
             {format(monthStart, "MMM d, yyyy")} –{" "}
@@ -95,7 +95,7 @@ export function SimpleCalendar() {
             size="sm"
             onClick={goToToday}
             disabled={isCurrentMonth}
-            className="border-gray-200 text-xs font-semibold hover:bg-gray-50"
+            className="text-xs font-semibold"
             data-testid="calendar-today-btn"
             aria-label="Go to today"
           >
@@ -105,7 +105,6 @@ export function SimpleCalendar() {
             variant="outline"
             size="icon"
             onClick={previousMonth}
-            className="border-gray-200 hover:bg-gray-50"
             data-testid="calendar-prev-month"
             aria-label="Previous month"
           >
@@ -115,7 +114,6 @@ export function SimpleCalendar() {
             variant="outline"
             size="icon"
             onClick={nextMonth}
-            className="border-gray-200 hover:bg-gray-50"
             data-testid="calendar-next-month"
             aria-label="Next month"
           >
@@ -126,17 +124,19 @@ export function SimpleCalendar() {
 
       {/* Loading indicator */}
       {isLoading && (
-        <div className="text-center text-gray-600">Loading events...</div>
+        <div className="text-muted-foreground text-center">
+          Loading events...
+        </div>
       )}
 
       {/* Calendar Grid */}
-      <div className="rounded-lg border border-gray-200 bg-white">
+      <div className="border-border bg-card rounded-lg border">
         {/* Day headers */}
-        <div className="grid grid-cols-7 border-b border-gray-200 bg-gray-50">
+        <div className="border-border bg-muted grid grid-cols-7 border-b">
           {["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"].map((day) => (
             <div
               key={day}
-              className="p-3 text-center text-sm font-semibold text-gray-700"
+              className="text-muted-foreground p-3 text-center text-sm font-semibold"
             >
               {day}
             </div>
@@ -149,7 +149,7 @@ export function SimpleCalendar() {
           {paddingDays.map((index) => (
             <div
               key={`padding-${index}`}
-              className="min-h-[100px] border-r border-b border-gray-200 bg-gray-50"
+              className="border-border bg-muted min-h-[100px] border-r border-b"
             />
           ))}
 
@@ -161,15 +161,15 @@ export function SimpleCalendar() {
             return (
               <div
                 key={day.toISOString()}
-                className={`min-h-[100px] border-r border-b border-gray-200 p-2 ${
-                  isToday ? "bg-blue-50" : "bg-white"
+                className={`border-border min-h-[100px] border-r border-b p-2 ${
+                  isToday ? "bg-blue-50 dark:bg-blue-950" : "bg-card"
                 }`}
               >
                 <div
                   className={`mb-1 text-sm ${
                     isToday
                       ? "inline-flex h-6 w-6 items-center justify-center rounded-full bg-blue-600 text-white"
-                      : "text-gray-700"
+                      : "text-muted-foreground"
                   }`}
                 >
                   {format(day, "d")}
@@ -182,23 +182,23 @@ export function SimpleCalendar() {
                       key={event.id}
                       className={`rounded px-2 py-1 text-xs ${
                         event.color === "blue"
-                          ? "bg-blue-100 text-blue-800"
+                          ? "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200"
                           : event.color === "green"
-                            ? "bg-green-100 text-green-800"
+                            ? "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200"
                             : event.color === "red"
-                              ? "bg-red-100 text-red-800"
+                              ? "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200"
                               : event.color === "yellow"
-                                ? "bg-yellow-100 text-yellow-800"
+                                ? "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200"
                                 : event.color === "purple"
-                                  ? "bg-purple-100 text-purple-800"
-                                  : "bg-orange-100 text-orange-800"
+                                  ? "bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200"
+                                  : "bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200"
                       }`}
                     >
                       {event.title}
                     </div>
                   ))}
                   {dayEvents.length > 3 && (
-                    <div className="text-xs text-gray-500">
+                    <div className="text-muted-foreground text-xs">
                       +{dayEvents.length - 3} more
                     </div>
                   )}

--- a/src/components/providers/ThemeProvider.tsx
+++ b/src/components/providers/ThemeProvider.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+
+interface ThemeProviderProps {
+  children: ReactNode;
+}
+
+export function ThemeProvider({ children }: ThemeProviderProps) {
+  return (
+    <NextThemesProvider
+      attribute="class"
+      defaultTheme="system"
+      enableSystem
+      disableTransitionOnChange
+    >
+      {children}
+    </NextThemesProvider>
+  );
+}

--- a/src/components/providers/__tests__/ThemeProvider.test.tsx
+++ b/src/components/providers/__tests__/ThemeProvider.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * Tests for ThemeProvider component
+ * TDD: Tests written before implementation
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+// Import after mock
+import { ThemeProvider } from "../ThemeProvider";
+
+// Mock next-themes
+vi.mock("next-themes", () => ({
+  ThemeProvider: ({
+    children,
+    ...props
+  }: {
+    children: React.ReactNode;
+    attribute?: string;
+    defaultTheme?: string;
+    enableSystem?: boolean;
+    disableTransitionOnChange?: boolean;
+  }) => (
+    <div
+      data-testid="next-themes-provider"
+      data-attribute={props.attribute}
+      data-default-theme={props.defaultTheme}
+      data-enable-system={String(props.enableSystem)}
+      data-disable-transition={String(props.disableTransitionOnChange)}
+    >
+      {children}
+    </div>
+  ),
+}));
+
+describe("ThemeProvider", () => {
+  it("renders children", () => {
+    render(
+      <ThemeProvider>
+        <div data-testid="child">Hello</div>
+      </ThemeProvider>
+    );
+
+    expect(screen.getByTestId("child")).toBeInTheDocument();
+    expect(screen.getByText("Hello")).toBeInTheDocument();
+  });
+
+  it("uses class attribute for theme switching", () => {
+    render(
+      <ThemeProvider>
+        <div>Content</div>
+      </ThemeProvider>
+    );
+
+    const provider = screen.getByTestId("next-themes-provider");
+    expect(provider).toHaveAttribute("data-attribute", "class");
+  });
+
+  it("defaults to system theme", () => {
+    render(
+      <ThemeProvider>
+        <div>Content</div>
+      </ThemeProvider>
+    );
+
+    const provider = screen.getByTestId("next-themes-provider");
+    expect(provider).toHaveAttribute("data-default-theme", "system");
+  });
+
+  it("enables system theme detection", () => {
+    render(
+      <ThemeProvider>
+        <div>Content</div>
+      </ThemeProvider>
+    );
+
+    const provider = screen.getByTestId("next-themes-provider");
+    expect(provider).toHaveAttribute("data-enable-system", "true");
+  });
+
+  it("disables CSS transitions on theme change to prevent flash", () => {
+    render(
+      <ThemeProvider>
+        <div>Content</div>
+      </ThemeProvider>
+    );
+
+    const provider = screen.getByTestId("next-themes-provider");
+    expect(provider).toHaveAttribute("data-disable-transition", "true");
+  });
+});

--- a/src/components/settings/__tests__/display-section.test.tsx
+++ b/src/components/settings/__tests__/display-section.test.tsx
@@ -13,6 +13,16 @@ vi.mock("@/components/ui/slider", () => ({
   Slider: MockSlider,
 }));
 
+// Mock next-themes
+const mockSetTheme = vi.fn();
+
+vi.mock("next-themes", () => ({
+  useTheme: () => ({
+    theme: "light",
+    setTheme: mockSetTheme,
+  }),
+}));
+
 const defaultValues = {
   theme: "light",
   timeFormat: "12h",
@@ -32,7 +42,7 @@ describe("DisplaySection", () => {
 
     expect(screen.getByLabelText(/light/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/dark/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/auto/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/system/i)).toBeInTheDocument();
   });
 
   it("renders time format options", () => {
@@ -50,7 +60,7 @@ describe("DisplaySection", () => {
     expect(screen.getByText(/100%/)).toBeInTheDocument();
   });
 
-  it("onChange fires when theme changes", async () => {
+  it("onChange fires and setTheme is called when theme changes", async () => {
     const user = userEvent.setup();
 
     render(<DisplaySection values={defaultValues} onChange={mockOnChange} />);
@@ -61,6 +71,7 @@ describe("DisplaySection", () => {
     expect(mockOnChange).toHaveBeenCalledWith(
       expect.objectContaining({ theme: "dark" })
     );
+    expect(mockSetTheme).toHaveBeenCalledWith("dark");
   });
 
   it("onChange fires when time format changes", async () => {
@@ -98,5 +109,31 @@ describe("DisplaySection", () => {
 
     const twentyFourHour = screen.getByLabelText(/24-hour/i);
     expect(twentyFourHour).toBeChecked();
+  });
+
+  it("maps legacy 'auto' theme value to 'system' for display", () => {
+    render(
+      <DisplaySection
+        values={{ ...defaultValues, theme: "auto" }}
+        onChange={mockOnChange}
+      />
+    );
+
+    const systemRadio = screen.getByLabelText(/system/i);
+    expect(systemRadio).toBeChecked();
+  });
+
+  it("calls setTheme with 'system' when system option is clicked", async () => {
+    const user = userEvent.setup();
+
+    render(<DisplaySection values={defaultValues} onChange={mockOnChange} />);
+
+    const systemRadio = screen.getByLabelText(/system/i);
+    await user.click(systemRadio);
+
+    expect(mockSetTheme).toHaveBeenCalledWith("system");
+    expect(mockOnChange).toHaveBeenCalledWith(
+      expect.objectContaining({ theme: "system" })
+    );
   });
 });

--- a/src/components/settings/display-section.tsx
+++ b/src/components/settings/display-section.tsx
@@ -2,6 +2,7 @@
 
 import { Label } from "@/components/ui/label";
 import { Slider } from "@/components/ui/slider";
+import { useTheme } from "next-themes";
 import { SettingsSection } from "./settings-section";
 
 interface DisplayValues {
@@ -16,8 +17,19 @@ interface DisplaySectionProps {
   onChange: (values: Partial<DisplayValues>) => void;
 }
 
+const THEME_OPTIONS = ["light", "dark", "system"] as const;
+
 export function DisplaySection({ values, onChange }: DisplaySectionProps) {
+  const { setTheme } = useTheme();
   const zoomPercentage = Math.round(values.defaultZoomLevel * 100);
+
+  // Map legacy "auto" to "system" for display
+  const currentTheme = values.theme === "auto" ? "system" : values.theme;
+
+  const handleThemeChange = (theme: string) => {
+    setTheme(theme);
+    onChange({ theme });
+  };
 
   return (
     <SettingsSection
@@ -27,16 +39,16 @@ export function DisplaySection({ values, onChange }: DisplaySectionProps) {
       <div className="space-y-6">
         {/* Theme selection */}
         <fieldset>
-          <legend className="text-sm font-medium text-gray-700">Theme</legend>
+          <legend className="text-foreground text-sm font-medium">Theme</legend>
           <div className="mt-2 flex gap-4">
-            {(["light", "dark", "auto"] as const).map((theme) => (
+            {THEME_OPTIONS.map((theme) => (
               <Label key={theme} className="flex items-center gap-2">
                 <input
                   type="radio"
                   name="theme"
                   value={theme}
-                  checked={values.theme === theme}
-                  onChange={() => onChange({ theme })}
+                  checked={currentTheme === theme}
+                  onChange={() => handleThemeChange(theme)}
                   className="text-blue-600"
                 />
                 <span className="capitalize">{theme}</span>
@@ -47,7 +59,7 @@ export function DisplaySection({ values, onChange }: DisplaySectionProps) {
 
         {/* Time format */}
         <fieldset>
-          <legend className="text-sm font-medium text-gray-700">
+          <legend className="text-foreground text-sm font-medium">
             Time Format
           </legend>
           <div className="mt-2 flex gap-4">
@@ -80,7 +92,9 @@ export function DisplaySection({ values, onChange }: DisplaySectionProps) {
         <div className="space-y-2">
           <div className="flex items-center justify-between">
             <Label>Zoom Level</Label>
-            <span className="text-sm text-gray-500">{zoomPercentage}%</span>
+            <span className="text-muted-foreground text-sm">
+              {zoomPercentage}%
+            </span>
           </div>
           <Slider
             value={[values.defaultZoomLevel]}

--- a/src/components/theme/__tests__/theme-toggle.test.tsx
+++ b/src/components/theme/__tests__/theme-toggle.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * Tests for ThemeToggle component
+ * TDD: Tests written before implementation
+ */
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ThemeToggle } from "../theme-toggle";
+
+// Mock next-themes
+const mockSetTheme = vi.fn();
+let mockTheme = "system";
+
+vi.mock("next-themes", () => ({
+  useTheme: () => ({
+    theme: mockTheme,
+    setTheme: mockSetTheme,
+    resolvedTheme: mockTheme === "system" ? "light" : mockTheme,
+  }),
+}));
+
+// Mock Radix dropdown since it doesn't work in jsdom
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuTrigger: ({
+    children,
+    asChild,
+  }: {
+    children: React.ReactNode;
+    asChild?: boolean;
+  }) => <div data-as-child={asChild}>{children}</div>,
+  DropdownMenuContent: ({
+    children,
+    align,
+  }: {
+    children: React.ReactNode;
+    align?: string;
+  }) => (
+    <div data-testid="theme-menu-content" data-align={align}>
+      {children}
+    </div>
+  ),
+  DropdownMenuItem: ({
+    children,
+    onClick,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+  }) => (
+    <button role="menuitem" onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
+describe("ThemeToggle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTheme = "system";
+  });
+
+  it("renders a toggle button", () => {
+    render(<ThemeToggle />);
+
+    const button = screen.getByRole("button", { name: /toggle theme/i });
+    expect(button).toBeInTheDocument();
+  });
+
+  it("shows sun and moon icons for visual indication", () => {
+    render(<ThemeToggle />);
+
+    // The button should contain SVG icons (sun and moon)
+    const button = screen.getByRole("button", { name: /toggle theme/i });
+    const svgs = button.querySelectorAll("svg");
+    expect(svgs.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders three theme options: Light, Dark, System", () => {
+    render(<ThemeToggle />);
+
+    const menuItems = screen.getAllByRole("menuitem");
+    const texts = menuItems.map((item) => item.textContent);
+
+    expect(texts).toContain("Light");
+    expect(texts).toContain("Dark");
+    expect(texts).toContain("System");
+  });
+
+  it("calls setTheme('light') when Light option is clicked", async () => {
+    const user = userEvent.setup();
+    render(<ThemeToggle />);
+
+    const lightOption = screen.getByRole("menuitem", { name: /light/i });
+    await user.click(lightOption);
+
+    expect(mockSetTheme).toHaveBeenCalledWith("light");
+  });
+
+  it("calls setTheme('dark') when Dark option is clicked", async () => {
+    const user = userEvent.setup();
+    render(<ThemeToggle />);
+
+    const darkOption = screen.getByRole("menuitem", { name: /dark/i });
+    await user.click(darkOption);
+
+    expect(mockSetTheme).toHaveBeenCalledWith("dark");
+  });
+
+  it("calls setTheme('system') when System option is clicked", async () => {
+    const user = userEvent.setup();
+    render(<ThemeToggle />);
+
+    const systemOption = screen.getByRole("menuitem", { name: /system/i });
+    await user.click(systemOption);
+
+    expect(mockSetTheme).toHaveBeenCalledWith("system");
+  });
+
+  it("accepts optional className prop for positioning", () => {
+    render(<ThemeToggle className="absolute top-4 right-4" />);
+
+    // The component should be renderable with custom positioning
+    const button = screen.getByRole("button", { name: /toggle theme/i });
+    expect(button).toBeInTheDocument();
+  });
+
+  it("has accessible screen reader text", () => {
+    render(<ThemeToggle />);
+
+    expect(screen.getByText("Toggle theme")).toBeInTheDocument();
+  });
+});

--- a/src/components/theme/theme-toggle.tsx
+++ b/src/components/theme/theme-toggle.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useTheme } from "next-themes";
+import { Monitor, Moon, Sun } from "lucide-react";
+
+interface ThemeToggleProps {
+  className?: string;
+}
+
+export function ThemeToggle({ className }: ThemeToggleProps) {
+  const { setTheme } = useTheme();
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          size="icon"
+          className={className}
+          aria-label="Toggle theme"
+        >
+          <Sun className="h-4 w-4 scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />
+          <Moon className="absolute h-4 w-4 scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" />
+          <span className="sr-only">Toggle theme</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={() => setTheme("light")}>
+          <Sun className="mr-2 h-4 w-4" />
+          Light
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("dark")}>
+          <Moon className="mr-2 h-4 w-4" />
+          Dark
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("system")}>
+          <Monitor className="mr-2 h-4 w-4" />
+          System
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}


### PR DESCRIPTION
## Summary

Implements #90 — adds a fully functional dark/light/system theme toggle using `next-themes` (already a project dependency) and complete shadcn/ui CSS variable definitions.

### What's included

- **ThemeProvider** wrapping root layout using `next-themes` with `attribute="class"`, `defaultTheme="system"`, and `enableSystem`
- **ThemeToggle** dropdown component (Sun/Moon/Monitor icons) using shadcn/ui DropdownMenu, placed in calendar page header
- **Complete CSS variable definitions** for light and dark themes in `globals.css` using oklch color space (slate base from components.json)
- **`@theme inline` block** registering all semantic colors as Tailwind CSS v4 utilities (`bg-background`, `text-foreground`, `bg-card`, etc.)
- **DisplaySection** wired to `next-themes` `setTheme()` for instant theme switching; options changed from `auto` to `system` (next-themes standard)
- **Dark mode support** across all major components: SimpleCalendar, AgendaCalendar, AccountManager, Calendar page, Home page, Settings pages
- **API validation** updated to accept both `"system"` and legacy `"auto"` theme values
- **Theme persistence** via `next-themes` localStorage (instant on page load, no flash)

### Components updated for dark mode

| Component | Changes |
|---|---|
| `globals.css` | CSS variables for `:root` and `.dark`, `@theme inline`, semantic base styles |
| `layout.tsx` | ThemeProvider wrapper, `suppressHydrationWarning` on `<html>` |
| `SimpleCalendar` | `bg-card`, `border-border`, `text-foreground`, dark event chips |
| `AgendaCalendar` | Semantic tokens, dark event card backgrounds |
| `AccountManager` | Semantic tokens, dark status cards |
| `Calendar page` | `bg-background`, ThemeToggle in header |
| `Home page` | `bg-background`, `border-border`, `hover:bg-accent` |
| `DisplaySection` | `useTheme()` integration, "system" option |
| Settings pages | `text-foreground` headings |

## Test plan

- [x] **5 unit tests** for ThemeProvider (renders children, class attribute, system default, enableSystem, disableTransitionOnChange)
- [x] **8 unit tests** for ThemeToggle (renders button, icons, three options, setTheme calls for each, className prop, sr-only text)
- [x] **9 unit tests** for DisplaySection (updated: system option, setTheme wiring, legacy auto→system mapping)
- [x] **1 unit test** for API settings (accepts "system" as valid theme)
- [x] **7 Playwright E2E tests** (theme.spec.ts): .dark class toggling, background color change, persistence across reload, keyboard a11y, fieldset structure
- [x] Updated existing settings E2E tests for "system" label
- [x] All 886 existing unit tests pass
- [x] `pnpm lint:fix` — 0 errors
- [x] `pnpm format:fix` — all formatted
- [x] `pnpm check-types` — 0 type errors

Closes #90

https://claude.ai/code/session_016tUarv688Xx11sVFiEStAZ