### PR TITLE
fix(auth): prevent duplicate Google accounts linking to one user (#61)

### DIFF
--- a/.claude/plans/mini-calendar-sidebar.md
+++ b/.claude/plans/mini-calendar-sidebar.md
@@ -48,7 +48,7 @@ changes are required in this ticket — that remains the follow-up scope of #114
 **Out of scope (deferred)**
 
 - Wiring the sidebar's date-navigation into a day/week view (depends on #70 / #114)
-- Per-event-color dot *clusters* (one dot per event-color up to N) — we ship a
+- Per-event-color dot _clusters_ (one dot per event-color up to N) — we ship a
   single dot colored by the first event, which is enough to signal "something
   is happening that day"; cluster visuals can come in #114 if desired
 - Full provider extensions for per-day event-indicator aggregation (tracked in #114)
@@ -68,7 +68,7 @@ non-empty. The dot color uses a lookup table
 Local `viewMonth` state is seeded from `startOfMonth(selectedDate)`. Chevron
 navigation mutates `viewMonth` only. Clicking a day cell calls
 `setSelectedDate(day)`; if that day is outside the currently viewed month
-(a padding cell), we *also* update `viewMonth` so the highlighted selection
+(a padding cell), we _also_ update `viewMonth` so the highlighted selection
 stays visible.
 
 We intentionally do **not** auto-sync `viewMonth` to follow external

--- a/.claude/plans/prevent-duplicate-google-accounts.md
+++ b/.claude/plans/prevent-duplicate-google-accounts.md
@@ -1,0 +1,82 @@
+# Prevent Duplicate Google Accounts per User (Issue #61)
+
+## Problem
+
+A single `User` can end up with multiple `Account` rows for the same `provider = "google"` but different `providerAccountId`s. When that happens:
+
+- `auth.ts` `session()` picks one via `findMany().then([0])`, which was consistently stale
+- Every session triggered `TokenRefreshFailed` against the stale refresh token
+- Users were stuck in a 401 / "session expired" loop
+
+The Prisma schema has `@@unique([provider, providerAccountId])` but **no** `@@unique([userId, provider])`, so the NextAuth Prisma adapter is free to attach a second Google identity to an existing user when email-matching or cookie state produces a collision.
+
+PR #48 applied a tactical `orderBy: { expires_at: "desc" }` fix. The _root cause_ (duplicate rows allowed at all) is still live. This PR addresses that.
+
+## Scope
+
+One-Google-account-per-user, enforced at two layers:
+
+1. **Database** — `@@unique([userId, provider])` constraint (new migration).
+2. **Application** — `signIn` callback guard that refuses to link a new Google `providerAccountId` onto a user that already has a `google` `Account` row with a _different_ `providerAccountId`.
+
+**Explicitly out of scope** (per the issue's "Future Considerations"):
+
+- Multi-Google-account-per-user support (would need smarter account selection UX/logic).
+- Any change to the `session()` token-refresh path — the `orderBy` patch already handles the defense-in-depth case.
+
+## Design
+
+### Phase 1 — DB constraint + migration
+
+`prisma/schema.prisma`:
+
+```prisma
+model Account {
+  ...
+  @@unique([provider, providerAccountId])
+  @@unique([userId, provider])
+}
+```
+
+New migration `prisma/migrations/0003_unique_account_user_provider/migration.sql`:
+
+```sql
+-- Enforce one account per (user, provider) to prevent stale duplicate OAuth links.
+-- If this fails with a uniqueness violation, run the dedup query in
+-- docs/nextauth-troubleshooting.md before retrying.
+CREATE UNIQUE INDEX "Account_userId_provider_key" ON "Account"("userId", "provider");
+```
+
+Update `prisma/__tests__/migration-setup.test.ts` to cover the new migration + constraint.
+
+### Phase 2 — `signIn` callback guard
+
+Extract a pure helper `shouldAllowSignIn({ user, account, existingAccounts })` that takes:
+
+- `user`: the incoming NextAuth user (may or may not have an `id` yet)
+- `account`: incoming OAuth account (`provider`, `providerAccountId`, etc.)
+- `existingAccounts`: accounts already in the DB for the incoming user
+
+Return `{ allow: boolean, reason?: string }`.
+
+Rules:
+
+- If there is no existing user (fresh sign-up): allow.
+- If the incoming account's `(provider, providerAccountId)` matches an existing row on the user: allow (same identity re-signing in).
+- If the incoming account shares the provider with an existing row but differs on `providerAccountId`: **deny** — this is the bug from #61.
+- Otherwise (different provider): allow.
+
+Wire the helper into `callbacks.signIn` in `auth.ts`. On deny, log a `GoogleAccountLinkRejected` event and return `false` so NextAuth redirects to the error page.
+
+Unit-test the helper exhaustively in `src/lib/auth/__tests__/sign-in-guard.test.ts`.
+
+## Phases
+
+1. Phase 1 — schema constraint + migration + migration-setup tests. Commit + push + open draft PR.
+2. Phase 2 — `shouldAllowSignIn` helper + wiring + unit tests. Commit + push.
+3. Finalize — full test suite, `pnpm lint:fix && pnpm format:fix && pnpm check-types`, mark PR ready, launch Sonnet reviewer.
+
+## Risks / rollout
+
+- If an existing prod DB has duplicates, the migration will fail. The issue body confirms that was manually cleaned up in PR #48. Migration SQL includes a comment pointing to the dedup path. Nothing fancier (no `DO $$ ... $$` dedup logic) because state is already clean and we don't want to silently destroy evidence.
+- The guard returns `false` from `signIn`, which NextAuth maps to the `/auth/error` page. That's the correct UX — the user should investigate why their account is linked to a stranger's Google identity.

--- a/prisma/__tests__/migration-setup.test.ts
+++ b/prisma/__tests__/migration-setup.test.ts
@@ -143,6 +143,46 @@ describe("package.json migration scripts", () => {
   });
 });
 
+describe("Account uniqueness constraints (issue #61)", () => {
+  it("schema enforces @@unique([userId, provider]) on Account", () => {
+    const schemaContent = fs.readFileSync(SCHEMA_PATH, "utf-8");
+
+    const accountBlockMatch = schemaContent.match(
+      /model Account \{[\s\S]*?\n\}/
+    );
+    expect(
+      accountBlockMatch,
+      "Account model not found in schema"
+    ).not.toBeNull();
+
+    const accountBlock = accountBlockMatch![0];
+    expect(accountBlock).toMatch(/@@unique\(\[userId,\s*provider\]\)/);
+  });
+
+  it("migration creates a unique index on Account(userId, provider)", () => {
+    const entries = fs.readdirSync(MIGRATIONS_DIR, { withFileTypes: true });
+    const migrationDirs = entries
+      .filter((e) => e.isDirectory() && e.name !== "__tests__")
+      .map((e) => e.name);
+
+    const combinedSql = migrationDirs
+      .map((dir) =>
+        fs.readFileSync(
+          path.join(MIGRATIONS_DIR, dir, "migration.sql"),
+          "utf-8"
+        )
+      )
+      .join("\n");
+
+    const uniqueIndexPattern =
+      /CREATE UNIQUE INDEX\s+"[^"]+"\s+ON\s+"Account"\s*\(\s*"userId"\s*,\s*"provider"\s*\)/;
+    expect(
+      combinedSql,
+      "Expected a CREATE UNIQUE INDEX on Account(userId, provider) across migrations"
+    ).toMatch(uniqueIndexPattern);
+  });
+});
+
 describe("schema and migration consistency", () => {
   it("should reference the same models in schema and migration", () => {
     const schemaContent = fs.readFileSync(SCHEMA_PATH, "utf-8");

--- a/prisma/migrations/0003_unique_account_user_provider/migration.sql
+++ b/prisma/migrations/0003_unique_account_user_provider/migration.sql
@@ -15,6 +15,13 @@
 --     AND a.id <> b.id
 --     AND (a.expires_at IS NULL
 --          OR (b.expires_at IS NOT NULL AND a.expires_at < b.expires_at));
+--
+-- Edge case: the predicate treats a row with expires_at IS NULL as the one
+-- to discard. That matches the stale-token scenario #48 was triaging, but
+-- a null expires_at can also legitimately mean a non-expiring offline
+-- token. If you are running this against an unfamiliar dataset, inspect
+-- `SELECT ... FROM "Account" WHERE "userId", "provider" IN (...)` first
+-- before running the DELETE so you don't silently drop a valid token.
 
 -- CreateIndex
 CREATE UNIQUE INDEX "Account_userId_provider_key" ON "Account"("userId", "provider");

--- a/prisma/migrations/0003_unique_account_user_provider/migration.sql
+++ b/prisma/migrations/0003_unique_account_user_provider/migration.sql
@@ -1,0 +1,20 @@
+-- Enforce one Account per (userId, provider) to prevent stale duplicate OAuth
+-- links (see issue #61). Without this constraint, NextAuth's Prisma adapter
+-- can create a second Account row for the same user when a different Google
+-- identity signs in under an existing session, which caused perpetual
+-- TokenRefreshFailed errors against the older stale refresh token.
+--
+-- If this migration fails with "could not create unique index" there are
+-- duplicate rows in production; dedup before retrying. The pattern used in
+-- PR #48 was to keep the row with the newest expires_at and delete the rest:
+--
+--   DELETE FROM "Account" a
+--   USING "Account" b
+--   WHERE a."userId" = b."userId"
+--     AND a."provider" = b."provider"
+--     AND a.id <> b.id
+--     AND (a.expires_at IS NULL
+--          OR (b.expires_at IS NOT NULL AND a.expires_at < b.expires_at));
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Account_userId_provider_key" ON "Account"("userId", "provider");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -47,6 +47,7 @@ model Account {
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([provider, providerAccountId])
+  @@unique([userId, provider])
 }
 
 model Session {

--- a/src/lib/auth/__tests__/sign-in-guard.test.ts
+++ b/src/lib/auth/__tests__/sign-in-guard.test.ts
@@ -3,12 +3,11 @@
  * Google accounts to the same User record (see issue #61).
  */
 import { describe, expect, it } from "vitest";
-import { shouldAllowSignIn } from "../sign-in-guard";
-
-type StoredAccount = {
-  provider: string;
-  providerAccountId: string;
-};
+import {
+  type StoredAccount,
+  lastSix,
+  shouldAllowSignIn,
+} from "../sign-in-guard";
 
 describe("shouldAllowSignIn", () => {
   const googleAccount = {
@@ -17,9 +16,8 @@ describe("shouldAllowSignIn", () => {
     type: "oauth",
   };
 
-  it("allows when there is no existing user (fresh sign-up)", () => {
+  it("allows when existingAccounts is empty (fresh sign-up or new provider)", () => {
     const result = shouldAllowSignIn({
-      user: { id: undefined, email: "new@example.com" },
       account: googleAccount,
       existingAccounts: [],
     });
@@ -27,9 +25,8 @@ describe("shouldAllowSignIn", () => {
     expect(result.allow).toBe(true);
   });
 
-  it("allows when incoming account is missing (credentials / email flows)", () => {
+  it("allows when the incoming account is null (credentials / email flows)", () => {
     const result = shouldAllowSignIn({
-      user: { id: "user-1", email: "u@example.com" },
       account: null,
       existingAccounts: [],
     });
@@ -43,7 +40,6 @@ describe("shouldAllowSignIn", () => {
     ];
 
     const result = shouldAllowSignIn({
-      user: { id: "user-1", email: "u@example.com" },
       account: googleAccount,
       existingAccounts,
     });
@@ -57,7 +53,6 @@ describe("shouldAllowSignIn", () => {
     ];
 
     const result = shouldAllowSignIn({
-      user: { id: "user-1", email: "u@example.com" },
       account: googleAccount,
       existingAccounts,
     });
@@ -73,7 +68,6 @@ describe("shouldAllowSignIn", () => {
     ];
 
     const result = shouldAllowSignIn({
-      user: { id: "user-1", email: "u@example.com" },
       account: {
         provider: "github",
         providerAccountId: "gh-123",
@@ -85,13 +79,32 @@ describe("shouldAllowSignIn", () => {
     expect(result.allow).toBe(true);
   });
 
-  it("is case-sensitive on provider to avoid treating 'google' and 'Google' as distinct", () => {
+  it("treats providers case-sensitively so 'google' and 'Google' are distinct", () => {
+    // A stored 'Google' row must not match an incoming 'google' account.
+    // Comparisons use ===, so different casing is a different provider and
+    // should be allowed to link (and vice versa).
+    const existingAccounts: StoredAccount[] = [
+      { provider: "Google", providerAccountId: "google-user-old" },
+    ];
+
+    const result = shouldAllowSignIn({
+      account: {
+        provider: "google",
+        providerAccountId: "google-user-new",
+        type: "oauth",
+      },
+      existingAccounts,
+    });
+
+    expect(result.allow).toBe(true);
+  });
+
+  it("denies same-provider sign-in with a different providerAccountId", () => {
     const existingAccounts: StoredAccount[] = [
       { provider: "google", providerAccountId: "google-user-old" },
     ];
 
     const result = shouldAllowSignIn({
-      user: { id: "user-1", email: "u@example.com" },
       account: {
         provider: "google",
         providerAccountId: "google-user-new",
@@ -110,12 +123,26 @@ describe("shouldAllowSignIn", () => {
     ];
 
     const result = shouldAllowSignIn({
-      user: { id: "user-1", email: "u@example.com" },
       account: googleAccount,
       existingAccounts,
     });
 
     if (result.allow) throw new Error("expected guard to deny");
     expect(result.existingProviderAccountId).toBe("google-user-old-a");
+  });
+});
+
+describe("lastSix", () => {
+  it("returns the last 6 characters of a long identifier", () => {
+    expect(lastSix("google-user-1234567890")).toBe("567890");
+  });
+
+  it("returns the whole string when it is 6 characters or shorter", () => {
+    expect(lastSix("abc")).toBe("abc");
+    expect(lastSix("abcdef")).toBe("abcdef");
+  });
+
+  it("handles the empty string without throwing", () => {
+    expect(lastSix("")).toBe("");
   });
 });

--- a/src/lib/auth/__tests__/sign-in-guard.test.ts
+++ b/src/lib/auth/__tests__/sign-in-guard.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Unit tests for the sign-in guard that prevents a user from linking multiple
+ * Google accounts to the same User record (see issue #61).
+ */
+import { describe, expect, it } from "vitest";
+import { shouldAllowSignIn } from "../sign-in-guard";
+
+type StoredAccount = {
+  provider: string;
+  providerAccountId: string;
+};
+
+describe("shouldAllowSignIn", () => {
+  const googleAccount = {
+    provider: "google",
+    providerAccountId: "google-user-abc",
+    type: "oauth",
+  };
+
+  it("allows when there is no existing user (fresh sign-up)", () => {
+    const result = shouldAllowSignIn({
+      user: { id: undefined, email: "new@example.com" },
+      account: googleAccount,
+      existingAccounts: [],
+    });
+
+    expect(result.allow).toBe(true);
+  });
+
+  it("allows when incoming account is missing (credentials / email flows)", () => {
+    const result = shouldAllowSignIn({
+      user: { id: "user-1", email: "u@example.com" },
+      account: null,
+      existingAccounts: [],
+    });
+
+    expect(result.allow).toBe(true);
+  });
+
+  it("allows when the incoming account already exists on the user (re-sign-in)", () => {
+    const existingAccounts: StoredAccount[] = [
+      { provider: "google", providerAccountId: "google-user-abc" },
+    ];
+
+    const result = shouldAllowSignIn({
+      user: { id: "user-1", email: "u@example.com" },
+      account: googleAccount,
+      existingAccounts,
+    });
+
+    expect(result.allow).toBe(true);
+  });
+
+  it("denies when a different Google identity tries to link onto a user that already has a Google account", () => {
+    const existingAccounts: StoredAccount[] = [
+      { provider: "google", providerAccountId: "google-user-old" },
+    ];
+
+    const result = shouldAllowSignIn({
+      user: { id: "user-1", email: "u@example.com" },
+      account: googleAccount,
+      existingAccounts,
+    });
+
+    if (result.allow) throw new Error("expected guard to deny");
+    expect(result.reason).toMatch(/already linked/i);
+    expect(result.existingProviderAccountId).toBe("google-user-old");
+  });
+
+  it("allows linking a different provider when Google is already linked", () => {
+    const existingAccounts: StoredAccount[] = [
+      { provider: "google", providerAccountId: "google-user-abc" },
+    ];
+
+    const result = shouldAllowSignIn({
+      user: { id: "user-1", email: "u@example.com" },
+      account: {
+        provider: "github",
+        providerAccountId: "gh-123",
+        type: "oauth",
+      },
+      existingAccounts,
+    });
+
+    expect(result.allow).toBe(true);
+  });
+
+  it("is case-sensitive on provider to avoid treating 'google' and 'Google' as distinct", () => {
+    const existingAccounts: StoredAccount[] = [
+      { provider: "google", providerAccountId: "google-user-old" },
+    ];
+
+    const result = shouldAllowSignIn({
+      user: { id: "user-1", email: "u@example.com" },
+      account: {
+        provider: "google",
+        providerAccountId: "google-user-new",
+        type: "oauth",
+      },
+      existingAccounts,
+    });
+
+    expect(result.allow).toBe(false);
+  });
+
+  it("handles multiple existing accounts on the same provider by reporting the first match", () => {
+    const existingAccounts: StoredAccount[] = [
+      { provider: "google", providerAccountId: "google-user-old-a" },
+      { provider: "google", providerAccountId: "google-user-old-b" },
+    ];
+
+    const result = shouldAllowSignIn({
+      user: { id: "user-1", email: "u@example.com" },
+      account: googleAccount,
+      existingAccounts,
+    });
+
+    if (result.allow) throw new Error("expected guard to deny");
+    expect(result.existingProviderAccountId).toBe("google-user-old-a");
+  });
+});

--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -5,6 +5,7 @@ import NextAuth from "next-auth";
 import Google from "next-auth/providers/google";
 import { PrismaAdapter } from "@auth/prisma-adapter";
 import { encryptLinkedAccount } from "./link-account";
+import { shouldAllowSignIn } from "./sign-in-guard";
 
 export const { handlers, signIn, signOut, auth } = NextAuth({
   adapter: PrismaAdapter(prisma),
@@ -28,6 +29,41 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
     }),
   ],
   callbacks: {
+    async signIn({ user, account }) {
+      // Guard against issue #61: reject attempts to link a second
+      // Google identity to a user that already has a different Google
+      // account. Without this, the Prisma adapter creates a duplicate
+      // row that the DB constraint will now reject, but we want a
+      // cleaner user-facing failure than a raw Postgres error.
+      if (!account || !user.id) return true;
+
+      const existingAccounts = await prisma.account.findMany({
+        where: { userId: user.id, provider: account.provider },
+        select: { provider: true, providerAccountId: true },
+      });
+
+      const decision = shouldAllowSignIn({
+        user: { id: user.id, email: user.email },
+        account: {
+          provider: account.provider,
+          providerAccountId: account.providerAccountId,
+          type: account.type,
+        },
+        existingAccounts,
+      });
+
+      if (!decision.allow) {
+        logger.event("GoogleAccountLinkRejected", {
+          userId: user.id,
+          provider: account.provider,
+          existingProviderAccountId: decision.existingProviderAccountId,
+          incomingProviderAccountId: account.providerAccountId,
+        });
+        return false;
+      }
+
+      return true;
+    },
     async session({ session, user }) {
       // Get the Google account for this user
       const [googleAccount] = await prisma.account.findMany({

--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -5,7 +5,7 @@ import NextAuth from "next-auth";
 import Google from "next-auth/providers/google";
 import { PrismaAdapter } from "@auth/prisma-adapter";
 import { encryptLinkedAccount } from "./link-account";
-import { shouldAllowSignIn } from "./sign-in-guard";
+import { lastSix, shouldAllowSignIn } from "./sign-in-guard";
 
 export const { handlers, signIn, signOut, auth } = NextAuth({
   adapter: PrismaAdapter(prisma),
@@ -35,6 +35,13 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       // account. Without this, the Prisma adapter creates a duplicate
       // row that the DB constraint will now reject, but we want a
       // cleaner user-facing failure than a raw Postgres error.
+      //
+      // user.id is only populated after the Prisma adapter has written
+      // the User row. If it is absent this callback is running for a
+      // fresh sign-up, so there are no existing accounts to check and
+      // we short-circuit — do NOT remove this guard, or every new
+      // sign-up will hit a prisma.account query against an undefined
+      // userId.
       if (!account || !user.id) return true;
 
       const existingAccounts = await prisma.account.findMany({
@@ -43,7 +50,6 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       });
 
       const decision = shouldAllowSignIn({
-        user: { id: user.id, email: user.email },
         account: {
           provider: account.provider,
           providerAccountId: account.providerAccountId,
@@ -53,11 +59,18 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       });
 
       if (!decision.allow) {
+        // userId alone is enough to trace the incident in the DB;
+        // providerAccountIds are Google's opaque user identifiers and
+        // qualify as PII once telemetry ships, so only emit a suffix
+        // that's useful for distinguishing which of two similar IDs
+        // was involved without leaking the full value.
         logger.event("GoogleAccountLinkRejected", {
           userId: user.id,
           provider: account.provider,
-          existingProviderAccountId: decision.existingProviderAccountId,
-          incomingProviderAccountId: account.providerAccountId,
+          existingProviderAccountIdSuffix: lastSix(
+            decision.existingProviderAccountId
+          ),
+          incomingProviderAccountIdSuffix: lastSix(account.providerAccountId),
         });
         return false;
       }

--- a/src/lib/auth/sign-in-guard.ts
+++ b/src/lib/auth/sign-in-guard.ts
@@ -11,24 +11,18 @@
  * which leaves `session()` stuck on a stale refresh token.
  */
 
-type IncomingUser = {
-  id?: string | null;
-  email?: string | null;
-};
-
 type IncomingAccount = {
   provider: string;
   providerAccountId: string;
   type?: string | null;
 } | null;
 
-type StoredAccount = {
+export type StoredAccount = {
   provider: string;
   providerAccountId: string;
 };
 
 export type SignInGuardInput = {
-  user: IncomingUser;
   account: IncomingAccount;
   existingAccounts: readonly StoredAccount[];
 };
@@ -36,6 +30,16 @@ export type SignInGuardInput = {
 export type SignInGuardResult =
   | { allow: true }
   | { allow: false; reason: string; existingProviderAccountId: string };
+
+/**
+ * Return the last 6 characters of an opaque identifier (or the whole string
+ * if it is shorter). Used when logging rejected sign-in attempts so the
+ * structured event carries enough information to distinguish which of two
+ * similar account IDs was involved, without emitting the full PII payload.
+ */
+export function lastSix(id: string): string {
+  return id.length <= 6 ? id : id.slice(-6);
+}
 
 export function shouldAllowSignIn(input: SignInGuardInput): SignInGuardResult {
   const { account, existingAccounts } = input;

--- a/src/lib/auth/sign-in-guard.ts
+++ b/src/lib/auth/sign-in-guard.ts
@@ -1,0 +1,58 @@
+/**
+ * Decides whether a NextAuth sign-in attempt should be allowed.
+ *
+ * Pure, side-effect-free, and deliberately separate from `auth.ts` so it can
+ * be unit-tested without booting the NextAuth handler. Wired into
+ * `callbacks.signIn` in `src/lib/auth/auth.ts`.
+ *
+ * The guard exists to close the bug in issue #61: without it, NextAuth's
+ * Prisma adapter will happily create a second `Account` row for the same
+ * user when a different Google identity signs in under an existing session,
+ * which leaves `session()` stuck on a stale refresh token.
+ */
+
+type IncomingUser = {
+  id?: string | null;
+  email?: string | null;
+};
+
+type IncomingAccount = {
+  provider: string;
+  providerAccountId: string;
+  type?: string | null;
+} | null;
+
+type StoredAccount = {
+  provider: string;
+  providerAccountId: string;
+};
+
+export type SignInGuardInput = {
+  user: IncomingUser;
+  account: IncomingAccount;
+  existingAccounts: readonly StoredAccount[];
+};
+
+export type SignInGuardResult =
+  | { allow: true }
+  | { allow: false; reason: string; existingProviderAccountId: string };
+
+export function shouldAllowSignIn(input: SignInGuardInput): SignInGuardResult {
+  const { account, existingAccounts } = input;
+
+  if (!account) return { allow: true };
+
+  const conflicting = existingAccounts.find(
+    (existing) =>
+      existing.provider === account.provider &&
+      existing.providerAccountId !== account.providerAccountId
+  );
+
+  if (!conflicting) return { allow: true };
+
+  return {
+    allow: false,
+    reason: `A ${account.provider} account is already linked to this user`,
+    existingProviderAccountId: conflicting.providerAccountId,
+  };
+}


### PR DESCRIPTION
Closes #61.

## Summary

Roots out the bug from PR #48: a single `User` could have multiple `Account` rows for the same provider with different `providerAccountId`s, leaving `session()` stuck picking a stale refresh token and the user in a perpetual 401 loop.

The tactical `orderBy: { expires_at: "desc" }` patch in PR #48 stopped picking the stale row but did nothing to stop the duplicate from being created. This PR enforces one-Google-account-per-user at two layers:

1. **Database** — adds `@@unique([userId, provider])` to the `Account` model and ships migration `0003_unique_account_user_provider` that creates the matching unique index.
2. **Application** — new `shouldAllowSignIn` helper wired into NextAuth's `callbacks.signIn`. When a sign-in would link a new Google `providerAccountId` to a user that already has a different Google account, the callback returns `false`, NextAuth redirects to `/auth/error`, and we log a `GoogleAccountLinkRejected` event. Returning `false` gives a cleaner user-facing failure than a raw Postgres unique-constraint error.

Explicitly out of scope per the issue's "Future Considerations": multi-Google-account-per-user support.

## Test plan

- [x] `pnpm test` — 1020 tests pass (was 1011 before this branch). New coverage:
  - `prisma/__tests__/migration-setup.test.ts` asserts `@@unique([userId, provider])` on the `Account` model and a `CREATE UNIQUE INDEX` on `Account(userId, provider)` across the migrations directory.
  - `src/lib/auth/__tests__/sign-in-guard.test.ts` — 7 tests covering fresh sign-up, re-sign-in on the same identity, conflicting-identity denial, different-provider allowance, case sensitivity, and multi-existing-account diagnostic messaging.
- [x] `pnpm lint:fix && pnpm format:fix && pnpm check-types` clean.

## Notes for reviewers

- If production ever ended up with duplicate rows again, the migration will fail with "could not create unique index". The dedup SQL is inlined as a comment in the migration file — we intentionally don't auto-dedup so evidence isn't silently destroyed.
- The guard is a pure function in `src/lib/auth/sign-in-guard.ts`, deliberately decoupled from NextAuth so it can be exercised without booting the handler.

https://claude.ai/code/session_01ShTzALvgWB8EZod2dioHW3