### PR TITLE
Extract shared PIN format validation utility (#123)

### DIFF
--- a/src/app/api/profiles/[id]/reset-pin/__tests__/route.test.ts
+++ b/src/app/api/profiles/[id]/reset-pin/__tests__/route.test.ts
@@ -191,66 +191,6 @@ describe("/api/profiles/[id]/reset-pin", () => {
       );
     });
 
-    it("returns 400 when newPin is invalid format (too short)", async () => {
-      vi.mocked(getSession).mockResolvedValue(mockSession);
-
-      const request = createMockRequest("/api/profiles/profile-1/reset-pin", {
-        method: "POST",
-        body: {
-          adminProfileId: mockAdminProfile.id,
-          adminPin: "1234",
-          newPin: "123", // Too short
-        },
-      });
-      const response = await POST(request, {
-        params: createParams("profile-1"),
-      });
-      const { status, data } = await parseResponse<ApiErrorResponse>(response);
-
-      expect(status).toBe(400);
-      expect(data.error).toBe("New PIN must be 4-6 digits");
-    });
-
-    it("returns 400 when newPin is invalid format (too long)", async () => {
-      vi.mocked(getSession).mockResolvedValue(mockSession);
-
-      const request = createMockRequest("/api/profiles/profile-1/reset-pin", {
-        method: "POST",
-        body: {
-          adminProfileId: mockAdminProfile.id,
-          adminPin: "1234",
-          newPin: "1234567", // Too long
-        },
-      });
-      const response = await POST(request, {
-        params: createParams("profile-1"),
-      });
-      const { status, data } = await parseResponse<ApiErrorResponse>(response);
-
-      expect(status).toBe(400);
-      expect(data.error).toBe("New PIN must be 4-6 digits");
-    });
-
-    it("returns 400 when newPin contains non-digits", async () => {
-      vi.mocked(getSession).mockResolvedValue(mockSession);
-
-      const request = createMockRequest("/api/profiles/profile-1/reset-pin", {
-        method: "POST",
-        body: {
-          adminProfileId: mockAdminProfile.id,
-          adminPin: "1234",
-          newPin: "12ab",
-        },
-      });
-      const response = await POST(request, {
-        params: createParams("profile-1"),
-      });
-      const { status, data } = await parseResponse<ApiErrorResponse>(response);
-
-      expect(status).toBe(400);
-      expect(data.error).toBe("New PIN must be 4-6 digits");
-    });
-
     it("returns 404 when admin profile not found", async () => {
       vi.mocked(getSession).mockResolvedValue(mockSession);
       mockPrisma.profile.findFirst.mockResolvedValue(null);

--- a/src/app/api/profiles/[id]/reset-pin/__tests__/route.test.ts
+++ b/src/app/api/profiles/[id]/reset-pin/__tests__/route.test.ts
@@ -191,6 +191,26 @@ describe("/api/profiles/[id]/reset-pin", () => {
       );
     });
 
+    it("returns 400 and forwards the validator error when newPin is malformed", async () => {
+      vi.mocked(getSession).mockResolvedValue(mockSession);
+
+      const request = createMockRequest("/api/profiles/profile-1/reset-pin", {
+        method: "POST",
+        body: {
+          adminProfileId: mockAdminProfile.id,
+          adminPin: "1234",
+          newPin: "abc",
+        },
+      });
+      const response = await POST(request, {
+        params: createParams("profile-1"),
+      });
+      const { status, data } = await parseResponse<ApiErrorResponse>(response);
+
+      expect(status).toBe(400);
+      expect(data.error).toBe("New PIN must be 4-6 digits");
+    });
+
     it("returns 404 when admin profile not found", async () => {
       vi.mocked(getSession).mockResolvedValue(mockSession);
       mockPrisma.profile.findFirst.mockResolvedValue(null);

--- a/src/app/api/profiles/[id]/reset-pin/route.ts
+++ b/src/app/api/profiles/[id]/reset-pin/route.ts
@@ -5,6 +5,7 @@
 import { getSession } from "@/lib/auth";
 import { prisma } from "@/lib/db";
 import { logger } from "@/lib/logger";
+import { validatePinFormat } from "@/lib/pin-utils";
 import { NextRequest, NextResponse } from "next/server";
 import bcrypt from "bcrypt";
 
@@ -47,12 +48,9 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       );
     }
 
-    // Validate new PIN format (4-6 digits)
-    if (!/^\d{4,6}$/.test(newPin)) {
-      return NextResponse.json(
-        { error: "New PIN must be 4-6 digits" },
-        { status: 400 }
-      );
+    const newPinCheck = validatePinFormat(newPin, { fieldLabel: "New PIN" });
+    if (!newPinCheck.valid) {
+      return NextResponse.json({ error: newPinCheck.error }, { status: 400 });
     }
 
     // Get admin profile

--- a/src/app/api/profiles/[id]/set-pin/__tests__/route.test.ts
+++ b/src/app/api/profiles/[id]/set-pin/__tests__/route.test.ts
@@ -96,6 +96,22 @@ describe("/api/profiles/[id]/set-pin", () => {
       expect(data.error).toBe("PIN must be 4-6 digits");
     });
 
+    it("returns 400 and forwards the validator error when PIN is malformed", async () => {
+      vi.mocked(getSession).mockResolvedValue(mockSession);
+
+      const request = createMockRequest("/api/profiles/profile-1/set-pin", {
+        method: "POST",
+        body: { pin: "abc" },
+      });
+      const response = await POST(request, {
+        params: createParams("profile-1"),
+      });
+      const { status, data } = await parseResponse<ApiErrorResponse>(response);
+
+      expect(status).toBe(400);
+      expect(data.error).toBe("PIN must be 4-6 digits");
+    });
+
     it("returns 404 when profile not found", async () => {
       vi.mocked(getSession).mockResolvedValue(mockSession);
       mockPrisma.profile.findFirst.mockResolvedValue(null);

--- a/src/app/api/profiles/[id]/set-pin/__tests__/route.test.ts
+++ b/src/app/api/profiles/[id]/set-pin/__tests__/route.test.ts
@@ -96,54 +96,6 @@ describe("/api/profiles/[id]/set-pin", () => {
       expect(data.error).toBe("PIN must be 4-6 digits");
     });
 
-    it("returns 400 when PIN is too short", async () => {
-      vi.mocked(getSession).mockResolvedValue(mockSession);
-
-      const request = createMockRequest("/api/profiles/profile-1/set-pin", {
-        method: "POST",
-        body: { pin: "123" },
-      });
-      const response = await POST(request, {
-        params: createParams("profile-1"),
-      });
-      const { status, data } = await parseResponse<ApiErrorResponse>(response);
-
-      expect(status).toBe(400);
-      expect(data.error).toBe("PIN must be 4-6 digits");
-    });
-
-    it("returns 400 when PIN is too long", async () => {
-      vi.mocked(getSession).mockResolvedValue(mockSession);
-
-      const request = createMockRequest("/api/profiles/profile-1/set-pin", {
-        method: "POST",
-        body: { pin: "1234567" },
-      });
-      const response = await POST(request, {
-        params: createParams("profile-1"),
-      });
-      const { status, data } = await parseResponse<ApiErrorResponse>(response);
-
-      expect(status).toBe(400);
-      expect(data.error).toBe("PIN must be 4-6 digits");
-    });
-
-    it("returns 400 when PIN contains non-digits", async () => {
-      vi.mocked(getSession).mockResolvedValue(mockSession);
-
-      const request = createMockRequest("/api/profiles/profile-1/set-pin", {
-        method: "POST",
-        body: { pin: "12ab" },
-      });
-      const response = await POST(request, {
-        params: createParams("profile-1"),
-      });
-      const { status, data } = await parseResponse<ApiErrorResponse>(response);
-
-      expect(status).toBe(400);
-      expect(data.error).toBe("PIN must be 4-6 digits");
-    });
-
     it("returns 404 when profile not found", async () => {
       vi.mocked(getSession).mockResolvedValue(mockSession);
       mockPrisma.profile.findFirst.mockResolvedValue(null);

--- a/src/app/api/profiles/[id]/set-pin/route.ts
+++ b/src/app/api/profiles/[id]/set-pin/route.ts
@@ -5,6 +5,7 @@
 import { getSession } from "@/lib/auth";
 import { prisma } from "@/lib/db";
 import { logger } from "@/lib/logger";
+import { validatePinFormat } from "@/lib/pin-utils";
 import { NextRequest, NextResponse } from "next/server";
 import bcrypt from "bcrypt";
 
@@ -38,12 +39,9 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     const body = (await request.json()) as SetPinBody;
     const { pin, currentPin } = body;
 
-    // Validate PIN format (4-6 digits)
-    if (!pin || !/^\d{4,6}$/.test(pin)) {
-      return NextResponse.json(
-        { error: "PIN must be 4-6 digits" },
-        { status: 400 }
-      );
+    const pinCheck = validatePinFormat(pin);
+    if (!pinCheck.valid) {
+      return NextResponse.json({ error: pinCheck.error }, { status: 400 });
     }
 
     // Get profile

--- a/src/lib/__tests__/pin-utils.test.ts
+++ b/src/lib/__tests__/pin-utils.test.ts
@@ -7,11 +7,9 @@ import { validatePinFormat } from "../pin-utils";
 describe("validatePinFormat", () => {
   describe("valid PINs", () => {
     it.each([["1234"], ["12345"], ["123456"]])(
-      "accepts a %s-digit numeric PIN",
+      "accepts %s as a valid PIN",
       (pin) => {
-        const result = validatePinFormat(pin);
-        expect(result.valid).toBe(true);
-        expect(result.error).toBeUndefined();
+        expect(validatePinFormat(pin)).toEqual({ valid: true });
       }
     );
   });
@@ -25,40 +23,46 @@ describe("validatePinFormat", () => {
       ["12-34", "contains punctuation"],
       ["", "is empty"],
     ])("rejects %s — %s", (pin) => {
-      const result = validatePinFormat(pin);
-      expect(result.valid).toBe(false);
-      expect(result.error).toBe("PIN must be 4-6 digits");
+      expect(validatePinFormat(pin)).toEqual({
+        valid: false,
+        error: "PIN must be 4-6 digits",
+      });
     });
 
     it("rejects undefined", () => {
-      const result = validatePinFormat(undefined);
-      expect(result.valid).toBe(false);
-      expect(result.error).toBe("PIN must be 4-6 digits");
+      expect(validatePinFormat(undefined)).toEqual({
+        valid: false,
+        error: "PIN must be 4-6 digits",
+      });
     });
 
     it("rejects null", () => {
-      const result = validatePinFormat(null);
-      expect(result.valid).toBe(false);
-      expect(result.error).toBe("PIN must be 4-6 digits");
+      expect(validatePinFormat(null)).toEqual({
+        valid: false,
+        error: "PIN must be 4-6 digits",
+      });
     });
   });
 
   describe("custom field label", () => {
     it("uses the provided field label in the error message", () => {
-      const result = validatePinFormat("abc", { fieldLabel: "New PIN" });
-      expect(result.valid).toBe(false);
-      expect(result.error).toBe("New PIN must be 4-6 digits");
+      expect(validatePinFormat("abc", { fieldLabel: "New PIN" })).toEqual({
+        valid: false,
+        error: "New PIN must be 4-6 digits",
+      });
     });
 
     it("does not affect valid results", () => {
-      const result = validatePinFormat("1234", { fieldLabel: "New PIN" });
-      expect(result.valid).toBe(true);
-      expect(result.error).toBeUndefined();
+      expect(validatePinFormat("1234", { fieldLabel: "New PIN" })).toEqual({
+        valid: true,
+      });
     });
 
     it("falls back to 'PIN' when no label is given", () => {
-      const result = validatePinFormat("abc");
-      expect(result.error).toBe("PIN must be 4-6 digits");
+      expect(validatePinFormat("abc")).toEqual({
+        valid: false,
+        error: "PIN must be 4-6 digits",
+      });
     });
   });
 });

--- a/src/lib/__tests__/pin-utils.test.ts
+++ b/src/lib/__tests__/pin-utils.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Tests for PIN validation utilities.
+ */
+import { describe, expect, it } from "vitest";
+import { validatePinFormat } from "../pin-utils";
+
+describe("validatePinFormat", () => {
+  describe("valid PINs", () => {
+    it.each([["1234"], ["12345"], ["123456"]])(
+      "accepts a %s-digit numeric PIN",
+      (pin) => {
+        const result = validatePinFormat(pin);
+        expect(result.valid).toBe(true);
+        expect(result.error).toBeUndefined();
+      }
+    );
+  });
+
+  describe("invalid PINs", () => {
+    it.each([
+      ["123", "too short (3 digits)"],
+      ["1234567", "too long (7 digits)"],
+      ["12ab", "contains letters"],
+      ["12 34", "contains whitespace"],
+      ["12-34", "contains punctuation"],
+      ["", "is empty"],
+    ])("rejects %s — %s", (pin) => {
+      const result = validatePinFormat(pin);
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe("PIN must be 4-6 digits");
+    });
+
+    it("rejects undefined", () => {
+      const result = validatePinFormat(undefined);
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe("PIN must be 4-6 digits");
+    });
+
+    it("rejects null", () => {
+      const result = validatePinFormat(null);
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe("PIN must be 4-6 digits");
+    });
+  });
+
+  describe("custom field label", () => {
+    it("uses the provided field label in the error message", () => {
+      const result = validatePinFormat("abc", { fieldLabel: "New PIN" });
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe("New PIN must be 4-6 digits");
+    });
+
+    it("does not affect valid results", () => {
+      const result = validatePinFormat("1234", { fieldLabel: "New PIN" });
+      expect(result.valid).toBe(true);
+      expect(result.error).toBeUndefined();
+    });
+
+    it("falls back to 'PIN' when no label is given", () => {
+      const result = validatePinFormat("abc");
+      expect(result.error).toBe("PIN must be 4-6 digits");
+    });
+  });
+});

--- a/src/lib/pin-utils.ts
+++ b/src/lib/pin-utils.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared PIN validation utilities.
+ */
+
+const PIN_FORMAT = /^\d{4,6}$/;
+
+export interface PinFormatValidation {
+  valid: boolean;
+  error?: string;
+}
+
+export interface ValidatePinFormatOptions {
+  /** Label used in the error message (e.g., "PIN", "New PIN"). Defaults to "PIN". */
+  fieldLabel?: string;
+}
+
+/**
+ * Validate that a PIN is a 4-6 digit numeric string.
+ *
+ * Accepts `undefined` / `null` so callers can pass request-body fields without
+ * a separate presence check.
+ */
+export function validatePinFormat(
+  pin: string | undefined | null,
+  options: ValidatePinFormatOptions = {}
+): PinFormatValidation {
+  const fieldLabel = options.fieldLabel ?? "PIN";
+  if (!pin || !PIN_FORMAT.test(pin)) {
+    return { valid: false, error: `${fieldLabel} must be 4-6 digits` };
+  }
+  return { valid: true };
+}

--- a/src/lib/pin-utils.ts
+++ b/src/lib/pin-utils.ts
@@ -4,10 +4,9 @@
 
 const PIN_FORMAT = /^\d{4,6}$/;
 
-export interface PinFormatValidation {
-  valid: boolean;
-  error?: string;
-}
+export type PinFormatValidation =
+  | { valid: true }
+  | { valid: false; error: string };
 
 export interface ValidatePinFormatOptions {
   /** Label used in the error message (e.g., "PIN", "New PIN"). Defaults to "PIN". */


### PR DESCRIPTION
Closes #123.

## Summary

- Introduces `validatePinFormat` in `src/lib/pin-utils.ts` — a pure, zero-mocks helper that returns `{ valid, error? }` for a 4-6 digit numeric PIN.
- Adds `src/lib/__tests__/pin-utils.test.ts` with parameterized coverage of the valid matrix (1234, 12345, 123456), invalid shapes (too short, too long, letters, whitespace, punctuation, empty, `null`, `undefined`), and the `fieldLabel` option.
- Supports an optional `fieldLabel` so callers can choose between `"PIN must be 4-6 digits"` and `"New PIN must be 4-6 digits"` (the two distinct error strings the existing `set-pin` and `reset-pin` routes already return) without reinventing the regex.

## Phased delivery

This PR delivers **phase 1** of issue #123: the utility plus its tests. Phase 2, delivered in a follow-up commit to this same branch, will:

- Call `validatePinFormat` from `src/app/api/profiles/[id]/set-pin/route.ts` and `.../reset-pin/route.ts`, replacing the inlined regex.
- Remove the redundant route-level validation tests the issue explicitly authorizes dropping (3 format tests in `set-pin` + 3 in `reset-pin`) now that the pure-function tests cover the matrix.

## TDD

Tests were written first (red), then the implementation (green). `pnpm test`, `pnpm lint:fix`, `pnpm format:fix`, and `pnpm check-types` all pass.

## Test plan

- [x] `pnpm test src/lib/__tests__/pin-utils.test.ts` — 14/14 green
- [x] `pnpm check-types`
- [ ] After phase 2: full route test suites for `set-pin` and `reset-pin` still green

https://claude.ai/code/session_01DhQUEiHG7aERThHwRugmQ9