### PR TITLE
feat(calendar): smooth view transition animations (#87)

### DIFF
--- a/.claude/plans/view-transition-animations.md
+++ b/.claude/plans/view-transition-animations.md
@@ -1,0 +1,105 @@
+# Smooth view transition animations (#87)
+
+## Goal
+
+Add smooth, performant animations to the calendar UI when:
+
+1. The top-level view changes (Month ↔ Agenda today; extensible to Day/Week/Year later).
+2. The user navigates between periods in Month view (prev/next month → directional slide).
+
+Animations must respect `prefers-reduced-motion` and target 60 fps for the wall display.
+
+## Non-goals
+
+- Panel expand/collapse animation (out of scope this slice).
+- Wiring animations for views that do not yet exist (Day, Week, Year land in separate PRs).
+- Changing the scheduler's `ScreenTransition` component (different concern — cross-page transitions).
+
+## Architecture
+
+Two new pieces, both internal to `src/components/calendar`:
+
+1. **`useReducedMotion()`** (`src/hooks/use-reduced-motion.ts`)
+   - Reads `(prefers-reduced-motion: reduce)` via `window.matchMedia`.
+   - SSR-safe (returns `false` when `window` is undefined).
+   - Live-updating via `change` event subscription.
+   - Returned boolean is read by every animated component.
+
+2. **`AnimatedSwap`** (`src/components/calendar/animated-swap.tsx`)
+   - Generic single-child swap animator keyed by a `swapKey` string.
+   - Supports `type: "fade" | "slide"`, `direction: "forward" | "backward"`, `durationMs`.
+   - Renders outgoing + incoming children during the transition using CSS transforms/opacity (GPU-composited).
+   - When `prefers-reduced-motion` is set, or `durationMs <= 0`, swaps children instantly — no animation frames.
+   - Pattern mirrors `ScreenTransition` but decoupled from `pathname` semantics.
+
+Integration points:
+
+- `src/app/calendar/page.tsx` — wrap the `SimpleCalendar`/`AgendaCalendar` branch in `AnimatedSwap` keyed on `view` with fade.
+- `src/components/calendar/SimpleCalendar.tsx` — wrap the grid in `AnimatedSwap` keyed on `format(selectedDate, "yyyy-MM")` with slide; pass direction based on whether the user clicked prev vs next.
+
+No changes to `ScreenTransition`, `CalendarProvider` public API, or existing tests.
+
+## Phases
+
+### Phase 1 — `useReducedMotion` hook
+
+- Unit tests (`src/hooks/__tests__/use-reduced-motion.test.ts`):
+  - Returns `false` when `matchMedia.matches` is `false`.
+  - Returns `true` when `matchMedia.matches` is `true`.
+  - Updates on `change` event.
+  - Unsubscribes on unmount.
+  - SSR-safe (returns `false` when `window` is undefined, covered via mocked environment guard).
+- Implement hook to make tests pass.
+
+### Phase 2 — `AnimatedSwap` component
+
+- Component tests (`src/components/calendar/__tests__/animated-swap.test.tsx`):
+  - Renders the incoming child in the idle state.
+  - On `swapKey` change, runs through exiting → entering → idle phases with configured `durationMs`.
+  - `type: "fade"` applies `opacity: 0` to outgoing, no translateX.
+  - `type: "slide"` applies `translateX(-100%)` forward / `translateX(100%)` backward.
+  - Skips animation and swaps instantly when `prefers-reduced-motion: reduce` is set.
+  - Skips animation when `durationMs === 0`.
+  - Same-`swapKey` re-render updates children in place without triggering a transition.
+- Implement component.
+
+### Phase 3 — Wire into calendar surfaces
+
+- Component test (`src/components/calendar/__tests__/calendar-view-animation.test.tsx`):
+  - Toggling the view from Month to Agenda renders both views simultaneously mid-transition.
+  - After the duration elapses, only the Agenda view remains.
+  - With reduced motion, the swap is instant (no simultaneous render).
+- Component test (`src/components/calendar/__tests__/SimpleCalendar.test.tsx`): extend with:
+  - Clicking Next month sets slide direction `forward`.
+  - Clicking Previous month sets slide direction `backward`.
+- Edit `src/app/calendar/page.tsx` to wrap the view branch in `AnimatedSwap type="fade"`.
+- Edit `src/components/calendar/SimpleCalendar.tsx` to track `direction` locally and wrap the grid in `AnimatedSwap type="slide"` keyed on month.
+
+### Phase 4 — Playwright E2E (video capture)
+
+- `e2e/calendar-transitions.spec.ts` with `test.use({ video: "on" })`:
+  - Switching Month → Agenda via `ViewSwitcher` renders both view root containers simultaneously during the transition window.
+  - Clicking Next month advances the header and runs the slide animation (the slide wrapper briefly shows two months).
+  - With `Emulate reduced-motion: "reduce"`, the swap is instant — no two-view overlap frame.
+
+## Test strategy
+
+- Unit: `useReducedMotion` with mocked `matchMedia`.
+- Component: `AnimatedSwap` lifecycle with fake timers (mirrors existing `ScreenTransition` test style).
+- Integration (component): test the calendar page wiring with React Testing Library.
+- E2E: Playwright with video capture on Chromium to visually verify animation behavior.
+
+## Acceptance criteria (from #87)
+
+- [x] Animated transitions when switching between view modes (Month ↔ Agenda covered this slice; Day/Week/Year/year slots ready for future wiring).
+- [x] Slide animations when navigating prev/next month.
+- [x] `prefers-reduced-motion` respected — animations skip.
+- [x] CSS transforms for 60 fps.
+- [x] React Compiler handles memoization (no manual `useMemo`/`useCallback`).
+- [ ] Layout transitions for expanding/collapsing panels — deferred to a follow-up (no such toggles exist on the calendar page today).
+
+## Deferred
+
+- Wiring animations for Day / Week / Year views — those views are not yet exposed via `ViewSwitcher` (tracked in PRs #149, #145).
+- Panel expand/collapse animations — no applicable panel toggles exist today.
+- Animation config via user settings — currently hardcoded; can be exposed in the settings panel (#86) later.

--- a/e2e/calendar-transitions.spec.ts
+++ b/e2e/calendar-transitions.spec.ts
@@ -1,0 +1,119 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * E2E tests for calendar view-mode and month-navigation transition
+ * animations (#87).
+ *
+ * Uses video capture so animation behavior is reviewable in test-results/.
+ * Animations are not committed; only the spec is.
+ */
+
+test.use({
+  video: "on",
+  viewport: { width: 1280, height: 720 },
+});
+
+test.describe("Calendar transition animations", () => {
+  test("fades between Month and Agenda view when the view switcher changes", async ({
+    page,
+  }) => {
+    await page.goto("/test/calendar?events=default&view=month");
+
+    // The grid view is wrapped in AnimatedSwap.
+    const swap = page.getByTestId("animated-swap").first();
+    await expect(swap).toBeVisible();
+
+    // Initially we are in Month view — header reads "MMMM yyyy".
+    await expect(page.locator("h2").first()).toBeVisible();
+
+    // Switch to Agenda by clicking the Agenda tab in the view switcher.
+    await page.getByRole("tab", { name: /agenda/i }).click();
+
+    // During the transition the outgoing snapshot of Month and the
+    // incoming Agenda root are both present in the same wrapper.
+    // The transition completes within ~250ms; the assertion below races
+    // for the entering or idle state and confirms Agenda is rendered.
+    await expect(page.getByText("Morning Standup").first()).toBeVisible({
+      timeout: 5000,
+    });
+  });
+
+  test("slides the month grid left when navigating to next month", async ({
+    page,
+  }) => {
+    await page.goto("/test/calendar?events=default&view=month");
+
+    const header = page.locator("h2").first();
+    const initialMonth = await header.textContent();
+
+    await page.getByTestId("calendar-next-month").click();
+
+    // During the slide, the outgoing wrapper carries translateX(-100%).
+    // We may catch it mid-animation; if not, the new month is rendered.
+    const outgoing = page.getByTestId("animated-swap-outgoing").first();
+    if (await outgoing.isVisible().catch(() => false)) {
+      const transform = await outgoing.evaluate(
+        (el) => (el as HTMLElement).style.transform
+      );
+      expect(transform).toBe("translateX(-100%)");
+    }
+
+    // Header must update to a new month label.
+    await expect(header).not.toHaveText(initialMonth ?? "", { timeout: 5000 });
+  });
+
+  test("slides the month grid right when navigating to previous month", async ({
+    page,
+  }) => {
+    await page.goto("/test/calendar?events=default&view=month");
+
+    const header = page.locator("h2").first();
+    const initialMonth = await header.textContent();
+
+    await page.getByTestId("calendar-prev-month").click();
+
+    const outgoing = page.getByTestId("animated-swap-outgoing").first();
+    if (await outgoing.isVisible().catch(() => false)) {
+      const transform = await outgoing.evaluate(
+        (el) => (el as HTMLElement).style.transform
+      );
+      expect(transform).toBe("translateX(100%)");
+    }
+
+    await expect(header).not.toHaveText(initialMonth ?? "", { timeout: 5000 });
+  });
+
+  test("skips animations when prefers-reduced-motion is set", async ({
+    browser,
+  }) => {
+    const context = await browser.newContext({
+      reducedMotion: "reduce",
+      viewport: { width: 1280, height: 720 },
+    });
+    const page = await context.newPage();
+
+    try {
+      await page.goto("/test/calendar?events=default&view=month");
+
+      // With reduced motion, AnimatedSwap renders a single wrapper with
+      // its child directly — no outgoing/incoming/entering nodes.
+      await page.getByRole("tab", { name: /agenda/i }).click();
+
+      // Outgoing should never appear when animations are disabled.
+      const outgoing = page.getByTestId("animated-swap-outgoing");
+      await expect(outgoing).toHaveCount(0);
+
+      // Agenda content is visible immediately.
+      await expect(page.getByText("Morning Standup").first()).toBeVisible({
+        timeout: 5000,
+      });
+
+      // Same for month navigation.
+      await page.getByRole("tab", { name: /month/i }).click();
+      await page.getByTestId("calendar-next-month").click();
+      await expect(outgoing).toHaveCount(0);
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/src/app/calendar/__tests__/page.test.tsx
+++ b/src/app/calendar/__tests__/page.test.tsx
@@ -54,6 +54,10 @@ vi.mock("@/components/calendar/ViewSwitcher", () => ({
   ViewSwitcher: () => <div data-testid="mock-view-switcher" />,
 }));
 
+vi.mock("@/components/calendar/CalendarFilterPanel", () => ({
+  CalendarFilterPanel: () => <div data-testid="mock-calendar-filter-panel" />,
+}));
+
 vi.mock("@/components/theme/theme-toggle", () => ({
   ThemeToggle: () => <div data-testid="mock-theme-toggle" />,
 }));

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -3,7 +3,6 @@
 import { AccountManager } from "@/components/calendar/AccountManager";
 import { AgendaCalendar } from "@/components/calendar/AgendaCalendar";
 import { AnalogClockView } from "@/components/calendar/AnalogClockView";
-import { AnimatedSwap } from "@/components/calendar/animated-swap";
 import { CalendarFilterPanel } from "@/components/calendar/CalendarFilterPanel";
 import { DayCalendar } from "@/components/calendar/DayCalendar";
 import { MiniCalendarSidebar } from "@/components/calendar/MiniCalendarSidebar";
@@ -11,6 +10,7 @@ import { SimpleCalendar } from "@/components/calendar/SimpleCalendar";
 import { ViewSwitcher } from "@/components/calendar/ViewSwitcher";
 import { WeekCalendar } from "@/components/calendar/WeekCalendar";
 import { YearCalendar } from "@/components/calendar/YearCalendar";
+import { AnimatedSwap } from "@/components/calendar/animated-swap";
 import {
   CalendarProvider,
   useCalendar,

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -2,8 +2,9 @@
 
 import { AccountManager } from "@/components/calendar/AccountManager";
 import { AgendaCalendar } from "@/components/calendar/AgendaCalendar";
-import { CalendarFilterPanel } from "@/components/calendar/CalendarFilterPanel";
 import { AnalogClockView } from "@/components/calendar/AnalogClockView";
+import { AnimatedSwap } from "@/components/calendar/animated-swap";
+import { CalendarFilterPanel } from "@/components/calendar/CalendarFilterPanel";
 import { DayCalendar } from "@/components/calendar/DayCalendar";
 import { MiniCalendarSidebar } from "@/components/calendar/MiniCalendarSidebar";
 import { SimpleCalendar } from "@/components/calendar/SimpleCalendar";
@@ -20,6 +21,8 @@ import { Toaster } from "@/components/ui/sonner";
 import type { TCalendarView } from "@/types/calendar";
 import { useState } from "react";
 import { Settings } from "lucide-react";
+
+const VIEW_FADE_DURATION_MS = 250;
 
 function CalendarView({ view }: { view: TCalendarView }) {
   switch (view) {
@@ -50,7 +53,7 @@ function CalendarContent() {
   // Views that surface the mini-calendar sidebar. Month duplicates the main
   // grid (issue #146) and the Clock view ships its own all-day events aside,
   // so neither needs the shared sidebar.
-  const showSidebar = view !== "month" && view !== "clock" && view !== "year" ;
+  const showSidebar = view !== "month" && view !== "clock" && view !== "year";
 
   return (
     <div className="bg-background min-h-screen p-4 sm:p-8">
@@ -97,7 +100,14 @@ function CalendarContent() {
           }
         >
           <div className="border-border bg-card rounded-lg border p-6">
-            <CalendarView view={view} />
+            <AnimatedSwap
+              swapKey={view}
+              type="fade"
+              direction="forward"
+              durationMs={VIEW_FADE_DURATION_MS}
+            >
+              <CalendarView view={view} />
+            </AnimatedSwap>
           </div>
           {showSidebar && <MiniCalendarSidebar />}
         </div>

--- a/src/app/test/calendar/page.tsx
+++ b/src/app/test/calendar/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { AgendaCalendar } from "@/components/calendar/AgendaCalendar";
-import { CalendarFilterPanel } from "@/components/calendar/CalendarFilterPanel";
 import { AnalogClockView } from "@/components/calendar/AnalogClockView";
+import { AnimatedSwap } from "@/components/calendar/animated-swap";
+import { CalendarFilterPanel } from "@/components/calendar/CalendarFilterPanel";
 import { DayCalendar } from "@/components/calendar/DayCalendar";
 import { MiniCalendarSidebar } from "@/components/calendar/MiniCalendarSidebar";
 import { SimpleCalendar } from "@/components/calendar/SimpleCalendar";
@@ -304,12 +305,19 @@ function CalendarDisplay() {
 
   return (
     <div data-testid="calendar-display">
-      {view === "day" && <DayCalendar />}
-      {view === "week" && <WeekCalendar />}
-      {view === "month" && <SimpleCalendar />}
-      {view === "year" && <YearCalendar />}
-      {view === "agenda" && <AgendaCalendar />}
-      {view === "clock" && <AnalogClockView />}
+      <AnimatedSwap
+        swapKey={view}
+        type="fade"
+        direction="forward"
+        durationMs={250}
+      >
+        {view === "day" && <DayCalendar />}
+        {view === "week" && <WeekCalendar />}
+        {view === "month" && <SimpleCalendar />}
+        {view === "year" && <YearCalendar />}
+        {view === "agenda" && <AgendaCalendar />}
+        {view === "clock" && <AnalogClockView />}
+      </AnimatedSwap>
     </div>
   );
 }

--- a/src/app/test/calendar/page.tsx
+++ b/src/app/test/calendar/page.tsx
@@ -2,7 +2,6 @@
 
 import { AgendaCalendar } from "@/components/calendar/AgendaCalendar";
 import { AnalogClockView } from "@/components/calendar/AnalogClockView";
-import { AnimatedSwap } from "@/components/calendar/animated-swap";
 import { CalendarFilterPanel } from "@/components/calendar/CalendarFilterPanel";
 import { DayCalendar } from "@/components/calendar/DayCalendar";
 import { MiniCalendarSidebar } from "@/components/calendar/MiniCalendarSidebar";
@@ -10,6 +9,7 @@ import { SimpleCalendar } from "@/components/calendar/SimpleCalendar";
 import { ViewSwitcher } from "@/components/calendar/ViewSwitcher";
 import { WeekCalendar } from "@/components/calendar/WeekCalendar";
 import { YearCalendar } from "@/components/calendar/YearCalendar";
+import { AnimatedSwap } from "@/components/calendar/animated-swap";
 import {
   MockCalendarProvider,
   useCalendar,

--- a/src/components/calendar/SimpleCalendar.tsx
+++ b/src/components/calendar/SimpleCalendar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { AnimatedSwap } from "@/components/calendar/animated-swap";
 import { useCalendar } from "@/components/providers/CalendarProvider";
 import { Button } from "@/components/ui/button";
 import { WEEK_STARTS_ON, getShortWeekdayLabels } from "@/lib/calendar-helpers";
@@ -30,6 +31,14 @@ const CELL_DATE_ATTR = "data-date";
 
 function toDateKey(date: Date): string {
   return format(date, "yyyy-MM-dd");
+}
+
+const MONTH_SLIDE_DURATION_MS = 300;
+
+/** Stable absolute month index used to derive slide direction across year
+ * boundaries (e.g. Dec 2024 -> Jan 2025 should still slide "forward"). */
+function absoluteMonthIndex(date: Date): number {
+  return date.getFullYear() * 12 + date.getMonth();
 }
 
 export function SimpleCalendar() {
@@ -77,6 +86,18 @@ export function SimpleCalendar() {
   for (let i = 0; i < allCells.length; i += 7) {
     weekRows.push(allCells.slice(i, i + 7));
   }
+
+  // Track the previously rendered month so we can derive slide direction
+  // automatically as the user navigates (next/prev buttons, today, keyboard,
+  // mini-calendar). A ref avoids an extra render and lets React Compiler
+  // handle memoization without manual useMemo/useCallback.
+  const currentMonthIndex = absoluteMonthIndex(monthStart);
+  const previousMonthIndexRef = useRef(currentMonthIndex);
+  const slideDirection: "forward" | "backward" =
+    currentMonthIndex < previousMonthIndexRef.current ? "backward" : "forward";
+  useEffect(() => {
+    previousMonthIndexRef.current = currentMonthIndex;
+  }, [currentMonthIndex]);
 
   const previousMonth = () => {
     const newDate = new Date(selectedDate);
@@ -224,7 +245,10 @@ export function SimpleCalendar() {
 
       {/* Calendar Grid — role="grid" wraps both the header rowgroup and the
        * body rowgroup so all rows and columnheaders are true descendants of
-       * the grid per WAI-ARIA ownership rules.
+       * the grid per WAI-ARIA ownership rules. The role="grid" element itself
+       * is intentionally stable (does NOT remount on month change) so screen
+       * readers retain context; only the day-cell rowgroup inside is wrapped
+       * in <AnimatedSwap> for the slide animation.
        */}
       <div
         ref={gridRef}
@@ -236,7 +260,7 @@ export function SimpleCalendar() {
         onKeyDown={handleGridKeyDown}
         className="border-border bg-card rounded-lg border"
       >
-        {/* Day headers */}
+        {/* Day headers — stable across month changes */}
         <div role="rowgroup">
           <div
             role="row"
@@ -254,101 +278,110 @@ export function SimpleCalendar() {
           </div>
         </div>
 
-        {/* Calendar days */}
-        <div role="rowgroup">
-          {weekRows.map((row, rowIndex) => (
-            <div
-              key={`row-${rowIndex}`}
-              role="row"
-              className="grid grid-cols-7"
-            >
-              {row.map(({ date, isCurrentMonth: inMonth }) => {
-                const dayEvents = inMonth ? getEventsForDay(date) : [];
-                const isToday = isSameDay(date, today);
-                const isSelected = isSameDay(date, selectedDate);
-                const dateKey = toDateKey(date);
-                const longLabel = format(date, "EEEE, MMMM d, yyyy");
-                const ariaLabel =
-                  dayEvents.length === 0
-                    ? longLabel
-                    : `${longLabel}, ${dayEvents.length} ${
-                        dayEvents.length === 1 ? "event" : "events"
-                      }`;
+        {/* Calendar days — animated swap on month change. Direction is
+         * derived from the previous month index so navigating forward slides
+         * left-to-right and backward slides right-to-left. */}
+        <AnimatedSwap
+          swapKey={format(monthStart, "yyyy-MM")}
+          type="slide"
+          direction={slideDirection}
+          durationMs={MONTH_SLIDE_DURATION_MS}
+        >
+          <div role="rowgroup" data-testid="calendar-month-grid">
+            {weekRows.map((row, rowIndex) => (
+              <div
+                key={`row-${rowIndex}`}
+                role="row"
+                className="grid grid-cols-7"
+              >
+                {row.map(({ date, isCurrentMonth: inMonth }) => {
+                  const dayEvents = inMonth ? getEventsForDay(date) : [];
+                  const isToday = isSameDay(date, today);
+                  const isSelected = isSameDay(date, selectedDate);
+                  const dateKey = toDateKey(date);
+                  const longLabel = format(date, "EEEE, MMMM d, yyyy");
+                  const ariaLabel =
+                    dayEvents.length === 0
+                      ? longLabel
+                      : `${longLabel}, ${dayEvents.length} ${
+                          dayEvents.length === 1 ? "event" : "events"
+                        }`;
 
-                if (!inMonth) {
-                  // Padding cells are decorative — screen readers shouldn't
-                  // navigate them, so we hide them from the a11y tree. They
-                  // remain gridcells for layout/ARIA row-ownership purposes.
+                  if (!inMonth) {
+                    // Padding cells are decorative — screen readers shouldn't
+                    // navigate them, so we hide them from the a11y tree. They
+                    // remain gridcells for layout/ARIA row-ownership purposes.
+                    return (
+                      <div
+                        key={dateKey}
+                        role="gridcell"
+                        aria-hidden="true"
+                        tabIndex={-1}
+                        {...{ [CELL_DATE_ATTR]: dateKey }}
+                        className="border-border bg-muted min-h-[100px] border-r border-b"
+                      />
+                    );
+                  }
+
                   return (
                     <div
                       key={dateKey}
                       role="gridcell"
-                      aria-hidden="true"
-                      tabIndex={-1}
+                      aria-label={ariaLabel}
                       {...{ [CELL_DATE_ATTR]: dateKey }}
-                      className="border-border bg-muted min-h-[100px] border-r border-b"
-                    />
-                  );
-                }
-
-                return (
-                  <div
-                    key={dateKey}
-                    role="gridcell"
-                    aria-label={ariaLabel}
-                    {...{ [CELL_DATE_ATTR]: dateKey }}
-                    aria-selected={isSelected}
-                    aria-current={isToday ? "date" : undefined}
-                    tabIndex={isSelected ? 0 : -1}
-                    onClick={() => setSelectedDate(date)}
-                    className={`border-border min-h-[100px] cursor-pointer border-r border-b p-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-inset ${
-                      isToday ? "bg-blue-50 dark:bg-blue-950" : "bg-card"
-                    } ${isSelected ? "ring-2 ring-blue-500 ring-inset" : ""}`}
-                  >
-                    <div
-                      className={`mb-1 text-sm ${
-                        isToday
-                          ? "inline-flex h-6 w-6 items-center justify-center rounded-full bg-blue-600 text-white"
-                          : "text-muted-foreground"
-                      }`}
+                      aria-selected={isSelected}
+                      aria-current={isToday ? "date" : undefined}
+                      tabIndex={isSelected ? 0 : -1}
+                      onClick={() => setSelectedDate(date)}
+                      className={`border-border min-h-[100px] cursor-pointer border-r border-b p-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-inset ${
+                        isToday ? "bg-blue-50 dark:bg-blue-950" : "bg-card"
+                      } ${isSelected ? "ring-2 ring-blue-500 ring-inset" : ""}`}
                     >
-                      {format(date, "d")}
-                    </div>
+                      <div
+                        className={`mb-1 text-sm ${
+                          isToday
+                            ? "inline-flex h-6 w-6 items-center justify-center rounded-full bg-blue-600 text-white"
+                            : "text-muted-foreground"
+                        }`}
+                      >
+                        {format(date, "d")}
+                      </div>
 
-                    {/* Events for this day */}
-                    <div className="space-y-1">
-                      {dayEvents.slice(0, maxEventsPerDay).map((event) => (
-                        <div
-                          key={event.id}
-                          className={`rounded px-2 py-1 text-xs ${
-                            event.color === "blue"
-                              ? "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200"
-                              : event.color === "green"
-                                ? "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200"
-                                : event.color === "red"
-                                  ? "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200"
-                                  : event.color === "yellow"
-                                    ? "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200"
-                                    : event.color === "purple"
-                                      ? "bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200"
-                                      : "bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200"
-                          }`}
-                        >
-                          {event.title}
-                        </div>
-                      ))}
-                      {dayEvents.length > maxEventsPerDay && (
-                        <div className="text-muted-foreground text-xs">
-                          +{dayEvents.length - maxEventsPerDay} more
-                        </div>
-                      )}
+                      {/* Events for this day */}
+                      <div className="space-y-1">
+                        {dayEvents.slice(0, maxEventsPerDay).map((event) => (
+                          <div
+                            key={event.id}
+                            className={`rounded px-2 py-1 text-xs ${
+                              event.color === "blue"
+                                ? "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200"
+                                : event.color === "green"
+                                  ? "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200"
+                                  : event.color === "red"
+                                    ? "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200"
+                                    : event.color === "yellow"
+                                      ? "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200"
+                                      : event.color === "purple"
+                                        ? "bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200"
+                                        : "bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200"
+                            }`}
+                          >
+                            {event.title}
+                          </div>
+                        ))}
+                        {dayEvents.length > maxEventsPerDay && (
+                          <div className="text-muted-foreground text-xs">
+                            +{dayEvents.length - maxEventsPerDay} more
+                          </div>
+                        )}
+                      </div>
                     </div>
-                  </div>
-                );
-              })}
-            </div>
-          ))}
-        </div>
+                  );
+                })}
+              </div>
+            ))}
+          </div>
+        </AnimatedSwap>
       </div>
     </div>
   );

--- a/src/components/calendar/SimpleCalendar.tsx
+++ b/src/components/calendar/SimpleCalendar.tsx
@@ -12,6 +12,7 @@ import {
   type KeyboardEvent as ReactKeyboardEvent,
   useEffect,
   useRef,
+  useState,
 } from "react";
 import {
   eachDayOfInterval,
@@ -89,15 +90,20 @@ export function SimpleCalendar() {
 
   // Track the previously rendered month so we can derive slide direction
   // automatically as the user navigates (next/prev buttons, today, keyboard,
-  // mini-calendar). A ref avoids an extra render and lets React Compiler
-  // handle memoization without manual useMemo/useCallback.
+  // mini-calendar). Uses the React-recommended "setState during render" pattern
+  // (same as AnimatedSwap) so the direction is settled in a single pass; React
+  // Compiler handles memoization automatically — no useMemo/useCallback needed.
   const currentMonthIndex = absoluteMonthIndex(monthStart);
-  const previousMonthIndexRef = useRef(currentMonthIndex);
-  const slideDirection: "forward" | "backward" =
-    currentMonthIndex < previousMonthIndexRef.current ? "backward" : "forward";
-  useEffect(() => {
-    previousMonthIndexRef.current = currentMonthIndex;
-  }, [currentMonthIndex]);
+  const [prevMonthIndex, setPrevMonthIndex] = useState(currentMonthIndex);
+  const [slideDirection, setSlideDirection] = useState<"forward" | "backward">(
+    "forward"
+  );
+  if (prevMonthIndex !== currentMonthIndex) {
+    setSlideDirection(
+      currentMonthIndex < prevMonthIndex ? "backward" : "forward"
+    );
+    setPrevMonthIndex(currentMonthIndex);
+  }
 
   const previousMonth = () => {
     const newDate = new Date(selectedDate);

--- a/src/components/calendar/__tests__/SimpleCalendar.test.tsx
+++ b/src/components/calendar/__tests__/SimpleCalendar.test.tsx
@@ -770,4 +770,78 @@ describe("SimpleCalendar", () => {
       );
     });
   });
+
+  describe("Month navigation slide direction", () => {
+    it("slides the outgoing grid left (translateX(-100%)) on Next month", async () => {
+      const user = userEvent.setup();
+      const initialDate = new Date(2026, 3, 15); // April 2026
+
+      const { rerender, contextValue } = renderWithContext({
+        selectedDate: initialDate,
+      });
+
+      // Click Next; the parent provider then commits the new selectedDate
+      // and the AnimatedSwap derives slide direction from the month delta.
+      await user.click(screen.getByTestId("calendar-next-month"));
+
+      // Simulate the provider committing the new selectedDate.
+      rerender(
+        <CalendarContext.Provider
+          value={{ ...contextValue, selectedDate: new Date(2026, 4, 15) }}
+        >
+          <SimpleCalendar />
+        </CalendarContext.Provider>
+      );
+
+      const outgoing = screen.getByTestId("animated-swap-outgoing");
+      expect(outgoing.style.transform).toBe("translateX(-100%)");
+    });
+
+    it("slides the outgoing grid right (translateX(100%)) on Previous month", async () => {
+      const user = userEvent.setup();
+      const initialDate = new Date(2026, 3, 15); // April 2026
+
+      const { rerender, contextValue } = renderWithContext({
+        selectedDate: initialDate,
+      });
+
+      await user.click(screen.getByTestId("calendar-prev-month"));
+
+      rerender(
+        <CalendarContext.Provider
+          value={{ ...contextValue, selectedDate: new Date(2026, 2, 15) }}
+        >
+          <SimpleCalendar />
+        </CalendarContext.Provider>
+      );
+
+      const outgoing = screen.getByTestId("animated-swap-outgoing");
+      expect(outgoing.style.transform).toBe("translateX(100%)");
+    });
+
+    it("keeps the role='grid' element stable across month changes (no remount)", async () => {
+      const user = userEvent.setup();
+      const initialDate = new Date(2026, 3, 15);
+
+      const { rerender, contextValue } = renderWithContext({
+        selectedDate: initialDate,
+      });
+
+      const gridBefore = screen.getByRole("grid", { name: /April 2026/ });
+
+      await user.click(screen.getByTestId("calendar-next-month"));
+      rerender(
+        <CalendarContext.Provider
+          value={{ ...contextValue, selectedDate: new Date(2026, 4, 15) }}
+        >
+          <SimpleCalendar />
+        </CalendarContext.Provider>
+      );
+
+      // The grid root stays mounted (same DOM node) so screen readers
+      // retain context — only the inner day-cells rowgroup is animated.
+      const gridAfter = screen.getByRole("grid", { name: /May 2026/ });
+      expect(gridAfter).toBe(gridBefore);
+    });
+  });
 });

--- a/src/components/calendar/__tests__/animated-swap.test.tsx
+++ b/src/components/calendar/__tests__/animated-swap.test.tsx
@@ -1,0 +1,354 @@
+/**
+ * Tests for AnimatedSwap component.
+ *
+ * Covers transition lifecycle (idle → exiting → entering → idle),
+ * fade vs slide animation modes, directional slides, reduced-motion
+ * bypass, and zero-duration bypass. Mirrors the test style used by
+ * src/components/scheduler/__tests__/screen-transition.test.tsx.
+ */
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AnimatedSwap } from "../animated-swap";
+
+const mockMatchMedia = vi.fn().mockImplementation((query: string) => ({
+  matches: false,
+  media: query,
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+  addListener: vi.fn(),
+  removeListener: vi.fn(),
+  dispatchEvent: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  window.matchMedia = mockMatchMedia;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  mockMatchMedia.mockClear();
+});
+
+describe("AnimatedSwap", () => {
+  describe("idle state", () => {
+    it("renders the child in idle state on initial mount", () => {
+      render(
+        <AnimatedSwap
+          swapKey="a"
+          type="fade"
+          direction="forward"
+          durationMs={300}
+        >
+          <div data-testid="content-a">Content A</div>
+        </AnimatedSwap>
+      );
+
+      expect(screen.getByTestId("content-a")).toBeInTheDocument();
+      expect(screen.getByTestId("animated-swap-idle")).toBeInTheDocument();
+    });
+
+    it("wraps the child in a container with data-testid", () => {
+      render(
+        <AnimatedSwap
+          swapKey="a"
+          type="fade"
+          direction="forward"
+          durationMs={300}
+        >
+          <div>Content</div>
+        </AnimatedSwap>
+      );
+
+      expect(screen.getByTestId("animated-swap")).toBeInTheDocument();
+    });
+  });
+
+  describe("transition lifecycle", () => {
+    it("enters exiting phase when swapKey changes", () => {
+      const { rerender } = render(
+        <AnimatedSwap
+          swapKey="a"
+          type="fade"
+          direction="forward"
+          durationMs={300}
+        >
+          <div>A</div>
+        </AnimatedSwap>
+      );
+
+      rerender(
+        <AnimatedSwap
+          swapKey="b"
+          type="fade"
+          direction="forward"
+          durationMs={300}
+        >
+          <div>B</div>
+        </AnimatedSwap>
+      );
+
+      expect(screen.getByTestId("animated-swap-outgoing")).toBeInTheDocument();
+      expect(screen.getByTestId("animated-swap-incoming")).toBeInTheDocument();
+    });
+
+    it("transitions from exiting to entering after duration", () => {
+      const { rerender } = render(
+        <AnimatedSwap
+          swapKey="a"
+          type="fade"
+          direction="forward"
+          durationMs={300}
+        >
+          <div>A</div>
+        </AnimatedSwap>
+      );
+
+      rerender(
+        <AnimatedSwap
+          swapKey="b"
+          type="fade"
+          direction="forward"
+          durationMs={300}
+        >
+          <div>B</div>
+        </AnimatedSwap>
+      );
+
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+
+      expect(
+        screen.queryByTestId("animated-swap-outgoing")
+      ).not.toBeInTheDocument();
+      expect(screen.getByTestId("animated-swap-entering")).toBeInTheDocument();
+    });
+
+    it("returns to idle state after full transition", () => {
+      const { rerender } = render(
+        <AnimatedSwap
+          swapKey="a"
+          type="fade"
+          direction="forward"
+          durationMs={300}
+        >
+          <div>A</div>
+        </AnimatedSwap>
+      );
+
+      rerender(
+        <AnimatedSwap
+          swapKey="b"
+          type="fade"
+          direction="forward"
+          durationMs={300}
+        >
+          <div>B</div>
+        </AnimatedSwap>
+      );
+
+      // Exit phase
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+      // Enter phase
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+
+      expect(screen.getByTestId("animated-swap-idle")).toBeInTheDocument();
+    });
+  });
+
+  describe("fade transitions", () => {
+    it("animates outgoing opacity to 0 with no horizontal translation", () => {
+      const { rerender } = render(
+        <AnimatedSwap
+          swapKey="a"
+          type="fade"
+          direction="forward"
+          durationMs={300}
+        >
+          <div>A</div>
+        </AnimatedSwap>
+      );
+
+      rerender(
+        <AnimatedSwap
+          swapKey="b"
+          type="fade"
+          direction="forward"
+          durationMs={300}
+        >
+          <div>B</div>
+        </AnimatedSwap>
+      );
+
+      const outgoing = screen.getByTestId("animated-swap-outgoing");
+      expect(outgoing.style.opacity).toBe("0");
+      expect(outgoing.style.transform).toBe("translateX(0)");
+    });
+  });
+
+  describe("slide transitions", () => {
+    it("translates outgoing left for forward direction", () => {
+      const { rerender } = render(
+        <AnimatedSwap
+          swapKey="a"
+          type="slide"
+          direction="forward"
+          durationMs={300}
+        >
+          <div>A</div>
+        </AnimatedSwap>
+      );
+
+      rerender(
+        <AnimatedSwap
+          swapKey="b"
+          type="slide"
+          direction="forward"
+          durationMs={300}
+        >
+          <div>B</div>
+        </AnimatedSwap>
+      );
+
+      const outgoing = screen.getByTestId("animated-swap-outgoing");
+      expect(outgoing.style.transform).toBe("translateX(-100%)");
+      expect(outgoing.style.opacity).toBe("1");
+    });
+
+    it("translates outgoing right for backward direction", () => {
+      const { rerender } = render(
+        <AnimatedSwap
+          swapKey="a"
+          type="slide"
+          direction="backward"
+          durationMs={300}
+        >
+          <div>A</div>
+        </AnimatedSwap>
+      );
+
+      rerender(
+        <AnimatedSwap
+          swapKey="b"
+          type="slide"
+          direction="backward"
+          durationMs={300}
+        >
+          <div>B</div>
+        </AnimatedSwap>
+      );
+
+      const outgoing = screen.getByTestId("animated-swap-outgoing");
+      expect(outgoing.style.transform).toBe("translateX(100%)");
+    });
+  });
+
+  describe("reduced motion", () => {
+    it("skips animation and swaps instantly when prefers-reduced-motion is set", () => {
+      window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+        matches: query === "(prefers-reduced-motion: reduce)",
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }));
+
+      const { rerender } = render(
+        <AnimatedSwap
+          swapKey="a"
+          type="slide"
+          direction="forward"
+          durationMs={300}
+        >
+          <div data-testid="a">A</div>
+        </AnimatedSwap>
+      );
+
+      rerender(
+        <AnimatedSwap
+          swapKey="b"
+          type="slide"
+          direction="forward"
+          durationMs={300}
+        >
+          <div data-testid="b">B</div>
+        </AnimatedSwap>
+      );
+
+      expect(
+        screen.queryByTestId("animated-swap-outgoing")
+      ).not.toBeInTheDocument();
+      expect(screen.getByTestId("b")).toBeInTheDocument();
+    });
+  });
+
+  describe("zero duration bypass", () => {
+    it("swaps instantly when durationMs is 0", () => {
+      const { rerender } = render(
+        <AnimatedSwap
+          swapKey="a"
+          type="slide"
+          direction="forward"
+          durationMs={0}
+        >
+          <div data-testid="a">A</div>
+        </AnimatedSwap>
+      );
+
+      rerender(
+        <AnimatedSwap
+          swapKey="b"
+          type="slide"
+          direction="forward"
+          durationMs={0}
+        >
+          <div data-testid="b">B</div>
+        </AnimatedSwap>
+      );
+
+      expect(screen.getByTestId("b")).toBeInTheDocument();
+      expect(
+        screen.queryByTestId("animated-swap-outgoing")
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("same swapKey", () => {
+    it("re-renders children in place without triggering a transition", () => {
+      const { rerender } = render(
+        <AnimatedSwap
+          swapKey="a"
+          type="fade"
+          direction="forward"
+          durationMs={300}
+        >
+          <div data-testid="v1">V1</div>
+        </AnimatedSwap>
+      );
+
+      rerender(
+        <AnimatedSwap
+          swapKey="a"
+          type="fade"
+          direction="forward"
+          durationMs={300}
+        >
+          <div data-testid="v2">V2</div>
+        </AnimatedSwap>
+      );
+
+      expect(screen.getByTestId("v2")).toBeInTheDocument();
+      expect(screen.getByTestId("animated-swap-idle")).toBeInTheDocument();
+      expect(
+        screen.queryByTestId("animated-swap-outgoing")
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/calendar/__tests__/animated-swap.test.tsx
+++ b/src/components/calendar/__tests__/animated-swap.test.tsx
@@ -1,10 +1,9 @@
 /**
  * Tests for AnimatedSwap component.
  *
- * Covers transition lifecycle (idle → exiting → entering → idle),
- * fade vs slide animation modes, directional slides, reduced-motion
- * bypass, and zero-duration bypass. Mirrors the test style used by
- * src/components/scheduler/__tests__/screen-transition.test.tsx.
+ * Covers transition lifecycle, fade vs slide modes, directional slides,
+ * reduced-motion bypass, zero-duration bypass, layout preservation,
+ * timer behavior under rapid swaps, and same-key re-render.
  */
 import { act, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -64,8 +63,8 @@ describe("AnimatedSwap", () => {
     });
   });
 
-  describe("transition lifecycle", () => {
-    it("enters exiting phase when swapKey changes", () => {
+  describe("animating phase", () => {
+    it("renders both outgoing snapshot and incoming child while animating", () => {
       const { rerender } = render(
         <AnimatedSwap
           swapKey="a"
@@ -90,9 +89,12 @@ describe("AnimatedSwap", () => {
 
       expect(screen.getByTestId("animated-swap-outgoing")).toBeInTheDocument();
       expect(screen.getByTestId("animated-swap-incoming")).toBeInTheDocument();
+      expect(
+        screen.queryByTestId("animated-swap-idle")
+      ).not.toBeInTheDocument();
     });
 
-    it("transitions from exiting to entering after duration", () => {
+    it("returns to idle after duration, dropping the outgoing snapshot", () => {
       const { rerender } = render(
         <AnimatedSwap
           swapKey="a"
@@ -122,14 +124,14 @@ describe("AnimatedSwap", () => {
       expect(
         screen.queryByTestId("animated-swap-outgoing")
       ).not.toBeInTheDocument();
-      expect(screen.getByTestId("animated-swap-entering")).toBeInTheDocument();
+      expect(screen.getByTestId("animated-swap-idle")).toBeInTheDocument();
     });
 
-    it("returns to idle state after full transition", () => {
+    it("keeps the incoming child in normal flow so the container preserves its height", () => {
       const { rerender } = render(
         <AnimatedSwap
           swapKey="a"
-          type="fade"
+          type="slide"
           direction="forward"
           durationMs={300}
         >
@@ -140,7 +142,7 @@ describe("AnimatedSwap", () => {
       rerender(
         <AnimatedSwap
           swapKey="b"
-          type="fade"
+          type="slide"
           direction="forward"
           durationMs={300}
         >
@@ -148,21 +150,16 @@ describe("AnimatedSwap", () => {
         </AnimatedSwap>
       );
 
-      // Exit phase
-      act(() => {
-        vi.advanceTimersByTime(300);
-      });
-      // Enter phase
-      act(() => {
-        vi.advanceTimersByTime(300);
-      });
-
-      expect(screen.getByTestId("animated-swap-idle")).toBeInTheDocument();
+      const incoming = screen.getByTestId("animated-swap-incoming");
+      const outgoing = screen.getByTestId("animated-swap-outgoing");
+      // Outgoing is absolute (does not contribute to layout); incoming is in-flow.
+      expect(outgoing.className).toContain("absolute");
+      expect(incoming.className).not.toContain("absolute");
     });
   });
 
   describe("fade transitions", () => {
-    it("animates outgoing opacity to 0 with no horizontal translation", () => {
+    it("targets opacity 0 on the outgoing element with no horizontal translation", () => {
       const { rerender } = render(
         <AnimatedSwap
           swapKey="a"
@@ -246,6 +243,33 @@ describe("AnimatedSwap", () => {
       const outgoing = screen.getByTestId("animated-swap-outgoing");
       expect(outgoing.style.transform).toBe("translateX(100%)");
     });
+
+    it("animates the incoming child via a keyframe (so it doesn't snap to position)", () => {
+      const { rerender } = render(
+        <AnimatedSwap
+          swapKey="a"
+          type="slide"
+          direction="forward"
+          durationMs={300}
+        >
+          <div>A</div>
+        </AnimatedSwap>
+      );
+
+      rerender(
+        <AnimatedSwap
+          swapKey="b"
+          type="slide"
+          direction="forward"
+          durationMs={300}
+        >
+          <div>B</div>
+        </AnimatedSwap>
+      );
+
+      const incoming = screen.getByTestId("animated-swap-incoming");
+      expect(incoming.style.animation).toMatch(/animated-swap-enter-/);
+    });
   });
 
   describe("reduced motion", () => {
@@ -317,6 +341,128 @@ describe("AnimatedSwap", () => {
       expect(
         screen.queryByTestId("animated-swap-outgoing")
       ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("rapid swaps", () => {
+    it("resets the timer on every swap so a second mid-flight swap completes the full new duration", () => {
+      const { rerender } = render(
+        <AnimatedSwap
+          swapKey="a"
+          type="fade"
+          direction="forward"
+          durationMs={300}
+        >
+          <div>A</div>
+        </AnimatedSwap>
+      );
+
+      rerender(
+        <AnimatedSwap
+          swapKey="b"
+          type="fade"
+          direction="forward"
+          durationMs={300}
+        >
+          <div>B</div>
+        </AnimatedSwap>
+      );
+
+      // Advance halfway through the first transition.
+      act(() => {
+        vi.advanceTimersByTime(150);
+      });
+      expect(screen.getByTestId("animated-swap-outgoing")).toBeInTheDocument();
+
+      // Trigger a second swap mid-flight.
+      rerender(
+        <AnimatedSwap
+          swapKey="c"
+          type="fade"
+          direction="forward"
+          durationMs={300}
+        >
+          <div data-testid="c">C</div>
+        </AnimatedSwap>
+      );
+
+      // Advance through the remaining half of the original duration.
+      act(() => {
+        vi.advanceTimersByTime(150);
+      });
+      // First timer must have been cleared; we should still be animating.
+      expect(screen.getByTestId("animated-swap-outgoing")).toBeInTheDocument();
+
+      // Advance the rest of the new duration.
+      act(() => {
+        vi.advanceTimersByTime(150);
+      });
+      expect(
+        screen.queryByTestId("animated-swap-outgoing")
+      ).not.toBeInTheDocument();
+      expect(screen.getByTestId("c")).toBeInTheDocument();
+    });
+  });
+
+  describe("reduced motion mid-animation", () => {
+    it("collapses to idle and clears pending timers when reduced-motion turns on mid-animation", () => {
+      // First mount with reduced-motion off.
+      let mqlListeners: ((e: MediaQueryListEvent) => void)[] = [];
+      window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        addEventListener: (
+          _evt: string,
+          handler: (e: MediaQueryListEvent) => void
+        ) => {
+          mqlListeners.push(handler);
+        },
+        removeEventListener: (
+          _evt: string,
+          handler: (e: MediaQueryListEvent) => void
+        ) => {
+          mqlListeners = mqlListeners.filter((h) => h !== handler);
+        },
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }));
+
+      const { rerender } = render(
+        <AnimatedSwap
+          swapKey="a"
+          type="fade"
+          direction="forward"
+          durationMs={300}
+        >
+          <div>A</div>
+        </AnimatedSwap>
+      );
+
+      rerender(
+        <AnimatedSwap
+          swapKey="b"
+          type="fade"
+          direction="forward"
+          durationMs={300}
+        >
+          <div data-testid="b">B</div>
+        </AnimatedSwap>
+      );
+
+      expect(screen.getByTestId("animated-swap-outgoing")).toBeInTheDocument();
+
+      // OS-level reduced motion turns on; hook's subscribed listener fires.
+      act(() => {
+        mqlListeners.forEach((h) =>
+          h({ matches: true } as MediaQueryListEvent)
+        );
+      });
+
+      expect(
+        screen.queryByTestId("animated-swap-outgoing")
+      ).not.toBeInTheDocument();
+      expect(screen.getByTestId("b")).toBeInTheDocument();
     });
   });
 

--- a/src/components/calendar/__tests__/calendar-view-animation.test.tsx
+++ b/src/components/calendar/__tests__/calendar-view-animation.test.tsx
@@ -49,6 +49,7 @@ function createMockContext(
     refreshEvents: vi.fn(),
     isLoading: false,
     isAuthenticated: true,
+    maxEventsPerDay: 3,
     ...overrides,
   };
 }

--- a/src/components/calendar/__tests__/calendar-view-animation.test.tsx
+++ b/src/components/calendar/__tests__/calendar-view-animation.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * Integration tests for the view-mode fade wiring (#87).
+ *
+ * Verifies that when the calendar's `view` toggles between Month and Agenda,
+ * the AnimatedSwap wrapper renders both view containers simultaneously while
+ * the fade is in flight, then collapses to just the new view after the
+ * duration elapses, and skips animation under prefers-reduced-motion.
+ *
+ * Mirrors the integration the production calendar page wires up — the same
+ * AnimatedSwap call lives in `src/app/calendar/page.tsx` and
+ * `src/app/test/calendar/page.tsx`.
+ */
+import { AnimatedSwap } from "@/components/calendar/animated-swap";
+import {
+  CalendarContext,
+  type ICalendarContext,
+} from "@/components/providers/CalendarProvider";
+import type { IUser, TCalendarView, TEventColor } from "@/types/calendar";
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const VIEW_FADE_DURATION_MS = 250;
+
+function createMockContext(
+  overrides: Partial<ICalendarContext> = {}
+): ICalendarContext {
+  return {
+    selectedDate: new Date(),
+    view: "month" as TCalendarView,
+    setView: vi.fn(),
+    agendaModeGroupBy: "date",
+    setAgendaModeGroupBy: vi.fn(),
+    use24HourFormat: true,
+    toggleTimeFormat: vi.fn(),
+    setSelectedDate: vi.fn(),
+    selectedUserId: "all",
+    setSelectedUserId: vi.fn(),
+    badgeVariant: "colored",
+    setBadgeVariant: vi.fn(),
+    selectedColors: [] as TEventColor[],
+    filterEventsBySelectedColors: vi.fn(),
+    filterEventsBySelectedUser: vi.fn(),
+    users: [] as IUser[],
+    events: [],
+    addEvent: vi.fn(),
+    updateEvent: vi.fn(),
+    removeEvent: vi.fn(),
+    clearFilter: vi.fn(),
+    refreshEvents: vi.fn(),
+    isLoading: false,
+    isAuthenticated: true,
+    ...overrides,
+  };
+}
+
+function CalendarSurface({ view }: { view: TCalendarView }) {
+  return (
+    <AnimatedSwap
+      swapKey={view}
+      type="fade"
+      direction="forward"
+      durationMs={VIEW_FADE_DURATION_MS}
+    >
+      {view === "month" ? (
+        <div data-testid="month-surface">Month surface</div>
+      ) : (
+        <div data-testid="agenda-surface">Agenda surface</div>
+      )}
+    </AnimatedSwap>
+  );
+}
+
+function renderCalendarSurface(view: TCalendarView) {
+  const context = createMockContext({ view });
+  return render(
+    <CalendarContext.Provider value={context}>
+      <CalendarSurface view={view} />
+    </CalendarContext.Provider>
+  );
+}
+
+const mockMatchMedia = vi.fn().mockImplementation((query: string) => ({
+  matches: false,
+  media: query,
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+  addListener: vi.fn(),
+  removeListener: vi.fn(),
+  dispatchEvent: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  window.matchMedia = mockMatchMedia;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  mockMatchMedia.mockClear();
+});
+
+describe("Calendar view-mode animation (integration)", () => {
+  it("renders both Month and Agenda surfaces simultaneously while the fade is in flight", () => {
+    const { rerender } = renderCalendarSurface("month");
+    expect(screen.getByTestId("month-surface")).toBeInTheDocument();
+    expect(screen.queryByTestId("agenda-surface")).not.toBeInTheDocument();
+
+    rerender(
+      <CalendarContext.Provider value={createMockContext({ view: "agenda" })}>
+        <CalendarSurface view="agenda" />
+      </CalendarContext.Provider>
+    );
+
+    // The animation snapshot keeps the Month surface alive while Agenda
+    // fades in. Both must be in the DOM mid-transition.
+    expect(screen.getByTestId("month-surface")).toBeInTheDocument();
+    expect(screen.getByTestId("agenda-surface")).toBeInTheDocument();
+  });
+
+  it("settles to only the Agenda surface after the fade completes", () => {
+    const { rerender } = renderCalendarSurface("month");
+
+    rerender(
+      <CalendarContext.Provider value={createMockContext({ view: "agenda" })}>
+        <CalendarSurface view="agenda" />
+      </CalendarContext.Provider>
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(VIEW_FADE_DURATION_MS);
+    });
+
+    expect(screen.queryByTestId("month-surface")).not.toBeInTheDocument();
+    expect(screen.getByTestId("agenda-surface")).toBeInTheDocument();
+  });
+
+  it("swaps instantly under prefers-reduced-motion (no simultaneous render)", () => {
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: query === "(prefers-reduced-motion: reduce)",
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+
+    const { rerender } = renderCalendarSurface("month");
+
+    rerender(
+      <CalendarContext.Provider value={createMockContext({ view: "agenda" })}>
+        <CalendarSurface view="agenda" />
+      </CalendarContext.Provider>
+    );
+
+    expect(screen.queryByTestId("month-surface")).not.toBeInTheDocument();
+    expect(screen.getByTestId("agenda-surface")).toBeInTheDocument();
+  });
+});

--- a/src/components/calendar/animated-swap.tsx
+++ b/src/components/calendar/animated-swap.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { useReducedMotion } from "@/hooks/use-reduced-motion";
+import { useEffect, useState } from "react";
+
+export type AnimatedSwapType = "fade" | "slide";
+export type AnimatedSwapDirection = "forward" | "backward";
+
+interface AnimatedSwapProps {
+  /** Key whose change triggers the swap animation. */
+  swapKey: string;
+  /** Animation style to use. */
+  type: AnimatedSwapType;
+  /** Slide direction (no effect for `type="fade"`). */
+  direction: AnimatedSwapDirection;
+  /** Animation duration per phase in milliseconds. <=0 disables animation. */
+  durationMs: number;
+  /** Content to render. */
+  children: React.ReactNode;
+}
+
+type SwapPhase = "idle" | "exiting" | "entering";
+
+function exitTransform(
+  type: AnimatedSwapType,
+  direction: AnimatedSwapDirection
+): string {
+  if (type === "slide") {
+    return direction === "forward" ? "translateX(-100%)" : "translateX(100%)";
+  }
+  return "translateX(0)";
+}
+
+function enterStartTransform(
+  type: AnimatedSwapType,
+  direction: AnimatedSwapDirection
+): string {
+  if (type === "slide") {
+    return direction === "forward" ? "translateX(100%)" : "translateX(-100%)";
+  }
+  return "translateX(0)";
+}
+
+function exitOpacity(type: AnimatedSwapType): number {
+  return type === "fade" ? 0 : 1;
+}
+
+function enterStartOpacity(type: AnimatedSwapType): number {
+  return type === "fade" ? 0 : 1;
+}
+
+/**
+ * Generic single-child swap animator. When `swapKey` changes, animates the
+ * outgoing child out and the incoming child in using GPU-composited CSS
+ * transforms / opacity. Mirrors the lifecycle pattern used by
+ * `ScreenTransition` but is decoupled from router semantics so it can be
+ * reused for in-page swaps (e.g. calendar view-mode and period changes).
+ *
+ * - `prefers-reduced-motion: reduce` → swaps instantly.
+ * - `durationMs <= 0` → swaps instantly.
+ * - Same `swapKey` re-render → updates children in place, no animation.
+ */
+export function AnimatedSwap({
+  swapKey,
+  type,
+  direction,
+  durationMs,
+  children,
+}: AnimatedSwapProps) {
+  const reducedMotion = useReducedMotion();
+  const skipAnimation = reducedMotion || durationMs <= 0;
+
+  const [phase, setPhase] = useState<SwapPhase>("idle");
+  const [displayedChildren, setDisplayedChildren] =
+    useState<React.ReactNode>(children);
+  const [snapshotChildren, setSnapshotChildren] =
+    useState<React.ReactNode>(null);
+  const [prevSwapKey, setPrevSwapKey] = useState(swapKey);
+
+  // React-recommended "setState during render" pattern to derive state from
+  // changing props without an effect-driven cascade.
+  if (swapKey !== prevSwapKey) {
+    setPrevSwapKey(swapKey);
+
+    if (skipAnimation) {
+      setDisplayedChildren(children);
+      setSnapshotChildren(null);
+      setPhase("idle");
+    } else {
+      setSnapshotChildren(displayedChildren);
+      setDisplayedChildren(children);
+      setPhase("exiting");
+    }
+  } else if (phase === "idle" && displayedChildren !== children) {
+    setDisplayedChildren(children);
+  }
+
+  useEffect(() => {
+    if (phase !== "exiting") return;
+    const timer = setTimeout(() => setPhase("entering"), durationMs);
+    return () => clearTimeout(timer);
+  }, [phase, durationMs]);
+
+  useEffect(() => {
+    if (phase !== "entering") return;
+    const timer = setTimeout(() => {
+      setSnapshotChildren(null);
+      setPhase("idle");
+    }, durationMs);
+    return () => clearTimeout(timer);
+  }, [phase, durationMs]);
+
+  if (skipAnimation) {
+    return <div data-testid="animated-swap">{children}</div>;
+  }
+
+  const durationStyle = `${durationMs}ms`;
+  const transitionStyle = `transform ${durationStyle} ease-in-out, opacity ${durationStyle} ease-in-out`;
+
+  return (
+    <div data-testid="animated-swap" className="relative overflow-hidden">
+      {phase === "exiting" && snapshotChildren && (
+        <div
+          data-testid="animated-swap-outgoing"
+          className="absolute inset-0"
+          style={{
+            transform: exitTransform(type, direction),
+            opacity: exitOpacity(type),
+            transition: transitionStyle,
+            willChange: "transform, opacity",
+          }}
+        >
+          {snapshotChildren}
+        </div>
+      )}
+
+      {phase === "exiting" && (
+        <div
+          data-testid="animated-swap-incoming"
+          className="absolute inset-0"
+          style={{
+            transform: "translateX(0)",
+            opacity: 1,
+            transition: transitionStyle,
+            willChange: "transform, opacity",
+          }}
+        >
+          {displayedChildren}
+        </div>
+      )}
+
+      {phase === "entering" && (
+        <div
+          data-testid="animated-swap-entering"
+          style={{
+            animation: `animated-swap-enter ${durationStyle} ease-in-out`,
+            willChange: "transform, opacity",
+          }}
+        >
+          {displayedChildren}
+        </div>
+      )}
+
+      {phase === "idle" && (
+        <div data-testid="animated-swap-idle">{displayedChildren}</div>
+      )}
+
+      {phase === "entering" && (
+        <style>{`
+          @keyframes animated-swap-enter {
+            from {
+              transform: ${enterStartTransform(type, direction)};
+              opacity: ${enterStartOpacity(type)};
+            }
+            to {
+              transform: translateX(0);
+              opacity: 1;
+            }
+          }
+        `}</style>
+      )}
+    </div>
+  );
+}

--- a/src/components/calendar/animated-swap.tsx
+++ b/src/components/calendar/animated-swap.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useReducedMotion } from "@/hooks/use-reduced-motion";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 export type AnimatedSwapType = "fade" | "slide";
 export type AnimatedSwapDirection = "forward" | "backward";
@@ -13,52 +13,51 @@ interface AnimatedSwapProps {
   type: AnimatedSwapType;
   /** Slide direction (no effect for `type="fade"`). */
   direction: AnimatedSwapDirection;
-  /** Animation duration per phase in milliseconds. <=0 disables animation. */
+  /** Animation duration in milliseconds. <=0 disables animation. */
   durationMs: number;
   /** Content to render. */
   children: React.ReactNode;
 }
 
-type SwapPhase = "idle" | "exiting" | "entering";
+type SwapPhase = "idle" | "animating";
 
-function exitTransform(
+interface AnimationGeometry {
+  exitTo: { transform: string; opacity: number };
+  enterFrom: { transform: string; opacity: number };
+}
+
+function getAnimationGeometry(
   type: AnimatedSwapType,
   direction: AnimatedSwapDirection
-): string {
+): AnimationGeometry {
   if (type === "slide") {
-    return direction === "forward" ? "translateX(-100%)" : "translateX(100%)";
+    const exitX = direction === "forward" ? "-100%" : "100%";
+    const enterX = direction === "forward" ? "100%" : "-100%";
+    return {
+      exitTo: { transform: `translateX(${exitX})`, opacity: 1 },
+      enterFrom: { transform: `translateX(${enterX})`, opacity: 1 },
+    };
   }
-  return "translateX(0)";
-}
-
-function enterStartTransform(
-  type: AnimatedSwapType,
-  direction: AnimatedSwapDirection
-): string {
-  if (type === "slide") {
-    return direction === "forward" ? "translateX(100%)" : "translateX(-100%)";
-  }
-  return "translateX(0)";
-}
-
-function exitOpacity(type: AnimatedSwapType): number {
-  return type === "fade" ? 0 : 1;
-}
-
-function enterStartOpacity(type: AnimatedSwapType): number {
-  return type === "fade" ? 0 : 1;
+  // fade
+  return {
+    exitTo: { transform: "translateX(0)", opacity: 0 },
+    enterFrom: { transform: "translateX(0)", opacity: 0 },
+  };
 }
 
 /**
  * Generic single-child swap animator. When `swapKey` changes, animates the
- * outgoing child out and the incoming child in using GPU-composited CSS
- * transforms / opacity. Mirrors the lifecycle pattern used by
- * `ScreenTransition` but is decoupled from router semantics so it can be
- * reused for in-page swaps (e.g. calendar view-mode and period changes).
+ * outgoing child out and the incoming child in simultaneously via CSS
+ * keyframe animations (GPU-composited transform/opacity). The incoming
+ * child stays in normal flow so the container preserves its natural height
+ * during the transition; the outgoing child is positioned absolutely so it
+ * does not push layout.
  *
  * - `prefers-reduced-motion: reduce` → swaps instantly.
  * - `durationMs <= 0` → swaps instantly.
  * - Same `swapKey` re-render → updates children in place, no animation.
+ * - Rapid `swapKey` changes mid-animation → previous animation is cancelled
+ *   and the latest swap takes over from the previous outgoing snapshot.
  */
 export function AnimatedSwap({
   swapKey,
@@ -75,7 +74,13 @@ export function AnimatedSwap({
     useState<React.ReactNode>(children);
   const [snapshotChildren, setSnapshotChildren] =
     useState<React.ReactNode>(null);
+  const [activeGeometry, setActiveGeometry] = useState<AnimationGeometry>(() =>
+    getAnimationGeometry(type, direction)
+  );
+  const [animationId, setAnimationId] = useState(0);
   const [prevSwapKey, setPrevSwapKey] = useState(swapKey);
+
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // React-recommended "setState during render" pattern to derive state from
   // changing props without an effect-driven cascade.
@@ -87,46 +92,90 @@ export function AnimatedSwap({
       setSnapshotChildren(null);
       setPhase("idle");
     } else {
+      // Snapshot the previously displayed children as the outgoing content.
+      // If we're already animating, the previous snapshot represents an
+      // earlier-still page; the latest displayed is the better outgoing
+      // baseline because the user perceived it as "current" up to this tap.
       setSnapshotChildren(displayedChildren);
       setDisplayedChildren(children);
-      setPhase("exiting");
+      setActiveGeometry(getAnimationGeometry(type, direction));
+      setPhase("animating");
+      // Bump the animation id so React re-mounts the animated nodes and
+      // restarts the keyframe animations even on consecutive transitions.
+      setAnimationId((n) => n + 1);
     }
   } else if (phase === "idle" && displayedChildren !== children) {
     setDisplayedChildren(children);
+  } else if (skipAnimation && phase !== "idle") {
+    // Reduced-motion flipped on mid-animation — collapse to idle and drop
+    // the outgoing snapshot. The timer-effect's cleanup will clear any
+    // pending timeout when `phase` changes back to idle.
+    setPhase("idle");
+    setSnapshotChildren(null);
   }
 
+  // Single timer driven by animationId so a rapid second swap unconditionally
+  // resets the schedule, regardless of whether `phase` actually changed.
   useEffect(() => {
-    if (phase !== "exiting") return;
-    const timer = setTimeout(() => setPhase("entering"), durationMs);
-    return () => clearTimeout(timer);
-  }, [phase, durationMs]);
-
-  useEffect(() => {
-    if (phase !== "entering") return;
-    const timer = setTimeout(() => {
-      setSnapshotChildren(null);
+    if (phase !== "animating") {
+      return;
+    }
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+    }
+    timerRef.current = setTimeout(() => {
       setPhase("idle");
+      setSnapshotChildren(null);
+      timerRef.current = null;
     }, durationMs);
-    return () => clearTimeout(timer);
-  }, [phase, durationMs]);
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [phase, durationMs, animationId]);
 
   if (skipAnimation) {
     return <div data-testid="animated-swap">{children}</div>;
   }
 
+  if (phase === "idle") {
+    return (
+      <div data-testid="animated-swap" className="relative">
+        <div data-testid="animated-swap-idle">{displayedChildren}</div>
+      </div>
+    );
+  }
+
   const durationStyle = `${durationMs}ms`;
-  const transitionStyle = `transform ${durationStyle} ease-in-out, opacity ${durationStyle} ease-in-out`;
+  const exitKeyframeName = `animated-swap-exit-${animationId}`;
+  const enterKeyframeName = `animated-swap-enter-${animationId}`;
 
   return (
     <div data-testid="animated-swap" className="relative overflow-hidden">
-      {phase === "exiting" && snapshotChildren && (
+      {/* Incoming stays in normal flow so the container keeps its natural height. */}
+      <div
+        key={`incoming-${animationId}`}
+        data-testid="animated-swap-incoming"
+        style={{
+          animation: `${enterKeyframeName} ${durationStyle} ease-in-out forwards`,
+          willChange: "transform, opacity",
+        }}
+      >
+        {displayedChildren}
+      </div>
+
+      {/* Outgoing is absolutely positioned so it does not double the height. */}
+      {snapshotChildren && (
         <div
+          key={`outgoing-${animationId}`}
           data-testid="animated-swap-outgoing"
           className="absolute inset-0"
           style={{
-            transform: exitTransform(type, direction),
-            opacity: exitOpacity(type),
-            transition: transitionStyle,
+            transform: activeGeometry.exitTo.transform,
+            opacity: activeGeometry.exitTo.opacity,
+            animation: `${exitKeyframeName} ${durationStyle} ease-in-out forwards`,
             willChange: "transform, opacity",
           }}
         >
@@ -134,51 +183,28 @@ export function AnimatedSwap({
         </div>
       )}
 
-      {phase === "exiting" && (
-        <div
-          data-testid="animated-swap-incoming"
-          className="absolute inset-0"
-          style={{
-            transform: "translateX(0)",
-            opacity: 1,
-            transition: transitionStyle,
-            willChange: "transform, opacity",
-          }}
-        >
-          {displayedChildren}
-        </div>
-      )}
-
-      {phase === "entering" && (
-        <div
-          data-testid="animated-swap-entering"
-          style={{
-            animation: `animated-swap-enter ${durationStyle} ease-in-out`,
-            willChange: "transform, opacity",
-          }}
-        >
-          {displayedChildren}
-        </div>
-      )}
-
-      {phase === "idle" && (
-        <div data-testid="animated-swap-idle">{displayedChildren}</div>
-      )}
-
-      {phase === "entering" && (
-        <style>{`
-          @keyframes animated-swap-enter {
-            from {
-              transform: ${enterStartTransform(type, direction)};
-              opacity: ${enterStartOpacity(type)};
-            }
-            to {
-              transform: translateX(0);
-              opacity: 1;
-            }
+      <style>{`
+        @keyframes ${exitKeyframeName} {
+          from {
+            transform: translateX(0);
+            opacity: 1;
           }
-        `}</style>
-      )}
+          to {
+            transform: ${activeGeometry.exitTo.transform};
+            opacity: ${activeGeometry.exitTo.opacity};
+          }
+        }
+        @keyframes ${enterKeyframeName} {
+          from {
+            transform: ${activeGeometry.enterFrom.transform};
+            opacity: ${activeGeometry.enterFrom.opacity};
+          }
+          to {
+            transform: translateX(0);
+            opacity: 1;
+          }
+        }
+      `}</style>
     </div>
   );
 }

--- a/src/hooks/__tests__/use-reduced-motion.test.ts
+++ b/src/hooks/__tests__/use-reduced-motion.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Tests for useReducedMotion hook.
+ */
+import { act, renderHook } from "@testing-library/react";
+import {
+  type MockInstance,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { useReducedMotion } from "../use-reduced-motion";
+
+interface MockMediaQueryList {
+  matches: boolean;
+  media: string;
+  addEventListener: ReturnType<typeof vi.fn>;
+  removeEventListener: ReturnType<typeof vi.fn>;
+  addListener: ReturnType<typeof vi.fn>;
+  removeListener: ReturnType<typeof vi.fn>;
+  dispatchEvent: ReturnType<typeof vi.fn>;
+}
+
+function createMockMediaQueryList(matches: boolean): MockMediaQueryList {
+  return {
+    matches,
+    media: "(prefers-reduced-motion: reduce)",
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  };
+}
+
+let originalMatchMedia: typeof window.matchMedia | undefined;
+
+beforeEach(() => {
+  originalMatchMedia = window.matchMedia;
+});
+
+afterEach(() => {
+  if (originalMatchMedia) {
+    window.matchMedia = originalMatchMedia;
+  }
+});
+
+describe("useReducedMotion", () => {
+  it("returns false when the user does not prefer reduced motion", () => {
+    const mql = createMockMediaQueryList(false);
+    window.matchMedia = vi.fn().mockReturnValue(mql);
+
+    const { result } = renderHook(() => useReducedMotion());
+
+    expect(result.current).toBe(false);
+  });
+
+  it("returns true when the user prefers reduced motion", () => {
+    const mql = createMockMediaQueryList(true);
+    window.matchMedia = vi.fn().mockReturnValue(mql);
+
+    const { result } = renderHook(() => useReducedMotion());
+
+    expect(result.current).toBe(true);
+  });
+
+  it("queries the prefers-reduced-motion media feature", () => {
+    const mql = createMockMediaQueryList(false);
+    const matchMediaSpy: MockInstance = vi.fn().mockReturnValue(mql);
+    window.matchMedia = matchMediaSpy as unknown as typeof window.matchMedia;
+
+    renderHook(() => useReducedMotion());
+
+    expect(matchMediaSpy).toHaveBeenCalledWith(
+      "(prefers-reduced-motion: reduce)"
+    );
+  });
+
+  it("subscribes to change events on mount", () => {
+    const mql = createMockMediaQueryList(false);
+    window.matchMedia = vi.fn().mockReturnValue(mql);
+
+    renderHook(() => useReducedMotion());
+
+    expect(mql.addEventListener).toHaveBeenCalledWith(
+      "change",
+      expect.any(Function)
+    );
+  });
+
+  it("unsubscribes on unmount", () => {
+    const mql = createMockMediaQueryList(false);
+    window.matchMedia = vi.fn().mockReturnValue(mql);
+
+    const { unmount } = renderHook(() => useReducedMotion());
+    const handler = mql.addEventListener.mock.calls[0][1];
+
+    unmount();
+
+    expect(mql.removeEventListener).toHaveBeenCalledWith("change", handler);
+  });
+
+  it("updates when the media query changes from false to true", () => {
+    const mql = createMockMediaQueryList(false);
+    window.matchMedia = vi.fn().mockReturnValue(mql);
+
+    const { result } = renderHook(() => useReducedMotion());
+    expect(result.current).toBe(false);
+
+    const handler = mql.addEventListener.mock.calls[0][1];
+    act(() => {
+      handler({ matches: true } as MediaQueryListEvent);
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it("updates when the media query changes from true to false", () => {
+    const mql = createMockMediaQueryList(true);
+    window.matchMedia = vi.fn().mockReturnValue(mql);
+
+    const { result } = renderHook(() => useReducedMotion());
+    expect(result.current).toBe(true);
+
+    const handler = mql.addEventListener.mock.calls[0][1];
+    act(() => {
+      handler({ matches: false } as MediaQueryListEvent);
+    });
+
+    expect(result.current).toBe(false);
+  });
+});

--- a/src/hooks/use-reduced-motion.ts
+++ b/src/hooks/use-reduced-motion.ts
@@ -1,0 +1,47 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const MEDIA_QUERY = "(prefers-reduced-motion: reduce)";
+
+function getInitialPreference(): boolean {
+  if (
+    typeof window === "undefined" ||
+    typeof window.matchMedia !== "function"
+  ) {
+    return false;
+  }
+  return window.matchMedia(MEDIA_QUERY).matches;
+}
+
+/**
+ * Subscribes to the `prefers-reduced-motion` media query and returns the
+ * current preference. SSR-safe — returns `false` outside the browser.
+ *
+ * Live updates: re-renders whenever the OS-level preference changes.
+ */
+export function useReducedMotion(): boolean {
+  const [reduced, setReduced] = useState<boolean>(getInitialPreference);
+
+  useEffect(() => {
+    if (
+      typeof window === "undefined" ||
+      typeof window.matchMedia !== "function"
+    ) {
+      return;
+    }
+
+    const mql = window.matchMedia(MEDIA_QUERY);
+
+    const handler = (event: MediaQueryListEvent) => {
+      setReduced(event.matches);
+    };
+
+    mql.addEventListener("change", handler);
+    return () => {
+      mql.removeEventListener("change", handler);
+    };
+  }, []);
+
+  return reduced;
+}


### PR DESCRIPTION
Closes #87.

## Summary

Adds smooth, GPU-composited animations to the calendar UI:

- **View-mode change** (Month ↔ Agenda) — fades the active calendar surface in/out via `ViewSwitcher`.
- **Period navigation** in Month view — directional slide when clicking prev/next month.
- **`prefers-reduced-motion` respected** — animations skip cleanly for users who opt out.

Built on a small reusable primitive (`AnimatedSwap`) so the same animation engine extends to Day/Week/Year once those views are wired by their respective PRs.

## Phases

1. `useReducedMotion` hook (this commit) — SSR-safe live media-query subscription.
2. `AnimatedSwap` component — generic single-child swap animator (fade or directional slide).
3. Wire into `src/app/calendar/page.tsx` (view-change fade) and `src/components/calendar/SimpleCalendar.tsx` (month-navigation slide).
4. Playwright E2E with `video: "on"` covering the animation paths and the reduced-motion bypass.

## Plan

`.claude/plans/view-transition-animations.md`

## Out of scope (deferred)

- Animations for Day / Week / Year views — those views are not yet exposed via `ViewSwitcher` (tracked in PRs #149, #145).
- Panel expand/collapse animations — no calendar-page panel toggles exist today.
- User-configurable animation duration — currently constants; can later be exposed via the settings panel (#86).

## Test plan

- [ ] Vitest: `useReducedMotion` (subscribes, live-updates, unsubscribes, SSR-safe)
- [ ] Vitest: `AnimatedSwap` lifecycle (idle → exiting → entering → idle, fade vs slide, reduced-motion skip)
- [ ] Vitest: Calendar wiring (view fade, slide direction)
- [ ] Playwright (Chromium, video on): Month ↔ Agenda fade, prev/next month slide direction, reduced-motion bypass

🤖 Generated with [Claude Code](https://claude.com/claude-code)