### PR TITLE
feat(google-calendar): extend API types and add pure mappers (#76, #77)

### DIFF
--- a/src/app/api/calendar/calendars/route.ts
+++ b/src/app/api/calendar/calendars/route.ts
@@ -28,19 +28,6 @@ export interface CalendarsResponse {
   calendars: CalendarInfo[];
 }
 
-/**
- * Raw Google Calendar API calendarList item
- */
-interface GoogleCalendarListItem {
-  id: string;
-  summary: string;
-  description?: string;
-  backgroundColor?: string;
-  foregroundColor?: string;
-  primary?: boolean;
-  selected?: boolean;
-}
-
 export async function GET() {
   try {
     // Check authentication
@@ -100,7 +87,7 @@ export async function GET() {
     }
 
     const data = await response.json();
-    const items: GoogleCalendarListItem[] = data.items || [];
+    const items: gapi.client.calendar.CalendarListEntry[] = data.items || [];
 
     // Transform to our CalendarInfo format
     const calendars: CalendarInfo[] = items.map((item) => ({

--- a/src/app/api/calendar/calendars/route.ts
+++ b/src/app/api/calendar/calendars/route.ts
@@ -89,10 +89,12 @@ export async function GET() {
     const data = await response.json();
     const items: gapi.client.calendar.CalendarListEntry[] = data.items || [];
 
-    // Transform to our CalendarInfo format
+    // Transform to our CalendarInfo format. `summary` is optional per the
+    // Google schema — fall back to empty string so downstream UI code can
+    // treat it as a plain string.
     const calendars: CalendarInfo[] = items.map((item) => ({
       id: item.id,
-      summary: item.summary,
+      summary: item.summary ?? "",
       description: item.description,
       backgroundColor: item.backgroundColor || "#4285f4", // Default Google blue
       foregroundColor: item.foregroundColor || "#ffffff",

--- a/src/app/api/calendar/colors/route.ts
+++ b/src/app/api/calendar/colors/route.ts
@@ -26,14 +26,6 @@ export interface ColorsResponse {
   colorMappings: CalendarColorMapping[];
 }
 
-/**
- * Raw Google Calendar API calendarList item (subset of fields we need)
- */
-interface GoogleCalendarListItem {
-  id: string;
-  backgroundColor?: string;
-}
-
 export async function GET() {
   try {
     // Check authentication
@@ -93,7 +85,7 @@ export async function GET() {
     }
 
     const data = await response.json();
-    const items: GoogleCalendarListItem[] = data.items || [];
+    const items: gapi.client.calendar.CalendarListEntry[] = data.items || [];
 
     // Map each calendar to its color
     const colorMappings: CalendarColorMapping[] = items.map((item) => {

--- a/src/app/api/calendar/events/__tests__/route.test.ts
+++ b/src/app/api/calendar/events/__tests__/route.test.ts
@@ -130,6 +130,70 @@ describe("/api/calendar/events", () => {
       );
     });
 
+    it("preserves extended Google Calendar v3 fields on each event", async () => {
+      vi.mocked(getSession).mockResolvedValue(mockSession);
+      vi.mocked(getAccessToken).mockResolvedValue(
+        mockGoogleAccount.access_token!
+      );
+
+      const enrichedEvent = {
+        id: "evt-rich",
+        summary: "Design review",
+        start: { dateTime: "2026-05-01T14:00:00Z" },
+        end: { dateTime: "2026-05-01T15:00:00Z" },
+        status: "confirmed",
+        location: "Room 1",
+        htmlLink: "https://www.google.com/calendar/event?eid=abc",
+        iCalUID: "evt-rich@google.com",
+        etag: '"etag-xyz"',
+        organizer: { email: "alice@example.com", displayName: "Alice" },
+        attendees: [
+          {
+            email: "bob@example.com",
+            displayName: "Bob",
+            responseStatus: "accepted",
+          },
+        ],
+        recurrence: ["RRULE:FREQ=WEEKLY;BYDAY=MO"],
+        eventType: "default",
+      };
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            items: [enrichedEvent],
+            summary: "Primary Calendar",
+            timeZone: "UTC",
+          }),
+      });
+
+      const request = createMockRequest("/api/calendar/events");
+      const response = await GET(request);
+      const { status, data } = await parseResponse<{
+        events: Array<
+          typeof enrichedEvent & {
+            calendarId: string;
+          }
+        >;
+      }>(response);
+
+      expect(status).toBe(200);
+      expect(data.events).toHaveLength(1);
+      const returned = data.events[0];
+      expect(returned.calendarId).toBe("primary");
+      expect(returned.status).toBe("confirmed");
+      expect(returned.location).toBe("Room 1");
+      expect(returned.htmlLink).toBe(enrichedEvent.htmlLink);
+      expect(returned.iCalUID).toBe("evt-rich@google.com");
+      expect(returned.etag).toBe('"etag-xyz"');
+      expect(returned.organizer?.email).toBe("alice@example.com");
+      expect(returned.attendees).toHaveLength(1);
+      expect(returned.attendees?.[0]?.responseStatus).toBe("accepted");
+      expect(returned.recurrence).toEqual(["RRULE:FREQ=WEEKLY;BYDAY=MO"]);
+      expect(returned.eventType).toBe("default");
+    });
+
     it("returns empty array when no events exist", async () => {
       vi.mocked(getSession).mockResolvedValue(mockSession);
       vi.mocked(getAccessToken).mockResolvedValue(

--- a/src/app/api/calendar/events/route.ts
+++ b/src/app/api/calendar/events/route.ts
@@ -4,26 +4,14 @@
  * Supports fetching from multiple calendars
  */
 import { AuthError, getAccessToken, getSession } from "@/lib/auth";
+import {
+  type GoogleCalendarEvent,
+  normalizeFetchedEvent,
+} from "@/lib/google-calendar";
 import { logger } from "@/lib/logger";
 import { NextRequest, NextResponse } from "next/server";
 
 const GOOGLE_CALENDAR_API = "https://www.googleapis.com/calendar/v3";
-
-interface GoogleCalendarEvent {
-  id: string;
-  summary?: string;
-  description?: string;
-  start: { dateTime?: string; date?: string };
-  end: { dateTime?: string; date?: string };
-  colorId?: string;
-  creator?: { email?: string; displayName?: string };
-  organizer?: { email?: string; displayName?: string };
-  [key: string]: unknown;
-}
-
-interface CalendarEventWithId extends GoogleCalendarEvent {
-  calendarId: string;
-}
 
 interface CalendarFetchError {
   calendarId: string;
@@ -42,7 +30,7 @@ async function fetchEventsFromCalendar(
   maxResults: string,
   singleEvents: boolean
 ): Promise<{
-  events: CalendarEventWithId[];
+  events: GoogleCalendarEvent[];
   error?: CalendarFetchError;
   summary?: string;
   timeZone?: string;
@@ -76,11 +64,9 @@ async function fetchEventsFromCalendar(
   }
 
   const data = await response.json();
-  const events: CalendarEventWithId[] = (data.items || []).map(
-    (event: GoogleCalendarEvent) => ({
-      ...event,
-      calendarId,
-    })
+  const events: GoogleCalendarEvent[] = (data.items || []).map(
+    (event: gapi.client.calendar.Event) =>
+      normalizeFetchedEvent(event, calendarId)
   );
 
   return {
@@ -141,7 +127,7 @@ export async function GET(request: NextRequest) {
     );
 
     // Collect events and errors
-    const allEvents: CalendarEventWithId[] = [];
+    const allEvents: GoogleCalendarEvent[] = [];
     const errors: CalendarFetchError[] = [];
     let summary: string | undefined;
     let timeZone: string | undefined;
@@ -194,7 +180,7 @@ export async function GET(request: NextRequest) {
     });
 
     const response: {
-      events: CalendarEventWithId[];
+      events: GoogleCalendarEvent[];
       nextPageToken?: string;
       summary?: string;
       timeZone?: string;

--- a/src/app/api/calendar/events/route.ts
+++ b/src/app/api/calendar/events/route.ts
@@ -7,7 +7,7 @@ import { AuthError, getAccessToken, getSession } from "@/lib/auth";
 import {
   type GoogleCalendarEvent,
   normalizeFetchedEvent,
-} from "@/lib/google-calendar";
+} from "@/lib/google-calendar-mappers";
 import { logger } from "@/lib/logger";
 import { NextRequest, NextResponse } from "next/server";
 

--- a/src/lib/__tests__/google-calendar-mappers.test.ts
+++ b/src/lib/__tests__/google-calendar-mappers.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Unit tests for Google Calendar API response mappers.
+ *
+ * These tests exercise the pure mappers that translate raw Google Calendar API
+ * responses into the app's `GoogleCalendarEvent` and `UserCalendar` shapes.
+ *
+ * They serve as regression guards for two concerns:
+ *  1. Extended optional fields surfaced by the richer `gapi.d.ts` types are
+ *     preserved through the mappers (issue #76).
+ *  2. Comments/semantics around `fetchCalendarColorMappings` stay stable (#77).
+ */
+import type { CalendarColorMapping } from "@/lib/calendar-storage";
+import {
+  type GoogleCalendarEvent,
+  type UserCalendar,
+  normalizeCalendarListEntry,
+  normalizeFetchedEvent,
+} from "@/lib/google-calendar";
+import { describe, expect, it } from "vitest";
+
+describe("normalizeFetchedEvent", () => {
+  it("preserves required fields and stamps calendarId", () => {
+    const apiEvent: gapi.client.calendar.Event = {
+      id: "evt-1",
+      summary: "Standup",
+      start: { dateTime: "2026-05-01T09:00:00-04:00" },
+      end: { dateTime: "2026-05-01T09:30:00-04:00" },
+    };
+
+    const result = normalizeFetchedEvent(apiEvent, "primary");
+
+    expect(result.id).toBe("evt-1");
+    expect(result.summary).toBe("Standup");
+    expect(result.calendarId).toBe("primary");
+    expect(result.start.dateTime).toBe("2026-05-01T09:00:00-04:00");
+    expect(result.end.dateTime).toBe("2026-05-01T09:30:00-04:00");
+  });
+
+  it("passes through extended optional fields from Google Calendar v3", () => {
+    const apiEvent: gapi.client.calendar.Event = {
+      id: "evt-rich",
+      summary: "Board meeting",
+      description: "Quarterly review",
+      start: { dateTime: "2026-05-01T14:00:00Z", timeZone: "UTC" },
+      end: { dateTime: "2026-05-01T15:00:00Z", timeZone: "UTC" },
+      status: "confirmed",
+      location: "HQ Conference Room A",
+      htmlLink: "https://www.google.com/calendar/event?eid=abc",
+      iCalUID: "evt-rich@google.com",
+      etag: '"etag-123"',
+      created: "2026-04-20T12:00:00Z",
+      updated: "2026-04-21T08:00:00Z",
+      transparency: "opaque",
+      visibility: "default",
+      eventType: "default",
+      hangoutLink: "https://meet.google.com/abc-defg-hij",
+      colorId: "4",
+      creator: { email: "alice@example.com", displayName: "Alice" },
+      organizer: { email: "alice@example.com", displayName: "Alice" },
+      attendees: [
+        {
+          email: "bob@example.com",
+          displayName: "Bob",
+          responseStatus: "accepted",
+        },
+      ],
+      recurrence: ["RRULE:FREQ=WEEKLY;BYDAY=MO"],
+    };
+
+    const result = normalizeFetchedEvent(apiEvent, "team@example.com");
+
+    expect(result.calendarId).toBe("team@example.com");
+    expect(result.status).toBe("confirmed");
+    expect(result.location).toBe("HQ Conference Room A");
+    expect(result.htmlLink).toBe(
+      "https://www.google.com/calendar/event?eid=abc"
+    );
+    expect(result.iCalUID).toBe("evt-rich@google.com");
+    expect(result.etag).toBe('"etag-123"');
+    expect(result.created).toBe("2026-04-20T12:00:00Z");
+    expect(result.updated).toBe("2026-04-21T08:00:00Z");
+    expect(result.transparency).toBe("opaque");
+    expect(result.visibility).toBe("default");
+    expect(result.eventType).toBe("default");
+    expect(result.hangoutLink).toBe("https://meet.google.com/abc-defg-hij");
+    expect(result.organizer?.email).toBe("alice@example.com");
+    expect(result.attendees).toHaveLength(1);
+    expect(result.attendees?.[0]?.responseStatus).toBe("accepted");
+    expect(result.recurrence).toEqual(["RRULE:FREQ=WEEKLY;BYDAY=MO"]);
+  });
+
+  it("handles recurring-event instance fields (recurringEventId + originalStartTime)", () => {
+    const apiEvent: gapi.client.calendar.Event = {
+      id: "evt-instance_20260501T140000Z",
+      summary: "Weekly sync (moved)",
+      start: { dateTime: "2026-05-01T15:00:00Z" },
+      end: { dateTime: "2026-05-01T16:00:00Z" },
+      recurringEventId: "evt-parent",
+      originalStartTime: { dateTime: "2026-05-01T14:00:00Z" },
+    };
+
+    const result = normalizeFetchedEvent(apiEvent, "primary");
+
+    expect(result.recurringEventId).toBe("evt-parent");
+    expect(result.originalStartTime?.dateTime).toBe("2026-05-01T14:00:00Z");
+  });
+
+  it("accepts all-day events (date-only start/end with no dateTime)", () => {
+    const apiEvent: gapi.client.calendar.Event = {
+      id: "evt-allday",
+      summary: "Holiday",
+      start: { date: "2026-12-25" },
+      end: { date: "2026-12-26" },
+    };
+
+    const result = normalizeFetchedEvent(
+      apiEvent,
+      "holidays@group.v.calendar.google.com"
+    );
+
+    expect(result.start.date).toBe("2026-12-25");
+    expect(result.start.dateTime).toBeUndefined();
+    expect(result.end.date).toBe("2026-12-26");
+  });
+});
+
+describe("normalizeCalendarListEntry", () => {
+  it("maps the base fields consumed by the app", () => {
+    const apiEntry: gapi.client.calendar.CalendarListEntry = {
+      id: "family@group.calendar.google.com",
+      summary: "Family",
+      description: "Family events",
+      backgroundColor: "#16a765",
+      foregroundColor: "#ffffff",
+      primary: false,
+    };
+
+    const result = normalizeCalendarListEntry(apiEntry);
+
+    expect(result).toEqual<UserCalendar>({
+      id: "family@group.calendar.google.com",
+      summary: "Family",
+      description: "Family events",
+      backgroundColor: "#16a765",
+      foregroundColor: "#ffffff",
+      primary: false,
+      colorId: undefined,
+      timeZone: undefined,
+      summaryOverride: undefined,
+      selected: undefined,
+      accessRole: undefined,
+    });
+  });
+
+  it("preserves extended CalendarList fields surfaced by the richer types", () => {
+    const apiEntry: gapi.client.calendar.CalendarListEntry = {
+      id: "primary",
+      summary: "alice@example.com",
+      backgroundColor: "#3b82f6",
+      foregroundColor: "#000000",
+      primary: true,
+      colorId: "10",
+      timeZone: "America/New_York",
+      summaryOverride: "My Calendar",
+      selected: true,
+      accessRole: "owner",
+    };
+
+    const result = normalizeCalendarListEntry(apiEntry);
+
+    expect(result.colorId).toBe("10");
+    expect(result.timeZone).toBe("America/New_York");
+    expect(result.summaryOverride).toBe("My Calendar");
+    expect(result.selected).toBe(true);
+    expect(result.accessRole).toBe("owner");
+  });
+});
+
+describe("type-level coverage: GoogleCalendarEvent is assignable from raw API responses", () => {
+  // These assignments are effectively compile-time assertions. They fail
+  // `pnpm check-types` if the extended fields on the canonical type drift
+  // out of sync with the shapes accepted by `normalizeFetchedEvent`.
+  it("accepts a realistic enriched Google Calendar v3 event payload", () => {
+    const apiResponse: gapi.client.calendar.EventsListResponse = {
+      kind: "calendar#events",
+      etag: '"list-etag"',
+      summary: "Primary",
+      timeZone: "America/New_York",
+      accessRole: "owner",
+      defaultReminders: [{ method: "popup", minutes: 10 }],
+      nextPageToken: "next-page",
+      nextSyncToken: "sync-token",
+      updated: "2026-04-22T12:00:00Z",
+      items: [
+        {
+          id: "evt-a",
+          summary: "Lunch",
+          start: { dateTime: "2026-05-01T12:00:00Z" },
+          end: { dateTime: "2026-05-01T13:00:00Z" },
+          reminders: { useDefault: true },
+        },
+      ],
+    };
+
+    expect(apiResponse.items?.[0]?.id).toBe("evt-a");
+    expect(apiResponse.nextPageToken).toBe("next-page");
+    expect(apiResponse.defaultReminders?.[0]?.method).toBe("popup");
+
+    const mapped: GoogleCalendarEvent[] = (apiResponse.items ?? []).map(
+      (event) => normalizeFetchedEvent(event, "primary")
+    );
+
+    expect(mapped).toHaveLength(1);
+    expect(mapped[0]?.id).toBe("evt-a");
+  });
+
+  it("accepts a realistic enriched CalendarList response payload", () => {
+    const apiResponse: gapi.client.calendar.CalendarListListResponse = {
+      kind: "calendar#calendarList",
+      etag: '"etag"',
+      nextPageToken: "p2",
+      nextSyncToken: "s2",
+      items: [
+        {
+          id: "primary",
+          summary: "alice@example.com",
+          backgroundColor: "#3b82f6",
+          foregroundColor: "#000000",
+          primary: true,
+          accessRole: "owner",
+        },
+      ],
+    };
+
+    const mapped = (apiResponse.items ?? []).map(normalizeCalendarListEntry);
+    expect(mapped[0]?.accessRole).toBe("owner");
+  });
+});
+
+describe("color mapping semantics (#77 regression)", () => {
+  // This test pins down the expected post-#77 invariant: calendar-level
+  // color mappings deliberately leave `colorId` empty because that field is
+  // scoped to event-level colorIds, which calendarList items do not carry.
+  it("builds a CalendarColorMapping with an intentionally-empty colorId", () => {
+    const entry = normalizeCalendarListEntry({
+      id: "fam@group.calendar.google.com",
+      summary: "Family",
+      backgroundColor: "#16a765",
+      foregroundColor: "#ffffff",
+    });
+
+    const mapping: CalendarColorMapping = {
+      calendarId: entry.id,
+      colorId: "",
+      hexColor: entry.backgroundColor ?? "#3b82f6",
+      tailwindColor: "green",
+    };
+
+    expect(mapping.colorId).toBe("");
+    expect(mapping.calendarId).toBe("fam@group.calendar.google.com");
+  });
+});

--- a/src/lib/__tests__/google-calendar-mappers.test.ts
+++ b/src/lib/__tests__/google-calendar-mappers.test.ts
@@ -89,6 +89,73 @@ describe("normalizeFetchedEvent", () => {
     expect(result.recurrence).toEqual(["RRULE:FREQ=WEEKLY;BYDAY=MO"]);
   });
 
+  it("falls back to empty string when event has no summary", () => {
+    // Google marks Event.summary as optional. Downstream UI code (see
+    // `transformGoogleEvent` → `title: event.summary || "Untitled Event"`)
+    // expects a string, so the mapper defensively normalises.
+    const apiEvent: gapi.client.calendar.Event = {
+      id: "evt-no-title",
+      start: { dateTime: "2026-05-01T09:00:00Z" },
+      end: { dateTime: "2026-05-01T09:30:00Z" },
+    };
+
+    const result = normalizeFetchedEvent(apiEvent, "primary");
+
+    expect(result.summary).toBe("");
+    // And the field is typed as a plain string (no `undefined`), which is
+    // what the narrower `GoogleCalendarEvent.summary: string` buys us.
+    const summaryTypeCheck: string = result.summary;
+    expect(summaryTypeCheck).toBe("");
+  });
+
+  it("passes every Google-declared field through the spread (no silent drops)", () => {
+    // Guards against regressions on the review finding that
+    // `{ ...event }` was leaking fields the canonical type didn't declare.
+    // If `GoogleCalendarEvent` ever stops `extends Omit<Event, "summary">`,
+    // these assertions fail at the type layer and the runtime round-trip
+    // here fails as well.
+    const apiEvent: gapi.client.calendar.Event = {
+      id: "evt-full",
+      summary: "All fields",
+      start: { dateTime: "2026-05-01T09:00:00Z" },
+      end: { dateTime: "2026-05-01T10:00:00Z" },
+      kind: "calendar#event",
+      conferenceData: {
+        conferenceId: "abc",
+        entryPoints: [
+          { entryPointType: "video", uri: "https://meet.google.com/abc" },
+        ],
+      },
+      attachments: [
+        { fileUrl: "https://drive.google.com/file/d/1", title: "Agenda" },
+      ],
+      source: { url: "https://example.com", title: "Source" },
+      extendedProperties: { shared: { sharedKey: "sharedVal" } },
+      attendeesOmitted: false,
+      anyoneCanAddSelf: true,
+      guestsCanInviteOthers: true,
+      guestsCanModify: false,
+      guestsCanSeeOtherGuests: true,
+      privateCopy: false,
+      locked: false,
+    };
+
+    const result = normalizeFetchedEvent(apiEvent, "primary");
+
+    expect(result.kind).toBe("calendar#event");
+    expect(result.conferenceData?.conferenceId).toBe("abc");
+    expect(result.attachments?.[0]?.title).toBe("Agenda");
+    expect(result.source?.url).toBe("https://example.com");
+    expect(result.extendedProperties?.shared?.sharedKey).toBe("sharedVal");
+    expect(result.attendeesOmitted).toBe(false);
+    expect(result.anyoneCanAddSelf).toBe(true);
+    expect(result.guestsCanInviteOthers).toBe(true);
+    expect(result.guestsCanModify).toBe(false);
+    expect(result.guestsCanSeeOtherGuests).toBe(true);
+    expect(result.privateCopy).toBe(false);
+    expect(result.locked).toBe(false);
+  });
+
   it("handles recurring-event instance fields (recurringEventId + originalStartTime)", () => {
     const apiEvent: gapi.client.calendar.Event = {
       id: "evt-instance_20260501T140000Z",
@@ -152,6 +219,22 @@ describe("normalizeCalendarListEntry", () => {
     });
   });
 
+  it("falls back to empty string when calendarList entry has no summary", () => {
+    // CalendarList.summary is optional per the Google schema (and some
+    // synthetic/deleted entries may arrive without one). Mirror the
+    // defensive behaviour of `normalizeFetchedEvent` so the narrowed
+    // `UserCalendar.summary: string` is genuinely a string.
+    const apiEntry: gapi.client.calendar.CalendarListEntry = {
+      id: "quiet@group.calendar.google.com",
+    };
+
+    const result = normalizeCalendarListEntry(apiEntry);
+
+    expect(result.summary).toBe("");
+    const summaryTypeCheck: string = result.summary;
+    expect(summaryTypeCheck).toBe("");
+  });
+
   it("preserves extended CalendarList fields surfaced by the richer types", () => {
     const apiEntry: gapi.client.calendar.CalendarListEntry = {
       id: "primary",
@@ -176,18 +259,21 @@ describe("normalizeCalendarListEntry", () => {
   });
 });
 
-describe("type-level coverage: GoogleCalendarEvent is assignable from raw API responses", () => {
-  // These assignments are effectively compile-time assertions. They fail
-  // `pnpm check-types` if the extended fields on the canonical type drift
-  // out of sync with the shapes accepted by `normalizeFetchedEvent`.
-  it("accepts a realistic enriched Google Calendar v3 event payload", () => {
+describe("end-to-end: enriched API responses flow through the mappers", () => {
+  // These cases also act as compile-time coverage — enriched Google v3
+  // fixtures assigned to the richer response types will fail
+  // `pnpm check-types` if `gapi.d.ts` drifts away from the API. The runtime
+  // assertions here check the *full* round-trip so the tests earn their
+  // keep at runtime too.
+  it("round-trips an enriched events.list response through the mapper", () => {
+    const reminderMethod = "popup" as const;
     const apiResponse: gapi.client.calendar.EventsListResponse = {
       kind: "calendar#events",
       etag: '"list-etag"',
       summary: "Primary",
       timeZone: "America/New_York",
       accessRole: "owner",
-      defaultReminders: [{ method: "popup", minutes: 10 }],
+      defaultReminders: [{ method: reminderMethod, minutes: 10 }],
       nextPageToken: "next-page",
       nextSyncToken: "sync-token",
       updated: "2026-04-22T12:00:00Z",
@@ -195,26 +281,33 @@ describe("type-level coverage: GoogleCalendarEvent is assignable from raw API re
         {
           id: "evt-a",
           summary: "Lunch",
+          location: "Cafe",
+          htmlLink: "https://www.google.com/calendar/event?eid=a",
           start: { dateTime: "2026-05-01T12:00:00Z" },
           end: { dateTime: "2026-05-01T13:00:00Z" },
           reminders: { useDefault: true },
+          attendees: [{ email: "a@example.com", responseStatus: "accepted" }],
         },
       ],
     };
-
-    expect(apiResponse.items?.[0]?.id).toBe("evt-a");
-    expect(apiResponse.nextPageToken).toBe("next-page");
-    expect(apiResponse.defaultReminders?.[0]?.method).toBe("popup");
 
     const mapped: GoogleCalendarEvent[] = (apiResponse.items ?? []).map(
       (event) => normalizeFetchedEvent(event, "primary")
     );
 
     expect(mapped).toHaveLength(1);
-    expect(mapped[0]?.id).toBe("evt-a");
+    const [only] = mapped;
+    expect(only?.id).toBe("evt-a");
+    expect(only?.summary).toBe("Lunch");
+    expect(only?.location).toBe("Cafe");
+    expect(only?.htmlLink).toBe("https://www.google.com/calendar/event?eid=a");
+    expect(only?.calendarId).toBe("primary");
+    expect(only?.reminders?.useDefault).toBe(true);
+    expect(only?.attendees?.[0]?.email).toBe("a@example.com");
+    expect(apiResponse.nextSyncToken).toBe("sync-token");
   });
 
-  it("accepts a realistic enriched CalendarList response payload", () => {
+  it("round-trips an enriched calendarList.list response through the mapper", () => {
     const apiResponse: gapi.client.calendar.CalendarListListResponse = {
       kind: "calendar#calendarList",
       etag: '"etag"',
@@ -228,12 +321,27 @@ describe("type-level coverage: GoogleCalendarEvent is assignable from raw API re
           foregroundColor: "#000000",
           primary: true,
           accessRole: "owner",
+          timeZone: "UTC",
+          selected: true,
+        },
+        {
+          id: "shared@group.calendar.google.com",
+          summary: "Shared",
+          backgroundColor: "#16a765",
+          accessRole: "reader",
         },
       ],
     };
 
     const mapped = (apiResponse.items ?? []).map(normalizeCalendarListEntry);
+
+    expect(mapped).toHaveLength(2);
+    expect(mapped[0]?.id).toBe("primary");
     expect(mapped[0]?.accessRole).toBe("owner");
+    expect(mapped[0]?.timeZone).toBe("UTC");
+    expect(mapped[0]?.selected).toBe(true);
+    expect(mapped[1]?.accessRole).toBe("reader");
+    expect(mapped[1]?.summary).toBe("Shared");
   });
 });
 

--- a/src/lib/google-calendar-mappers.ts
+++ b/src/lib/google-calendar-mappers.ts
@@ -1,0 +1,98 @@
+/**
+ * Pure mappers and canonical domain types for Google Calendar API responses.
+ *
+ * This module is deliberately **universal**: it has no dependencies on
+ * `window`, `gapi` at runtime, or any browser global, so both server routes
+ * (Next.js route handlers in `src/app/api/calendar/**`) and the client-side
+ * `src/lib/google-calendar.ts` module can import from it safely.
+ *
+ * Keep this module free of side effects and do not import anything that
+ * references browser-only globals — if you need that, put it in
+ * `src/lib/google-calendar.ts` and import the mappers from here.
+ */
+
+/**
+ * Canonical shape of a Google Calendar event inside the app.
+ *
+ * Extends `Omit<gapi.client.calendar.Event, "summary">` so every field on the
+ * raw Google event schema is carried through the `{ ...event }` spread in
+ * `normalizeFetchedEvent` without any silent widening. `summary` is narrowed
+ * to a required `string` because the mapper applies a `?? ""` fallback,
+ * which matches what downstream UI code expects.
+ */
+export interface GoogleCalendarEvent extends Omit<
+  gapi.client.calendar.Event,
+  "summary"
+> {
+  /** Narrowed to `string` — `normalizeFetchedEvent` guarantees an empty string rather than `undefined`. */
+  summary: string;
+  /** The calendar this event was fetched from. Not a Google-API field. */
+  calendarId: string;
+}
+
+/**
+ * Shape returned by `fetchUserCalendars` — mirrors the fields we pluck off
+ * `gapi.client.calendar.CalendarListEntry` and narrows `summary` to a
+ * required string (with an empty-string fallback supplied by the mapper).
+ */
+export interface UserCalendar {
+  id: string;
+  /** Narrowed to `string` — `normalizeCalendarListEntry` guarantees an empty string rather than `undefined`. */
+  summary: string;
+  description?: string;
+  backgroundColor?: string;
+  foregroundColor?: string;
+  primary?: boolean;
+  /** Calendar-level colorId from the calendarList resource (not event-level). */
+  colorId?: string;
+  timeZone?: string;
+  summaryOverride?: string;
+  selected?: boolean;
+  accessRole?: "freeBusyReader" | "reader" | "writer" | "owner";
+}
+
+/**
+ * Normalise a raw Google Calendar API event into our {@link GoogleCalendarEvent}
+ * shape, stamping the source `calendarId` so cached events can be looked up by
+ * calendar later.
+ *
+ * Applies a `summary ?? ""` fallback because the Google API marks
+ * `Event.summary` as optional but our UI code (`transformGoogleEvent`) expects
+ * a string.
+ */
+export function normalizeFetchedEvent(
+  event: gapi.client.calendar.Event,
+  calendarId: string
+): GoogleCalendarEvent {
+  return {
+    ...event,
+    summary: event.summary ?? "",
+    calendarId,
+  };
+}
+
+/**
+ * Normalise a raw `CalendarListEntry` into the slim shape consumed by the app.
+ *
+ * Applies the same `summary ?? ""` fallback as {@link normalizeFetchedEvent}
+ * so {@link UserCalendar.summary} is genuinely a string — `CalendarListEntry.summary`
+ * is optional in the Google schema, even though it is almost always present
+ * in practice.
+ */
+export function normalizeCalendarListEntry(
+  entry: gapi.client.calendar.CalendarListEntry
+): UserCalendar {
+  return {
+    id: entry.id,
+    summary: entry.summary ?? "",
+    description: entry.description,
+    backgroundColor: entry.backgroundColor,
+    foregroundColor: entry.foregroundColor,
+    primary: entry.primary,
+    colorId: entry.colorId,
+    timeZone: entry.timeZone,
+    summaryOverride: entry.summaryOverride,
+    selected: entry.selected,
+    accessRole: entry.accessRole,
+  };
+}

--- a/src/lib/google-calendar.ts
+++ b/src/lib/google-calendar.ts
@@ -25,8 +25,19 @@ export interface GoogleCalendarAccount {
   calendarIds: string[]; // List of calendar IDs to fetch from this account
 }
 
+/**
+ * Canonical shape of a Google Calendar event inside the app.
+ *
+ * Mirrors the public Google Calendar API v3 Events resource
+ * (https://developers.google.com/workspace/calendar/api/v3/reference/events#resource)
+ * and adds a mandatory `calendarId` that we stamp on fetch so downstream code
+ * can round-trip events through IndexedDB caches and color mappings. All
+ * upstream-optional fields remain optional here; keep additions in sync with
+ * the ambient `gapi.client.calendar.Event` type in `src/types/gapi.d.ts`.
+ */
 export interface GoogleCalendarEvent {
   id: string;
+  /** Required here for our UI; Google marks this optional, so we tolerate an empty string upstream. */
   summary: string;
   description?: string;
   start: {
@@ -41,10 +52,117 @@ export interface GoogleCalendarEvent {
   };
   colorId?: string;
   creator?: {
+    id?: string;
     email?: string;
     displayName?: string;
+    self?: boolean;
   };
+  organizer?: {
+    id?: string;
+    email?: string;
+    displayName?: string;
+    self?: boolean;
+  };
+
+  /** Lifecycle metadata preserved for caching and conflict resolution. */
+  etag?: string;
+  status?: "confirmed" | "tentative" | "cancelled";
+  htmlLink?: string;
+  created?: string;
+  updated?: string;
+  iCalUID?: string;
+  sequence?: number;
+
+  /** Location / conferencing metadata. */
+  location?: string;
+  hangoutLink?: string;
+
+  /** Visibility / scheduling flags. */
+  transparency?: "opaque" | "transparent";
+  visibility?: "default" | "public" | "private" | "confidential";
+  eventType?:
+    | "default"
+    | "outOfOffice"
+    | "focusTime"
+    | "workingLocation"
+    | "fromGmail";
+
+  /** Attendees, reminders, recurrence. */
+  attendees?: gapi.client.calendar.EventAttendee[];
+  reminders?: gapi.client.calendar.EventReminders;
+  recurrence?: string[];
+  recurringEventId?: string;
+  originalStartTime?: gapi.client.calendar.EventDateTime;
+
+  /** The calendar this event was fetched from — not a Google-API field. */
   calendarId: string;
+}
+
+/**
+ * Shape returned by `fetchUserCalendars` — mirrors the fields we pluck off
+ * `gapi.client.calendar.CalendarListEntry`. Optional fields stay optional so
+ * callers can progressively opt in.
+ */
+export interface UserCalendar {
+  id: string;
+  summary: string;
+  description?: string;
+  backgroundColor?: string;
+  foregroundColor?: string;
+  primary?: boolean;
+  /** Calendar-level colorId from the calendarList resource (not event-level). */
+  colorId?: string;
+  timeZone?: string;
+  summaryOverride?: string;
+  selected?: boolean;
+  accessRole?: "freeBusyReader" | "reader" | "writer" | "owner";
+}
+
+/**
+ * Normalise a raw Google Calendar API event into our {@link GoogleCalendarEvent}
+ * shape, stamping the source `calendarId` so cached events can be looked up by
+ * calendar later.
+ *
+ * Exported for unit testing and for reuse by any code path that receives raw
+ * Google Calendar API responses (e.g. the server-side REST fetch in
+ * `src/app/api/calendar/events/route.ts`).
+ */
+export function normalizeFetchedEvent(
+  event: gapi.client.calendar.Event,
+  calendarId: string
+): GoogleCalendarEvent {
+  return {
+    ...event,
+    // Google marks `summary` optional; our UI expects a string so we fall back
+    // to the empty string and let `transformGoogleEvent` substitute a label.
+    summary: event.summary ?? "",
+    calendarId,
+  };
+}
+
+/**
+ * Normalise a raw `CalendarListEntry` into the slim shape consumed by the app.
+ *
+ * Also exported so server-side callers that fetch `calendarList.list` via
+ * plain `fetch()` can reuse the same mapping without duplicating the field
+ * selection.
+ */
+export function normalizeCalendarListEntry(
+  entry: gapi.client.calendar.CalendarListEntry
+): UserCalendar {
+  return {
+    id: entry.id,
+    summary: entry.summary,
+    description: entry.description,
+    backgroundColor: entry.backgroundColor,
+    foregroundColor: entry.foregroundColor,
+    primary: entry.primary,
+    colorId: entry.colorId,
+    timeZone: entry.timeZone,
+    summaryOverride: entry.summaryOverride,
+    selected: entry.selected,
+    accessRole: entry.accessRole,
+  };
 }
 
 const GOOGLE_CALENDAR_CONFIG: GoogleCalendarConfig = {
@@ -446,12 +564,7 @@ export async function fetchCalendarEvents(
       timeMax: timeMax.toISOString(),
     });
 
-    return events.map(
-      (event): GoogleCalendarEvent => ({
-        ...event,
-        calendarId,
-      })
-    );
+    return events.map((event) => normalizeFetchedEvent(event, calendarId));
   } catch (error: unknown) {
     const err = error as {
       result?: { error?: { code?: number; message?: string } };
@@ -510,7 +623,7 @@ export async function fetchEventsFromMultipleCalendars(
 /**
  * Fetch all calendars for the signed-in user
  */
-export async function fetchUserCalendars() {
+export async function fetchUserCalendars(): Promise<UserCalendar[]> {
   await initGoogleAPI();
 
   try {
@@ -519,23 +632,7 @@ export async function fetchUserCalendars() {
 
     logger.log("Fetched user calendars", { count: calendars.length });
 
-    return calendars.map(
-      (calendar: {
-        id: string;
-        summary: string;
-        description?: string;
-        backgroundColor?: string;
-        foregroundColor?: string;
-        primary?: boolean;
-      }) => ({
-        id: calendar.id,
-        summary: calendar.summary,
-        description: calendar.description,
-        backgroundColor: calendar.backgroundColor,
-        foregroundColor: calendar.foregroundColor,
-        primary: calendar.primary,
-      })
-    );
+    return calendars.map(normalizeCalendarListEntry);
   } catch (error) {
     logger.error(error as Error, { context: "fetchUserCalendars" });
     throw error;
@@ -558,7 +655,11 @@ export async function fetchCalendarColorMappings(): Promise<
 
       return {
         calendarId: calendar.id,
-        colorId: "", // Google Calendar API doesn't provide colorId in calendarList
+        // Intentionally empty: `CalendarColorMapping.colorId` models the
+        // event-level colorId (from `calendar#colors.event`). CalendarList
+        // entries only carry a calendar-level colorId, which we do not need
+        // because we map colors via the richer `backgroundColor` field above.
+        colorId: "",
         hexColor,
         tailwindColor,
       };

--- a/src/lib/google-calendar.ts
+++ b/src/lib/google-calendar.ts
@@ -2,10 +2,29 @@
  * Google Calendar API integration for client-side calendar fetching
  * This module handles OAuth authentication and event fetching from multiple Google Calendars
  * Uses Google Identity Services (GIS) for modern OAuth authentication
+ *
+ * The canonical `GoogleCalendarEvent` / `UserCalendar` types and the pure
+ * mappers that translate Google API responses live in
+ * `src/lib/google-calendar-mappers.ts` — a universal module that server code
+ * can import without dragging in the browser-only logic below. They are
+ * re-exported here for convenience.
  */
 import { logger } from "@/lib/logger";
 import { type CalendarColorMapping } from "./calendar-storage";
 import { mapHexToTailwindColor } from "./color-utils";
+import {
+  type GoogleCalendarEvent,
+  type UserCalendar,
+  normalizeCalendarListEntry,
+  normalizeFetchedEvent,
+} from "./google-calendar-mappers";
+
+export {
+  type GoogleCalendarEvent,
+  normalizeCalendarListEntry,
+  normalizeFetchedEvent,
+  type UserCalendar,
+} from "./google-calendar-mappers";
 
 // Google API configuration types
 export interface GoogleCalendarConfig {
@@ -23,146 +42,6 @@ export interface GoogleCalendarAccount {
   refreshToken?: string;
   expiresAt: number;
   calendarIds: string[]; // List of calendar IDs to fetch from this account
-}
-
-/**
- * Canonical shape of a Google Calendar event inside the app.
- *
- * Mirrors the public Google Calendar API v3 Events resource
- * (https://developers.google.com/workspace/calendar/api/v3/reference/events#resource)
- * and adds a mandatory `calendarId` that we stamp on fetch so downstream code
- * can round-trip events through IndexedDB caches and color mappings. All
- * upstream-optional fields remain optional here; keep additions in sync with
- * the ambient `gapi.client.calendar.Event` type in `src/types/gapi.d.ts`.
- */
-export interface GoogleCalendarEvent {
-  id: string;
-  /** Required here for our UI; Google marks this optional, so we tolerate an empty string upstream. */
-  summary: string;
-  description?: string;
-  start: {
-    dateTime?: string;
-    date?: string;
-    timeZone?: string;
-  };
-  end: {
-    dateTime?: string;
-    date?: string;
-    timeZone?: string;
-  };
-  colorId?: string;
-  creator?: {
-    id?: string;
-    email?: string;
-    displayName?: string;
-    self?: boolean;
-  };
-  organizer?: {
-    id?: string;
-    email?: string;
-    displayName?: string;
-    self?: boolean;
-  };
-
-  /** Lifecycle metadata preserved for caching and conflict resolution. */
-  etag?: string;
-  status?: "confirmed" | "tentative" | "cancelled";
-  htmlLink?: string;
-  created?: string;
-  updated?: string;
-  iCalUID?: string;
-  sequence?: number;
-
-  /** Location / conferencing metadata. */
-  location?: string;
-  hangoutLink?: string;
-
-  /** Visibility / scheduling flags. */
-  transparency?: "opaque" | "transparent";
-  visibility?: "default" | "public" | "private" | "confidential";
-  eventType?:
-    | "default"
-    | "outOfOffice"
-    | "focusTime"
-    | "workingLocation"
-    | "fromGmail";
-
-  /** Attendees, reminders, recurrence. */
-  attendees?: gapi.client.calendar.EventAttendee[];
-  reminders?: gapi.client.calendar.EventReminders;
-  recurrence?: string[];
-  recurringEventId?: string;
-  originalStartTime?: gapi.client.calendar.EventDateTime;
-
-  /** The calendar this event was fetched from — not a Google-API field. */
-  calendarId: string;
-}
-
-/**
- * Shape returned by `fetchUserCalendars` — mirrors the fields we pluck off
- * `gapi.client.calendar.CalendarListEntry`. Optional fields stay optional so
- * callers can progressively opt in.
- */
-export interface UserCalendar {
-  id: string;
-  summary: string;
-  description?: string;
-  backgroundColor?: string;
-  foregroundColor?: string;
-  primary?: boolean;
-  /** Calendar-level colorId from the calendarList resource (not event-level). */
-  colorId?: string;
-  timeZone?: string;
-  summaryOverride?: string;
-  selected?: boolean;
-  accessRole?: "freeBusyReader" | "reader" | "writer" | "owner";
-}
-
-/**
- * Normalise a raw Google Calendar API event into our {@link GoogleCalendarEvent}
- * shape, stamping the source `calendarId` so cached events can be looked up by
- * calendar later.
- *
- * Exported for unit testing and for reuse by any code path that receives raw
- * Google Calendar API responses (e.g. the server-side REST fetch in
- * `src/app/api/calendar/events/route.ts`).
- */
-export function normalizeFetchedEvent(
-  event: gapi.client.calendar.Event,
-  calendarId: string
-): GoogleCalendarEvent {
-  return {
-    ...event,
-    // Google marks `summary` optional; our UI expects a string so we fall back
-    // to the empty string and let `transformGoogleEvent` substitute a label.
-    summary: event.summary ?? "",
-    calendarId,
-  };
-}
-
-/**
- * Normalise a raw `CalendarListEntry` into the slim shape consumed by the app.
- *
- * Also exported so server-side callers that fetch `calendarList.list` via
- * plain `fetch()` can reuse the same mapping without duplicating the field
- * selection.
- */
-export function normalizeCalendarListEntry(
-  entry: gapi.client.calendar.CalendarListEntry
-): UserCalendar {
-  return {
-    id: entry.id,
-    summary: entry.summary,
-    description: entry.description,
-    backgroundColor: entry.backgroundColor,
-    foregroundColor: entry.foregroundColor,
-    primary: entry.primary,
-    colorId: entry.colorId,
-    timeZone: entry.timeZone,
-    summaryOverride: entry.summaryOverride,
-    selected: entry.selected,
-    accessRole: entry.accessRole,
-  };
 }
 
 const GOOGLE_CALENDAR_CONFIG: GoogleCalendarConfig = {

--- a/src/types/gapi.d.ts
+++ b/src/types/gapi.d.ts
@@ -271,10 +271,15 @@ declare namespace gapi.client.calendar {
   /**
    * CalendarList resource entry.
    * https://developers.google.com/workspace/calendar/api/v3/reference/calendarList#resource
+   *
+   * The Google API schema does not mark `summary` as required — matching the
+   * treatment of `Event.summary` — so it is modelled as optional here. Callers
+   * that need a guaranteed string should use `normalizeCalendarListEntry`,
+   * which applies the same `?? ""` fallback used for events.
    */
   interface CalendarListEntry {
     id: string;
-    summary: string;
+    summary?: string;
     description?: string;
     location?: string;
     timeZone?: string;

--- a/src/types/gapi.d.ts
+++ b/src/types/gapi.d.ts
@@ -1,117 +1,381 @@
 /**
- * Type declarations for Google Calendar API and Google Identity Services
- * Extends the existing gapi types with calendar-specific interfaces
+ * Ambient type declarations for the Google Calendar API v3 client (`gapi`)
+ * and Google Identity Services (`google.accounts.oauth2`).
+ *
+ * These are **custom partial type definitions** maintained by this project,
+ * because:
+ *
+ *   - `@types/gapi` covers the core loader but does not include calendar-
+ *     specific interfaces.
+ *   - `@types/gapi.auth2` is for the legacy auth flow we no longer use.
+ *   - There is no official DT package for `google.accounts` Identity Services
+ *     at the time of writing.
+ *
+ * Field definitions are modelled on the public Google documentation:
+ *   - Events resource:         https://developers.google.com/workspace/calendar/api/v3/reference/events
+ *   - CalendarList resource:   https://developers.google.com/workspace/calendar/api/v3/reference/calendarList
+ *   - Events.list parameters:  https://developers.google.com/workspace/calendar/api/v3/reference/events/list
+ *   - Identity Services token: https://developers.google.com/identity/oauth2/web/reference/js-reference
+ *
+ * They are partial by design — we only declare fields the app uses or is
+ * likely to use. Index signatures (`[key: string]: unknown`) are intentionally
+ * avoided so the compiler catches typos. Extend as new fields are consumed.
  */
 
 /**
- * Google Identity Services (GIS) types for OAuth2
+ * Google Identity Services (GIS) types for the `google.accounts.oauth2`
+ * namespace. Loaded via https://accounts.google.com/gsi/client.
  */
 declare namespace google.accounts.oauth2 {
+  /** Successful or failed token response delivered to the callback. */
   interface TokenResponse {
     access_token: string;
+    /** Token lifetime in seconds (Google returns this as a string in some clients). */
     expires_in: number;
+    /** Space-delimited list of scopes granted. */
     scope: string;
     token_type: string;
+    /**
+     * Refresh token. Only provided on initial consent (`prompt: "consent"`)
+     * and when `access_type=offline` is requested server-side.
+     */
     refresh_token?: string;
+    /** Present when an error prevented the token from being issued. */
     error?: string;
     error_description?: string;
+    error_uri?: string;
+    /** State value echoed back if supplied in the request. */
+    state?: string;
   }
 
+  /** A token client used to request OAuth2 access tokens. */
   interface TokenClient {
     callback: (response: TokenResponse) => void;
     requestAccessToken: (overrideConfig?: {
       prompt?: "" | "none" | "consent" | "select_account";
+      hint?: string;
+      state?: string;
+      /** Override scopes for this specific request. */
+      scope?: string;
+      include_granted_scopes?: boolean;
+      enable_granular_consent?: boolean;
     }) => void;
   }
 
   interface TokenClientConfig {
     client_id: string;
     scope: string;
+    /**
+     * Either a callback function or an empty string placeholder. When empty,
+     * the caller must assign `tokenClient.callback` per request.
+     */
     callback: string | ((response: TokenResponse) => void);
     prompt?: "" | "none" | "consent" | "select_account";
+    hint?: string;
+    state?: string;
+    hosted_domain?: string;
+    include_granted_scopes?: boolean;
+    enable_granular_consent?: boolean;
+    error_callback?: (error: { type: string; message?: string }) => void;
   }
 
   function initTokenClient(config: TokenClientConfig): TokenClient;
   function revoke(token: string, done?: () => void): void;
+  function hasGrantedAnyScope(
+    tokenResponse: TokenResponse,
+    ...scopes: string[]
+  ): boolean;
+  function hasGrantedAllScopes(
+    tokenResponse: TokenResponse,
+    ...scopes: string[]
+  ): boolean;
 }
 
 /**
- * GAPI client types
+ * `gapi` loader and client configuration.
  */
 declare namespace gapi {
   function load(
     apiName: string,
-    options: { callback: () => void; onerror?: () => void }
+    options: { callback: () => void; onerror?: (err?: unknown) => void }
   ): void;
 
   namespace client {
+    /**
+     * Initialise the gapi client. `apiKey` and `discoveryDocs` are the
+     * common pair; `clientId`/`scope` are optional legacy parameters that
+     * some older integrations still pass.
+     */
     function init(config: {
       apiKey?: string;
       discoveryDocs?: string[];
+      clientId?: string;
+      scope?: string;
     }): Promise<void>;
 
     function getToken(): {
       access_token: string;
       expires_in?: number;
       expires_at?: number;
+      scope?: string;
+      token_type?: string;
     } | null;
 
     function setToken(token: { access_token: string } | null): void;
   }
 }
 
+/**
+ * Google Calendar API v3 resources accessed through `gapi.client.calendar`.
+ */
 declare namespace gapi.client.calendar {
+  /**
+   * Event-level attendee entry.
+   * https://developers.google.com/workspace/calendar/api/v3/reference/events#resource
+   */
+  interface EventAttendee {
+    id?: string;
+    email?: string;
+    displayName?: string;
+    organizer?: boolean;
+    self?: boolean;
+    resource?: boolean;
+    optional?: boolean;
+    responseStatus?: "needsAction" | "declined" | "tentative" | "accepted";
+    comment?: string;
+    additionalGuests?: number;
+  }
+
+  interface EventDateTime {
+    /** RFC3339 timestamp for timed events. */
+    dateTime?: string;
+    /** `YYYY-MM-DD` for all-day events. */
+    date?: string;
+    timeZone?: string;
+  }
+
+  interface EventReminderOverride {
+    method: "email" | "popup";
+    minutes: number;
+  }
+
+  interface EventReminders {
+    useDefault?: boolean;
+    overrides?: EventReminderOverride[];
+  }
+
+  interface EventSource {
+    url: string;
+    title: string;
+  }
+
+  interface EventAttachment {
+    fileUrl: string;
+    title?: string;
+    mimeType?: string;
+    iconLink?: string;
+    fileId?: string;
+  }
+
+  interface EventConferenceData {
+    conferenceId?: string;
+    conferenceSolution?: {
+      key?: { type: string };
+      name?: string;
+      iconUri?: string;
+    };
+    entryPoints?: Array<{
+      entryPointType: "video" | "phone" | "sip" | "more";
+      uri?: string;
+      label?: string;
+      meetingCode?: string;
+    }>;
+    notes?: string;
+    signature?: string;
+  }
+
+  /**
+   * Events resource.
+   * https://developers.google.com/workspace/calendar/api/v3/reference/events#resource
+   */
   interface Event {
     id: string;
-    summary: string;
+    summary?: string;
     description?: string;
-    start: {
-      dateTime?: string;
-      date?: string;
-      timeZone?: string;
-    };
-    end: {
-      dateTime?: string;
-      date?: string;
-      timeZone?: string;
-    };
+    start: EventDateTime;
+    end: EventDateTime;
+
+    /** Event-level colorId (references `calendar#colors.event`). */
     colorId?: string;
     creator?: {
+      id?: string;
       email?: string;
       displayName?: string;
+      self?: boolean;
+    };
+    organizer?: {
+      id?: string;
+      email?: string;
+      displayName?: string;
+      self?: boolean;
+    };
+
+    /** Lifecycle metadata. */
+    kind?: "calendar#event";
+    etag?: string;
+    status?: "confirmed" | "tentative" | "cancelled";
+    htmlLink?: string;
+    created?: string;
+    updated?: string;
+    iCalUID?: string;
+    sequence?: number;
+
+    /** Location + meeting metadata. */
+    location?: string;
+    hangoutLink?: string;
+    conferenceData?: EventConferenceData;
+
+    /** Visibility / scheduling flags. */
+    transparency?: "opaque" | "transparent";
+    visibility?: "default" | "public" | "private" | "confidential";
+    anyoneCanAddSelf?: boolean;
+    guestsCanInviteOthers?: boolean;
+    guestsCanModify?: boolean;
+    guestsCanSeeOtherGuests?: boolean;
+    privateCopy?: boolean;
+    locked?: boolean;
+
+    /** Attendees, reminders, recurrence. */
+    attendees?: EventAttendee[];
+    attendeesOmitted?: boolean;
+    reminders?: EventReminders;
+    recurrence?: string[];
+    recurringEventId?: string;
+    originalStartTime?: EventDateTime;
+
+    /** Extras surfaced to consumers. */
+    attachments?: EventAttachment[];
+    source?: EventSource;
+    eventType?:
+      | "default"
+      | "outOfOffice"
+      | "focusTime"
+      | "workingLocation"
+      | "fromGmail";
+    extendedProperties?: {
+      private?: Record<string, string>;
+      shared?: Record<string, string>;
     };
   }
 
+  /**
+   * CalendarList resource entry.
+   * https://developers.google.com/workspace/calendar/api/v3/reference/calendarList#resource
+   */
   interface CalendarListEntry {
     id: string;
     summary: string;
     description?: string;
+    location?: string;
+    timeZone?: string;
+    summaryOverride?: string;
+    /** Calendar-level colorId (references `calendar#colors.calendar`). */
+    colorId?: string;
     backgroundColor?: string;
     foregroundColor?: string;
+    hidden?: boolean;
+    selected?: boolean;
+    accessRole?: "freeBusyReader" | "reader" | "writer" | "owner";
     primary?: boolean;
+    deleted?: boolean;
+    defaultReminders?: EventReminderOverride[];
+    notificationSettings?: {
+      notifications?: Array<{
+        type:
+          | "eventCreation"
+          | "eventChange"
+          | "eventCancellation"
+          | "eventResponse"
+          | "agenda";
+        method: "email";
+      }>;
+    };
+    conferenceProperties?: {
+      allowedConferenceSolutionTypes?: string[];
+    };
+    kind?: "calendar#calendarListEntry";
+    etag?: string;
   }
 
+  /**
+   * Response from `events.list`.
+   * https://developers.google.com/workspace/calendar/api/v3/reference/events/list
+   */
   interface EventsListResponse {
+    kind?: "calendar#events";
+    etag?: string;
+    summary?: string;
+    description?: string;
+    updated?: string;
+    timeZone?: string;
+    accessRole?: "freeBusyReader" | "reader" | "writer" | "owner";
+    defaultReminders?: EventReminderOverride[];
+    nextPageToken?: string;
+    nextSyncToken?: string;
     items?: Event[];
   }
 
+  /** Response from `calendarList.list`. */
   interface CalendarListListResponse {
+    kind?: "calendar#calendarList";
+    etag?: string;
+    nextPageToken?: string;
+    nextSyncToken?: string;
     items?: CalendarListEntry[];
   }
 
+  /**
+   * Query parameters accepted by `events.list`.
+   * https://developers.google.com/workspace/calendar/api/v3/reference/events/list#parameters
+   */
+  interface EventsListRequest {
+    calendarId: string;
+    timeMin?: string;
+    timeMax?: string;
+    updatedMin?: string;
+    showDeleted?: boolean;
+    showHiddenInvitations?: boolean;
+    singleEvents?: boolean;
+    maxResults?: number;
+    orderBy?: "startTime" | "updated";
+    pageToken?: string;
+    syncToken?: string;
+    q?: string;
+    iCalUID?: string;
+    timeZone?: string;
+    privateExtendedProperty?: string | string[];
+    sharedExtendedProperty?: string | string[];
+    /** Partial-response field mask. */
+    fields?: string;
+    eventTypes?: Array<
+      "default" | "outOfOffice" | "focusTime" | "workingLocation" | "fromGmail"
+    >;
+  }
+
   namespace events {
-    function list(request: {
-      calendarId: string;
-      timeMin: string;
-      timeMax: string;
-      showDeleted: boolean;
-      singleEvents: boolean;
-      maxResults: number;
-      orderBy: string;
-    }): Promise<{ result: EventsListResponse }>;
+    function list(
+      request: EventsListRequest
+    ): Promise<{ result: EventsListResponse }>;
   }
 
   namespace calendarList {
-    function list(): Promise<{ result: CalendarListListResponse }>;
+    function list(request?: {
+      maxResults?: number;
+      pageToken?: string;
+      minAccessRole?: "freeBusyReader" | "reader" | "writer" | "owner";
+      showDeleted?: boolean;
+      showHidden?: boolean;
+      syncToken?: string;
+    }): Promise<{ result: CalendarListListResponse }>;
   }
 }


### PR DESCRIPTION
## Summary

Closes #76 — manually defined Google Calendar API types were incomplete.
Closes #77 — the `colorId: ""` comment in `fetchCalendarColorMappings` was ambiguous.

### What changed (two commits)

**Commit 1 — extend types and add pure mappers:**

- **`src/types/gapi.d.ts` rewritten to a documented, comprehensive partial model of the Google Calendar API v3 surface.** Additions (all cross-referenced to Google's published schema):
  - `Event`: `status`, `htmlLink`, `created`/`updated`, `iCalUID`, `etag`, `sequence`, `location`, `hangoutLink`, `conferenceData`, `transparency`/`visibility`/sharing booleans, `attendees`, `reminders`, `recurrence`/`recurringEventId`/`originalStartTime`, `attachments`, `source`, `eventType`, `extendedProperties`.
  - `CalendarListEntry`: `colorId`, `timeZone`, `summaryOverride`, `selected`, `accessRole`, `hidden`, `deleted`, `defaultReminders`, `notificationSettings`, `conferenceProperties`, `etag`.
  - `EventsListResponse` / `CalendarListListResponse`: `nextPageToken`, `nextSyncToken`, `etag`, `kind`, `updated`, `timeZone`, `accessRole`, `defaultReminders`.
  - `events.list` request: `pageToken`, `syncToken`, `q`, `iCalUID`, `updatedMin`, `timeZone`, `fields` (field mask), `eventTypes`, extended-property filters, `showHiddenInvitations`.
  - `google.accounts.oauth2`: fleshed-out `TokenResponse` (incl. `error_uri`/`state`), `TokenClient.requestAccessToken` overrides (`hint`, `scope`, `include_granted_scopes`, etc.), `hasGrantedAnyScope`/`hasGrantedAllScopes`.
  - `gapi.client.init`: accept `clientId`/`scope`; richer `getToken()` shape.
- **Pure mappers added to `src/lib/google-calendar.ts`** — `normalizeFetchedEvent` and `normalizeCalendarListEntry` — so the same normalisation logic can be reused by both the client gapi path and any server-side REST caller. `fetchCalendarEvents` and `fetchUserCalendars` now delegate to them.
- **`GoogleCalendarEvent` extended** with the new Google-v3 optional fields (all optional — no caller is forced to change). New `UserCalendar` type exported for calendar-list consumers.
- **#77 colorId comment clarified**: the `""` value is deliberate because `CalendarColorMapping.colorId` models *event-level* colorIds (`calendar#colors.event`), which calendar-list entries do not carry — we derive the color from `backgroundColor` instead.
- **Unit tests** (`src/lib/__tests__/google-calendar-mappers.test.ts`, 9 cases) exercise both mappers against realistic API payloads and assert that extended optional fields pass through.

**Commit 2 — consume canonical types in server routes:**

Previously, each of the three calendar API routes re-declared its own partial interface for Google Calendar responses:

- `src/app/api/calendar/events/route.ts` — `GoogleCalendarEvent` with a `[key: string]: unknown` index signature (defeating field-name checking) plus a `CalendarEventWithId` subtype.
- `src/app/api/calendar/calendars/route.ts` — `GoogleCalendarListItem`.
- `src/app/api/calendar/colors/route.ts` — another `GoogleCalendarListItem` (different field subset).

All three are now replaced by the shared canonical types:
- the ambient `gapi.client.calendar.Event` / `gapi.client.calendar.CalendarListEntry` from `src/types/gapi.d.ts`;
- the runtime `GoogleCalendarEvent` / `normalizeFetchedEvent` from `@/lib/google-calendar`.

The index signature that was papering over missing fields is gone — typos in event-field accesses are now compile errors. Added a regression test (`route.test.ts`) asserting extended Google Calendar v3 fields (status, location, htmlLink, iCalUID, etag, organizer, attendees, recurrence, eventType) pass through the route's serialisation.

### Why

- #76: our hand-written types are now an auditable reference — every field has a doc comment pointing to the Google schema, consumers get IntelliSense for the full surface, and typos become compile errors. Duplicate partial interfaces across the three server routes are gone.
- #77: the comment now tells the reader *why* `colorId` is empty, not just *that* it is.

### Test plan

- [x] `pnpm test` — 1021 tests pass (75 files), including the 9 new mapper tests and the new route regression test.
- [x] `pnpm check-types` — clean.
- [x] `pnpm lint:fix` / `pnpm format:fix` — clean.

No UI changes — this is a pure type/infrastructure refactor, so no Playwright coverage is added.

https://claude.ai/code/session_01Uc76r4qY2Ea7kaTsy7Ev4T