### PR TITLE
feat(http): retry with exponential backoff for transient errors (#68)

### DIFF
--- a/src/app/api/tasks/[taskId]/__tests__/route.test.ts
+++ b/src/app/api/tasks/[taskId]/__tests__/route.test.ts
@@ -37,6 +37,27 @@ vi.mock("@/lib/logger", () => ({
   },
 }));
 
+// Replace the real `sleep` inside fetchWithRetry with a no-op so transient-
+// status tests (5xx, 429) don't wait for real backoff delays.
+vi.mock("@/lib/http/retry", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/http/retry")>(
+      "@/lib/http/retry"
+    );
+  return {
+    ...actual,
+    fetchWithRetry: (
+      input: Parameters<typeof actual.fetchWithRetry>[0],
+      init?: Parameters<typeof actual.fetchWithRetry>[1],
+      options: Parameters<typeof actual.fetchWithRetry>[2] = {}
+    ) =>
+      actual.fetchWithRetry(input, init, {
+        ...options,
+        sleep: () => Promise.resolve(),
+      }),
+  };
+});
+
 // Mock global fetch
 const mockFetch = vi.fn();
 global.fetch = mockFetch;

--- a/src/app/api/tasks/[taskId]/__tests__/route.test.ts
+++ b/src/app/api/tasks/[taskId]/__tests__/route.test.ts
@@ -333,5 +333,44 @@ describe("/api/tasks/[taskId]", () => {
       expect(status).toBe(200);
       expect(data.task.status).toBe("needsAction");
     });
+
+    it("retries a transient 503 on PATCH and returns the eventual 200 (issue #68)", async () => {
+      vi.mocked(getSession).mockResolvedValue(mockSession);
+      vi.mocked(getAccessToken).mockResolvedValue(
+        mockGoogleAccount.access_token!
+      );
+
+      const updatedTask = { id: taskId, title: "Test", status: "completed" };
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 503,
+          headers: new Headers(),
+          json: () => Promise.resolve({ error: "Service Unavailable" }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(updatedTask),
+        });
+
+      const request = createMockRequest(
+        `/api/tasks/${taskId}?listId=${listId}`,
+        { method: "PATCH", body: { status: "completed" } }
+      );
+      const response = await PATCH(request, {
+        params: Promise.resolve({ taskId }),
+      });
+      const { status, data } = await parseResponse<{
+        task: typeof updatedTask;
+      }>(response);
+
+      expect(status).toBe(200);
+      expect(data.task).toEqual(updatedTask);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      // PATCH body is a string (JSON.stringify) — retry re-sends it verbatim.
+      const [[, firstInit], [, secondInit]] = mockFetch.mock.calls;
+      expect(firstInit?.body).toBe(secondInit?.body);
+      expect(firstInit?.method).toBe("PATCH");
+    });
   });
 });

--- a/src/app/api/tasks/[taskId]/route.ts
+++ b/src/app/api/tasks/[taskId]/route.ts
@@ -3,6 +3,7 @@
  * Uses server-side authentication with NextAuth.js
  */
 import { AuthError, getAccessToken, getSession } from "@/lib/auth";
+import { fetchWithRetry } from "@/lib/http/retry";
 import { logger } from "@/lib/logger";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -71,7 +72,7 @@ export async function PATCH(
 
     const accessToken = await getAccessToken();
 
-    const response = await fetch(
+    const response = await fetchWithRetry(
       `${GOOGLE_TASKS_API}/lists/${encodeURIComponent(listId)}/tasks/${encodeURIComponent(taskId)}`,
       {
         method: "PATCH",

--- a/src/app/api/tasks/__tests__/route.test.ts
+++ b/src/app/api/tasks/__tests__/route.test.ts
@@ -38,6 +38,28 @@ vi.mock("@/lib/logger", () => ({
   },
 }));
 
+// Replace the real `sleep` inside fetchWithRetry with a no-op so transient-
+// status tests (5xx, 429) don't wait for real backoff delays. All other
+// retry behaviour stays untouched.
+vi.mock("@/lib/http/retry", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/http/retry")>(
+      "@/lib/http/retry"
+    );
+  return {
+    ...actual,
+    fetchWithRetry: (
+      input: Parameters<typeof actual.fetchWithRetry>[0],
+      init?: Parameters<typeof actual.fetchWithRetry>[1],
+      options: Parameters<typeof actual.fetchWithRetry>[2] = {}
+    ) =>
+      actual.fetchWithRetry(input, init, {
+        ...options,
+        sleep: () => Promise.resolve(),
+      }),
+  };
+});
+
 // Mock global fetch
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
@@ -193,6 +215,92 @@ describe("/api/tasks", () => {
 
       expect(status).toBe(500);
       expect(data.error).toBe("An unexpected error occurred");
+    });
+
+    it("retries a transient 503 and returns the eventual 200 (issue #68)", async () => {
+      vi.mocked(getSession).mockResolvedValue(mockSession);
+      vi.mocked(getAccessToken).mockResolvedValue(
+        mockGoogleAccount.access_token!
+      );
+
+      // First two calls fail with 503; the third succeeds. The route should
+      // surface the final success, not the transient failures.
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 503,
+          headers: new Headers(),
+          json: () => Promise.resolve({ error: "Service Unavailable" }),
+        })
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 503,
+          headers: new Headers(),
+          json: () => Promise.resolve({ error: "Service Unavailable" }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ items: [{ id: "t1", title: "T1" }] }),
+        });
+
+      const request = createMockRequest("/api/tasks?listId=list-123");
+      const response = await GET(request);
+      const { status, data } = await parseResponse<{
+        tasks: { id: string; title: string }[];
+      }>(response);
+
+      expect(status).toBe(200);
+      expect(data.tasks).toHaveLength(1);
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+
+    it("retries a 429 honouring Retry-After and returns the eventual 200 (issue #68)", async () => {
+      vi.mocked(getSession).mockResolvedValue(mockSession);
+      vi.mocked(getAccessToken).mockResolvedValue(
+        mockGoogleAccount.access_token!
+      );
+
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 429,
+          headers: new Headers({ "Retry-After": "1" }),
+          json: () => Promise.resolve({ error: "rate limited" }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ items: [] }),
+        });
+
+      const request = createMockRequest("/api/tasks?listId=list-123");
+      const response = await GET(request);
+      const { status } = await parseResponse<{ tasks: unknown[] }>(response);
+
+      expect(status).toBe(200);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("does NOT retry a 401 from the upstream API (non-transient, issue #68)", async () => {
+      vi.mocked(getSession).mockResolvedValue(mockSession);
+      vi.mocked(getAccessToken).mockResolvedValue(
+        mockGoogleAccount.access_token!
+      );
+
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 401,
+        headers: new Headers(),
+        json: () => Promise.resolve({ error: "Unauthorized" }),
+      });
+
+      const request = createMockRequest("/api/tasks?listId=list-123");
+      const response = await GET(request);
+      const { status, data } = await parseResponse<ApiErrorResponse>(response);
+
+      expect(status).toBe(401);
+      expect(data.requiresReauth).toBe(true);
+      // 401 is not transient — the route must not retry.
+      expect(mockFetch).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/app/api/tasks/__tests__/route.test.ts
+++ b/src/app/api/tasks/__tests__/route.test.ts
@@ -417,5 +417,42 @@ describe("/api/tasks", () => {
       expect(status).toBe(401);
       expect(data.requiresReauth).toBe(true);
     });
+
+    it("retries a transient 503 on create and returns the eventual 201 (issue #68)", async () => {
+      vi.mocked(getSession).mockResolvedValue(mockSession);
+      vi.mocked(getAccessToken).mockResolvedValue(
+        mockGoogleAccount.access_token!
+      );
+
+      const createdTask = { id: "t1", title: "New Task" };
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 503,
+          headers: new Headers(),
+          json: () => Promise.resolve({ error: "Service Unavailable" }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(createdTask),
+        });
+
+      const request = createMockRequest("/api/tasks", {
+        method: "POST",
+        body: { listId: "list-123", title: "New Task" },
+      });
+      const response = await POST(request);
+      const { status, data } = await parseResponse<{
+        task: typeof createdTask;
+      }>(response);
+
+      expect(status).toBe(201);
+      expect(data.task).toEqual(createdTask);
+      // Both attempts carry the same JSON body string (safe to re-send).
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      const [[, firstInit], [, secondInit]] = mockFetch.mock.calls;
+      expect(firstInit?.body).toBe(secondInit?.body);
+      expect(firstInit?.method).toBe("POST");
+    });
   });
 });

--- a/src/app/api/tasks/lists/__tests__/route.test.ts
+++ b/src/app/api/tasks/lists/__tests__/route.test.ts
@@ -37,6 +37,27 @@ vi.mock("@/lib/logger", () => ({
   },
 }));
 
+// Replace the real `sleep` inside fetchWithRetry with a no-op so transient-
+// status tests (5xx, 429) don't wait for real backoff delays.
+vi.mock("@/lib/http/retry", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/http/retry")>(
+      "@/lib/http/retry"
+    );
+  return {
+    ...actual,
+    fetchWithRetry: (
+      input: Parameters<typeof actual.fetchWithRetry>[0],
+      init?: Parameters<typeof actual.fetchWithRetry>[1],
+      options: Parameters<typeof actual.fetchWithRetry>[2] = {}
+    ) =>
+      actual.fetchWithRetry(input, init, {
+        ...options,
+        sleep: () => Promise.resolve(),
+      }),
+  };
+});
+
 // Mock global fetch
 const mockFetch = vi.fn();
 global.fetch = mockFetch;

--- a/src/app/api/tasks/lists/__tests__/route.test.ts
+++ b/src/app/api/tasks/lists/__tests__/route.test.ts
@@ -172,9 +172,13 @@ describe("/api/tasks/lists", () => {
         mockGoogleAccount.access_token!
       );
 
+      // 500 is transient — retries exhaust, the final response still bubbles
+      // up through the route's !ok branch unchanged. Headers must be a real
+      // Headers instance so fetchWithRetry can read Retry-After on each pass.
       mockFetch.mockResolvedValue({
         ok: false,
         status: 500,
+        headers: new Headers(),
         json: () => Promise.resolve({ error: "Internal error" }),
       });
 
@@ -194,6 +198,53 @@ describe("/api/tasks/lists", () => {
 
       expect(status).toBe(500);
       expect(data.error).toBe("An unexpected error occurred");
+    });
+
+    it("retries a transient 503 and returns the eventual 200 (issue #68)", async () => {
+      vi.mocked(getSession).mockResolvedValue(mockSession);
+      vi.mocked(getAccessToken).mockResolvedValue(
+        mockGoogleAccount.access_token!
+      );
+
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 503,
+          headers: new Headers(),
+          json: () => Promise.resolve({ error: "Service Unavailable" }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ items: [{ id: "l1", title: "List" }] }),
+        });
+
+      const response = await GET();
+      const { status, data } = await parseResponse<{
+        lists: { id: string; title: string }[];
+      }>(response);
+
+      expect(status).toBe(200);
+      expect(data.lists).toHaveLength(1);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("does NOT retry a 401 from upstream (non-transient, issue #68)", async () => {
+      vi.mocked(getSession).mockResolvedValue(mockSession);
+      vi.mocked(getAccessToken).mockResolvedValue(
+        mockGoogleAccount.access_token!
+      );
+
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 401,
+        headers: new Headers(),
+        json: () => Promise.resolve({ error: "Unauthorized" }),
+      });
+
+      const response = await GET();
+      await parseResponse<ApiErrorResponse>(response);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/app/api/tasks/lists/route.ts
+++ b/src/app/api/tasks/lists/route.ts
@@ -3,6 +3,7 @@
  * Uses server-side authentication with NextAuth.js
  */
 import { AuthError, getAccessToken, getSession } from "@/lib/auth";
+import { fetchWithRetry } from "@/lib/http/retry";
 import { logger } from "@/lib/logger";
 import { NextResponse } from "next/server";
 
@@ -30,12 +31,15 @@ export async function GET() {
 
     const accessToken = await getAccessToken();
 
-    const response = await fetch(`${GOOGLE_TASKS_API}/users/@me/lists`, {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        "Content-Type": "application/json",
-      },
-    });
+    const response = await fetchWithRetry(
+      `${GOOGLE_TASKS_API}/users/@me/lists`,
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          "Content-Type": "application/json",
+        },
+      }
+    );
 
     if (!response.ok) {
       const errorData = await response.json().catch(() => ({}));

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -3,6 +3,7 @@
  * Uses server-side authentication with NextAuth.js
  */
 import { AuthError, getAccessToken, getSession } from "@/lib/auth";
+import { fetchWithRetry } from "@/lib/http/retry";
 import { logger } from "@/lib/logger";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -53,7 +54,7 @@ export async function GET(request: NextRequest) {
     apiUrl.searchParams.set("maxResults", maxResults);
     apiUrl.searchParams.set("showCompleted", String(showCompleted));
 
-    const response = await fetch(apiUrl.toString(), {
+    const response = await fetchWithRetry(apiUrl.toString(), {
       headers: {
         Authorization: `Bearer ${accessToken}`,
         "Content-Type": "application/json",
@@ -150,7 +151,7 @@ export async function POST(request: NextRequest) {
 
     const accessToken = await getAccessToken();
 
-    const response = await fetch(
+    const response = await fetchWithRetry(
       `${GOOGLE_TASKS_API}/lists/${encodeURIComponent(listId)}/tasks`,
       {
         method: "POST",

--- a/src/lib/http/__tests__/retry.test.ts
+++ b/src/lib/http/__tests__/retry.test.ts
@@ -1,0 +1,585 @@
+/**
+ * Tests for the retry-with-backoff utility used to harden outbound HTTP calls
+ * against transient failures (see issue #68).
+ *
+ * All tests use deterministic `random` / `now` / `sleep` overrides so they
+ * run without real timers and without flakiness.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  HttpRetryError,
+  computeBackoffDelay,
+  fetchWithRetry,
+  isTransientHttpError,
+  parseRetryAfter,
+  withRetry,
+} from "../retry";
+
+/** Returns a sleep stub that records the delays it was asked to wait for. */
+function createSleep() {
+  const delays: number[] = [];
+  const sleep = vi.fn((ms: number) => {
+    delays.push(ms);
+    return Promise.resolve();
+  });
+  return { sleep, delays };
+}
+
+/** Deterministic "random" that always returns the midpoint of [0, 1). */
+const midpointRandom = () => 0.5;
+
+describe("parseRetryAfter", () => {
+  it("returns null for null / undefined / empty inputs", () => {
+    expect(parseRetryAfter(null)).toBeNull();
+    expect(parseRetryAfter(undefined)).toBeNull();
+    expect(parseRetryAfter("")).toBeNull();
+    expect(parseRetryAfter("   ")).toBeNull();
+  });
+
+  it("parses delay-seconds (integer) into milliseconds", () => {
+    expect(parseRetryAfter("0")).toBe(0);
+    expect(parseRetryAfter("5")).toBe(5000);
+    expect(parseRetryAfter("120")).toBe(120_000);
+  });
+
+  it("parses a delay with surrounding whitespace", () => {
+    expect(parseRetryAfter("   7   ")).toBe(7000);
+  });
+
+  it("returns null for negative or non-numeric non-date strings", () => {
+    expect(parseRetryAfter("-5")).toBeNull();
+    expect(parseRetryAfter("soon")).toBeNull();
+    expect(parseRetryAfter("5.5")).toBeNull();
+  });
+
+  it("parses an HTTP-date relative to `now`", () => {
+    const now = () => new Date("2026-04-22T12:00:00Z").getTime();
+    const tenSecondsFromNow = new Date("2026-04-22T12:00:10Z").toUTCString();
+    expect(parseRetryAfter(tenSecondsFromNow, now)).toBe(10_000);
+  });
+
+  it("clamps HTTP-dates in the past to 0", () => {
+    const now = () => new Date("2026-04-22T12:00:00Z").getTime();
+    const oneMinuteAgo = new Date("2026-04-22T11:59:00Z").toUTCString();
+    expect(parseRetryAfter(oneMinuteAgo, now)).toBe(0);
+  });
+
+  it("returns null for invalid date strings", () => {
+    expect(parseRetryAfter("not-a-date at all")).toBeNull();
+  });
+});
+
+describe("isTransientHttpError", () => {
+  it("treats 429 as transient", () => {
+    expect(isTransientHttpError(new HttpRetryError(429, null))).toBe(true);
+  });
+
+  it("treats 5xx as transient", () => {
+    expect(isTransientHttpError(new HttpRetryError(500, null))).toBe(true);
+    expect(isTransientHttpError(new HttpRetryError(502, null))).toBe(true);
+    expect(isTransientHttpError(new HttpRetryError(503, null))).toBe(true);
+    expect(isTransientHttpError(new HttpRetryError(599, null))).toBe(true);
+  });
+
+  it("treats non-429 4xx as NOT transient (don't mask auth/validation bugs)", () => {
+    expect(isTransientHttpError(new HttpRetryError(400, null))).toBe(false);
+    expect(isTransientHttpError(new HttpRetryError(401, null))).toBe(false);
+    expect(isTransientHttpError(new HttpRetryError(403, null))).toBe(false);
+    expect(isTransientHttpError(new HttpRetryError(404, null))).toBe(false);
+  });
+
+  it("treats network errors (TypeError from fetch) as transient", () => {
+    // `fetch` throws TypeError for DNS / TCP / CORS / abort-free network failures.
+    expect(isTransientHttpError(new TypeError("fetch failed"))).toBe(true);
+  });
+
+  it("does not treat AbortError as transient (caller requested abort)", () => {
+    const abortError = Object.assign(new Error("aborted"), {
+      name: "AbortError",
+    });
+    expect(isTransientHttpError(abortError)).toBe(false);
+  });
+
+  it("returns false for non-error values", () => {
+    expect(isTransientHttpError(undefined)).toBe(false);
+    expect(isTransientHttpError(null)).toBe(false);
+    expect(isTransientHttpError("boom")).toBe(false);
+    expect(isTransientHttpError(42)).toBe(false);
+  });
+});
+
+describe("computeBackoffDelay", () => {
+  it("grows exponentially with attempt number (jitter: 'none')", () => {
+    const opts = {
+      baseDelayMs: 100,
+      factor: 2,
+      maxDelayMs: 10_000,
+      jitter: "none" as const,
+      random: midpointRandom,
+    };
+    expect(computeBackoffDelay(1, opts)).toBe(100);
+    expect(computeBackoffDelay(2, opts)).toBe(200);
+    expect(computeBackoffDelay(3, opts)).toBe(400);
+    expect(computeBackoffDelay(4, opts)).toBe(800);
+  });
+
+  it("caps delay at `maxDelayMs`", () => {
+    const opts = {
+      baseDelayMs: 1000,
+      factor: 10,
+      maxDelayMs: 3000,
+      jitter: "none" as const,
+      random: midpointRandom,
+    };
+    expect(computeBackoffDelay(1, opts)).toBe(1000);
+    expect(computeBackoffDelay(2, opts)).toBe(3000);
+    expect(computeBackoffDelay(5, opts)).toBe(3000);
+  });
+
+  it("applies full jitter within [0, base] using the injected random source", () => {
+    const opts = {
+      baseDelayMs: 100,
+      factor: 2,
+      maxDelayMs: 10_000,
+      jitter: "full" as const,
+      random: () => 0.25,
+    };
+    // attempt 1: uniform in [0, 100) — random=0.25 → 25
+    // attempt 2: uniform in [0, 200) — random=0.25 → 50
+    expect(computeBackoffDelay(1, opts)).toBe(25);
+    expect(computeBackoffDelay(2, opts)).toBe(50);
+  });
+
+  it("prefers retryAfterMs over the backoff value when provided", () => {
+    const opts = {
+      baseDelayMs: 100,
+      factor: 2,
+      maxDelayMs: 10_000,
+      jitter: "none" as const,
+      random: midpointRandom,
+    };
+    expect(computeBackoffDelay(1, opts, 2500)).toBe(2500);
+  });
+
+  it("caps retryAfterMs at maxDelayMs", () => {
+    const opts = {
+      baseDelayMs: 100,
+      factor: 2,
+      maxDelayMs: 3000,
+      jitter: "none" as const,
+      random: midpointRandom,
+    };
+    expect(computeBackoffDelay(1, opts, 60_000)).toBe(3000);
+  });
+
+  it("clamps retryAfterMs at 0 (never negative)", () => {
+    const opts = {
+      baseDelayMs: 100,
+      factor: 2,
+      maxDelayMs: 3000,
+      jitter: "none" as const,
+      random: midpointRandom,
+    };
+    expect(computeBackoffDelay(1, opts, -50)).toBe(0);
+  });
+});
+
+describe("withRetry", () => {
+  it("returns the value on first success without calling sleep", async () => {
+    const { sleep, delays } = createSleep();
+    const fn = vi.fn().mockResolvedValue("ok");
+
+    const result = await withRetry(fn, { sleep, random: midpointRandom });
+
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith(1);
+    expect(delays).toEqual([]);
+  });
+
+  it("retries transient errors up to maxAttempts, then throws the final error", async () => {
+    const { sleep, delays } = createSleep();
+    const transient = new HttpRetryError(500, null);
+    const fn = vi.fn().mockRejectedValue(transient);
+
+    await expect(
+      withRetry(fn, {
+        maxAttempts: 3,
+        baseDelayMs: 10,
+        factor: 2,
+        jitter: "none",
+        sleep,
+        random: midpointRandom,
+      })
+    ).rejects.toBe(transient);
+
+    expect(fn).toHaveBeenCalledTimes(3);
+    // Two sleeps: between attempt 1→2 and 2→3. Not after the final failure.
+    expect(delays).toEqual([10, 20]);
+  });
+
+  it("does not retry non-transient errors", async () => {
+    const { sleep, delays } = createSleep();
+    const nonTransient = new HttpRetryError(404, null);
+    const fn = vi.fn().mockRejectedValue(nonTransient);
+
+    await expect(withRetry(fn, { sleep, random: midpointRandom })).rejects.toBe(
+      nonTransient
+    );
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(delays).toEqual([]);
+  });
+
+  it("respects a custom shouldRetry predicate", async () => {
+    const { sleep } = createSleep();
+    const err = new Error("always retry");
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(err)
+      .mockRejectedValueOnce(err)
+      .mockResolvedValue("ok");
+
+    const result = await withRetry(fn, {
+      maxAttempts: 4,
+      shouldRetry: () => true,
+      baseDelayMs: 1,
+      jitter: "none",
+      sleep,
+      random: midpointRandom,
+    });
+
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it("succeeds on a retry after transient failures", async () => {
+    const { sleep } = createSleep();
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new HttpRetryError(503, null))
+      .mockResolvedValue("recovered");
+
+    const result = await withRetry(fn, {
+      maxAttempts: 3,
+      baseDelayMs: 1,
+      jitter: "none",
+      sleep,
+      random: midpointRandom,
+    });
+
+    expect(result).toBe("recovered");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("invokes onRetry with attempt / delay / error metadata", async () => {
+    const { sleep } = createSleep();
+    const onRetry = vi.fn();
+    const err = new HttpRetryError(500, null);
+    const fn = vi.fn().mockRejectedValueOnce(err).mockResolvedValue("ok");
+
+    await withRetry(fn, {
+      maxAttempts: 3,
+      baseDelayMs: 100,
+      factor: 2,
+      jitter: "none",
+      onRetry,
+      sleep,
+      random: midpointRandom,
+    });
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(onRetry).toHaveBeenCalledWith({
+      attempt: 1,
+      delayMs: 100,
+      error: err,
+      retryAfterMs: null,
+    });
+  });
+
+  it("honours retryAfterMs from an HttpRetryError (caps at maxDelayMs)", async () => {
+    const { sleep, delays } = createSleep();
+    const err = new HttpRetryError(429, 2500);
+    const fn = vi.fn().mockRejectedValueOnce(err).mockResolvedValue("ok");
+
+    await withRetry(fn, {
+      maxAttempts: 3,
+      baseDelayMs: 100,
+      factor: 2,
+      maxDelayMs: 10_000,
+      jitter: "full",
+      sleep,
+      random: midpointRandom,
+    });
+
+    expect(delays).toEqual([2500]);
+  });
+
+  it("throws immediately when the AbortSignal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const fn = vi.fn();
+
+    await expect(
+      withRetry(fn, { signal: controller.signal })
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it("stops retrying once the signal is aborted between attempts", async () => {
+    const controller = new AbortController();
+    const { sleep } = createSleep();
+    const err = new HttpRetryError(500, null);
+    const fn = vi.fn(async (attempt: number) => {
+      if (attempt === 1) {
+        // Abort after the first failure but before the second attempt.
+        controller.abort();
+      }
+      throw err;
+    });
+
+    await expect(
+      withRetry(fn, {
+        maxAttempts: 5,
+        baseDelayMs: 1,
+        jitter: "none",
+        signal: controller.signal,
+        sleep,
+        random: midpointRandom,
+      })
+    ).rejects.toMatchObject({ name: "AbortError" });
+
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("defaults maxAttempts to 3 (one initial + two retries)", async () => {
+    const { sleep } = createSleep();
+    const err = new HttpRetryError(503, null);
+    const fn = vi.fn().mockRejectedValue(err);
+
+    await expect(
+      withRetry(fn, { baseDelayMs: 1, jitter: "none", sleep })
+    ).rejects.toBe(err);
+
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe("fetchWithRetry", () => {
+  let originalFetch: typeof fetch;
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    mockFetch = vi.fn();
+    global.fetch = mockFetch as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  const okResponse = (body: unknown = {}) =>
+    new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+
+  const errorResponse = (
+    status: number,
+    body: unknown = {},
+    headers: Record<string, string> = {}
+  ) =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json", ...headers },
+    });
+
+  it("returns the first ok response without retrying", async () => {
+    mockFetch.mockResolvedValueOnce(okResponse({ items: ["a"] }));
+    const { sleep, delays } = createSleep();
+
+    const response = await fetchWithRetry("https://example.com/x", undefined, {
+      sleep,
+      random: midpointRandom,
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ items: ["a"] });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(delays).toEqual([]);
+  });
+
+  it("returns a non-transient !ok response without retrying (e.g. 401)", async () => {
+    mockFetch.mockResolvedValueOnce(errorResponse(401, { error: "auth" }));
+    const { sleep, delays } = createSleep();
+
+    const response = await fetchWithRetry("https://example.com/x", undefined, {
+      sleep,
+      random: midpointRandom,
+    });
+
+    expect(response.status).toBe(401);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(delays).toEqual([]);
+  });
+
+  it("retries transient 5xx responses and returns the eventual ok response", async () => {
+    mockFetch
+      .mockResolvedValueOnce(errorResponse(503))
+      .mockResolvedValueOnce(errorResponse(502))
+      .mockResolvedValueOnce(okResponse({ ok: true }));
+    const { sleep, delays } = createSleep();
+
+    const response = await fetchWithRetry("https://example.com/x", undefined, {
+      maxAttempts: 3,
+      baseDelayMs: 10,
+      factor: 2,
+      jitter: "none",
+      sleep,
+      random: midpointRandom,
+    });
+
+    expect(response.status).toBe(200);
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    expect(delays).toEqual([10, 20]);
+  });
+
+  it("honours Retry-After on 429 responses", async () => {
+    mockFetch
+      .mockResolvedValueOnce(errorResponse(429, {}, { "Retry-After": "2" }))
+      .mockResolvedValueOnce(okResponse());
+    const { sleep, delays } = createSleep();
+
+    await fetchWithRetry("https://example.com/x", undefined, {
+      maxAttempts: 2,
+      baseDelayMs: 100,
+      maxDelayMs: 10_000,
+      jitter: "full",
+      sleep,
+      random: midpointRandom,
+    });
+
+    expect(delays).toEqual([2000]);
+  });
+
+  it("returns the last transient response if every retry also fails", async () => {
+    const finalResponse = errorResponse(503, { error: "still broken" });
+    mockFetch
+      .mockResolvedValueOnce(errorResponse(503))
+      .mockResolvedValueOnce(errorResponse(503))
+      .mockResolvedValueOnce(finalResponse);
+    const { sleep } = createSleep();
+
+    const response = await fetchWithRetry("https://example.com/x", undefined, {
+      maxAttempts: 3,
+      baseDelayMs: 1,
+      jitter: "none",
+      sleep,
+      random: midpointRandom,
+    });
+
+    // Caller still sees a Response with status 503 so their `if (!ok)` branch
+    // runs as before — retry is invisible to downstream error handling.
+    expect(response.status).toBe(503);
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it("retries when fetch itself throws a network error", async () => {
+    mockFetch
+      .mockRejectedValueOnce(new TypeError("fetch failed"))
+      .mockResolvedValueOnce(okResponse());
+    const { sleep } = createSleep();
+
+    const response = await fetchWithRetry("https://example.com/x", undefined, {
+      maxAttempts: 2,
+      baseDelayMs: 1,
+      jitter: "none",
+      sleep,
+      random: midpointRandom,
+    });
+
+    expect(response.status).toBe(200);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-throws a thrown network error after exhausting retries", async () => {
+    const netError = new TypeError("fetch failed");
+    mockFetch.mockRejectedValue(netError);
+    const { sleep } = createSleep();
+
+    await expect(
+      fetchWithRetry("https://example.com/x", undefined, {
+        maxAttempts: 2,
+        baseDelayMs: 1,
+        jitter: "none",
+        sleep,
+        random: midpointRandom,
+      })
+    ).rejects.toBe(netError);
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("threads an AbortSignal through to fetch", async () => {
+    mockFetch.mockResolvedValueOnce(okResponse());
+    const controller = new AbortController();
+    const { sleep } = createSleep();
+
+    await fetchWithRetry(
+      "https://example.com/x",
+      { method: "GET" },
+      {
+        signal: controller.signal,
+        sleep,
+        random: midpointRandom,
+      }
+    );
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://example.com/x",
+      expect.objectContaining({ signal: controller.signal })
+    );
+  });
+
+  it("does not clobber a pre-existing init.signal (caller signal wins)", async () => {
+    // If a caller passes their own signal via `init`, we keep it as-is. Merging
+    // two signals into one requires AbortSignal.any, which is available in
+    // Node 20+ but not universally, so the simpler contract is: caller's
+    // init.signal overrides options.signal.
+    mockFetch.mockResolvedValueOnce(okResponse());
+    const innerController = new AbortController();
+    const outerController = new AbortController();
+    const { sleep } = createSleep();
+
+    await fetchWithRetry(
+      "https://example.com/x",
+      { method: "GET", signal: innerController.signal },
+      {
+        signal: outerController.signal,
+        sleep,
+        random: midpointRandom,
+      }
+    );
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://example.com/x",
+      expect.objectContaining({ signal: innerController.signal })
+    );
+  });
+});
+
+describe("HttpRetryError", () => {
+  it("captures status and retryAfterMs for callers to inspect", () => {
+    const err = new HttpRetryError(503, 1500, "custom");
+    expect(err.name).toBe("HttpRetryError");
+    expect(err.status).toBe(503);
+    expect(err.retryAfterMs).toBe(1500);
+    expect(err.message).toContain("custom");
+  });
+
+  it("defaults message based on status", () => {
+    const err = new HttpRetryError(429, 500);
+    expect(err.message).toMatch(/429/);
+  });
+});

--- a/src/lib/http/__tests__/retry.test.ts
+++ b/src/lib/http/__tests__/retry.test.ts
@@ -89,8 +89,30 @@ describe("isTransientHttpError", () => {
   });
 
   it("treats network errors (TypeError from fetch) as transient", () => {
-    // `fetch` throws TypeError for DNS / TCP / CORS / abort-free network failures.
+    // `fetch` throws TypeError for DNS / TCP / CORS / abort-free network
+    // failures. Node emits "fetch failed", Chrome "Failed to fetch", Firefox
+    // "NetworkError when attempting to fetch resource" — all contain "fetch".
     expect(isTransientHttpError(new TypeError("fetch failed"))).toBe(true);
+    expect(isTransientHttpError(new TypeError("Failed to fetch"))).toBe(true);
+    expect(
+      isTransientHttpError(
+        new TypeError("NetworkError when attempting to fetch resource.")
+      )
+    ).toBe(true);
+  });
+
+  it("does NOT treat programming TypeErrors (bad URL / bad header) as transient", () => {
+    // Regression guard for review feedback: `fetch` also throws TypeError for
+    // synchronous programming errors — invalid URLs, malformed header values.
+    // Those are bugs, not transient failures; retrying wastes quota and masks
+    // the defect.
+    expect(isTransientHttpError(new TypeError("Invalid URL"))).toBe(false);
+    expect(
+      isTransientHttpError(new TypeError("Header value contains invalid bytes"))
+    ).toBe(false);
+    expect(isTransientHttpError(new TypeError("foo is not a function"))).toBe(
+      false
+    );
   });
 
   it("does not treat AbortError as transient (caller requested abort)", () => {
@@ -540,6 +562,64 @@ describe("fetchWithRetry", () => {
       "https://example.com/x",
       expect.objectContaining({ signal: controller.signal })
     );
+  });
+
+  it("re-throws a network error even when a prior attempt returned a transient response (no stale fallback)", async () => {
+    // Regression guard for review feedback: if attempts mix transient 5xx
+    // responses and network failures and the FINAL attempt throws a network
+    // error, `fetchWithRetry` must surface the thrown error — not the stale
+    // Response object left over from an earlier transient attempt.
+    const netError = new TypeError("fetch failed");
+    mockFetch
+      .mockResolvedValueOnce(errorResponse(503))
+      .mockRejectedValueOnce(netError)
+      .mockRejectedValueOnce(netError);
+    const { sleep } = createSleep();
+
+    await expect(
+      fetchWithRetry("https://example.com/x", undefined, {
+        maxAttempts: 3,
+        baseDelayMs: 1,
+        jitter: "none",
+        sleep,
+        random: midpointRandom,
+      })
+    ).rejects.toBe(netError);
+
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it("clones a Request input before retrying (body stream is single-shot)", async () => {
+    // A Request body is a ReadableStream that is consumed on the first fetch.
+    // Retrying with the same Request would send an empty body. `fetchWithRetry`
+    // must clone per attempt.
+    const request = new Request("https://example.com/x", {
+      method: "POST",
+      headers: { "Content-Type": "text/plain" },
+      body: "payload",
+    });
+
+    mockFetch
+      .mockResolvedValueOnce(errorResponse(503))
+      .mockResolvedValueOnce(okResponse());
+    const { sleep } = createSleep();
+
+    await fetchWithRetry(request, undefined, {
+      maxAttempts: 2,
+      baseDelayMs: 1,
+      jitter: "none",
+      sleep,
+      random: midpointRandom,
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    // Each call must receive a distinct Request instance so body reads
+    // succeed on the retry.
+    const firstArg = mockFetch.mock.calls[0]![0];
+    const secondArg = mockFetch.mock.calls[1]![0];
+    expect(firstArg).toBeInstanceOf(Request);
+    expect(secondArg).toBeInstanceOf(Request);
+    expect(firstArg).not.toBe(secondArg);
   });
 
   it("does not clobber a pre-existing init.signal (caller signal wins)", async () => {

--- a/src/lib/http/retry.ts
+++ b/src/lib/http/retry.ts
@@ -1,0 +1,313 @@
+/**
+ * Retry-with-backoff utility for outbound HTTP calls.
+ *
+ * Addresses the first bullet of issue #68 — transient network failures and
+ * rate-limited (429) / overloaded (5xx) responses against Google's APIs were
+ * bubbling straight to the user as one-shot errors. This module adds:
+ *
+ *   - {@link withRetry} — a generic retry wrapper around any async function
+ *   - {@link fetchWithRetry} — a drop-in replacement for `fetch` that retries
+ *     transient HTTP failures and leaves non-transient responses (401, 404,
+ *     etc.) alone for the caller to handle exactly as before
+ *   - {@link isTransientHttpError} — classifier used by the default retry
+ *     predicate
+ *   - {@link parseRetryAfter} — parses `Retry-After` in both seconds and
+ *     HTTP-date form
+ *
+ * All timing primitives (`sleep`, `now`, `random`) are injectable so the unit
+ * tests can exercise every branch deterministically without real timers.
+ */
+
+const DEFAULT_MAX_ATTEMPTS = 3;
+const DEFAULT_BASE_DELAY_MS = 300;
+const DEFAULT_MAX_DELAY_MS = 5_000;
+const DEFAULT_FACTOR = 2;
+
+export type JitterMode = "none" | "full";
+
+export interface BackoffOptions {
+  /** Initial delay before the second attempt, in ms. */
+  baseDelayMs?: number;
+  /** Hard ceiling on any computed delay (including Retry-After). */
+  maxDelayMs?: number;
+  /** Exponential factor applied per attempt. */
+  factor?: number;
+  /** "full" spreads delays uniformly in [0, base*factor^(n-1)]. */
+  jitter?: JitterMode;
+  /** RNG used for jitter — override in tests for determinism. */
+  random?: () => number;
+}
+
+export interface RetryAttemptInfo {
+  attempt: number;
+  delayMs: number;
+  error: unknown;
+  retryAfterMs: number | null;
+}
+
+export interface RetryOptions extends BackoffOptions {
+  /** Total attempts INCLUDING the first one. Defaults to 3. */
+  maxAttempts?: number;
+  /** Returns true if the error/attempt combination should trigger a retry. */
+  shouldRetry?: (error: unknown, attempt: number) => boolean;
+  /** Observer invoked immediately before each retry's sleep. */
+  onRetry?: (info: RetryAttemptInfo) => void;
+  /** Aborts the retry loop; honours both pre-armed and in-flight aborts. */
+  signal?: AbortSignal;
+  /** Sleep primitive — override in tests. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+/**
+ * Typed error raised when a response's HTTP status warrants a retry. Callers
+ * of {@link fetchWithRetry} should never see this — it is used internally to
+ * thread retry information (status + parsed Retry-After) through the retry
+ * loop, and to give {@link isTransientHttpError} a structured signal.
+ */
+export class HttpRetryError extends Error {
+  readonly status: number;
+  readonly retryAfterMs: number | null;
+
+  constructor(status: number, retryAfterMs: number | null, message?: string) {
+    super(message ?? `HTTP ${status}`);
+    this.name = "HttpRetryError";
+    this.status = status;
+    this.retryAfterMs = retryAfterMs;
+  }
+}
+
+const resolvedBackoffDefaults = (opts: BackoffOptions) => ({
+  baseDelayMs: opts.baseDelayMs ?? DEFAULT_BASE_DELAY_MS,
+  maxDelayMs: opts.maxDelayMs ?? DEFAULT_MAX_DELAY_MS,
+  factor: opts.factor ?? DEFAULT_FACTOR,
+  jitter: opts.jitter ?? "full",
+  random: opts.random ?? Math.random,
+});
+
+/**
+ * Classifies whether an error (or an {@link HttpRetryError}) is worth
+ * retrying. Intentionally strict: only 429, 5xx, and low-level network errors
+ * (`TypeError` thrown by `fetch`) are considered transient. Non-429 4xx
+ * responses — auth failures, validation errors, not-found — are treated as
+ * permanent so retries never mask real bugs.
+ */
+export function isTransientHttpError(error: unknown): boolean {
+  if (error instanceof HttpRetryError) {
+    if (error.status === 429) return true;
+    return error.status >= 500 && error.status < 600;
+  }
+  // `fetch` throws TypeError for DNS / TCP / CORS / offline failures. Abort is
+  // explicitly NOT transient — the caller asked to stop.
+  if (error instanceof TypeError) return true;
+  if (
+    error instanceof Error &&
+    (error.name === "AbortError" || error.name === "TimeoutError")
+  ) {
+    return false;
+  }
+  return false;
+}
+
+/**
+ * Parse a `Retry-After` header into milliseconds.
+ *
+ *  - `"5"` → 5000
+ *  - `"Wed, 21 Oct 2026 07:28:00 GMT"` → ms-until-that-date (clamped at 0)
+ *  - negative / malformed / empty → `null`
+ */
+export function parseRetryAfter(
+  header: string | null | undefined,
+  now: () => number = Date.now
+): number | null {
+  if (header == null) return null;
+  const trimmed = header.trim();
+  if (trimmed.length === 0) return null;
+
+  // Delay-seconds: must be a non-negative integer. Reject fractional seconds
+  // so we don't silently truncate (the spec only permits integer seconds).
+  if (/^\d+$/.test(trimmed)) {
+    const seconds = Number.parseInt(trimmed, 10);
+    return seconds * 1000;
+  }
+
+  // HTTP-date per RFC 7231 always contains a weekday abbreviation — require
+  // at least one alphabetic character so things like "-5" or "5.5" don't
+  // fall into `Date.parse`, which happily accepts "-5" as year -5.
+  if (!/[A-Za-z]/.test(trimmed)) return null;
+  const parsed = Date.parse(trimmed);
+  if (Number.isNaN(parsed)) return null;
+  const delta = parsed - now();
+  return delta > 0 ? delta : 0;
+}
+
+/**
+ * Compute the delay before the next attempt. `retryAfterMs`, when provided,
+ * overrides the exponential backoff but is still clamped by `maxDelayMs`.
+ * Exposed for unit testing of the delay math in isolation.
+ */
+export function computeBackoffDelay(
+  attempt: number,
+  options: BackoffOptions,
+  retryAfterMs: number | null = null
+): number {
+  const { baseDelayMs, maxDelayMs, factor, jitter, random } =
+    resolvedBackoffDefaults(options);
+
+  if (retryAfterMs != null) {
+    if (retryAfterMs < 0) return 0;
+    return Math.min(retryAfterMs, maxDelayMs);
+  }
+
+  const exp = baseDelayMs * Math.pow(factor, Math.max(0, attempt - 1));
+  const capped = Math.min(exp, maxDelayMs);
+
+  if (jitter === "full") {
+    return Math.floor(random() * capped);
+  }
+  return capped;
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  if (ms <= 0) return Promise.resolve();
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function abortError(): Error {
+  // DOMException isn't guaranteed in every runtime; a plain Error with
+  // `name: "AbortError"` is what the Web `fetch` spec surfaces and what
+  // callers are likely to check.
+  const err = new Error("The operation was aborted");
+  err.name = "AbortError";
+  return err;
+}
+
+function extractRetryAfterMs(error: unknown): number | null {
+  if (error instanceof HttpRetryError) return error.retryAfterMs;
+  return null;
+}
+
+/**
+ * Retry `fn` with exponential backoff + jitter when it throws a transient
+ * error. The function receives the 1-indexed `attempt` number so callers can
+ * log or adapt on retry.
+ *
+ * Callers that want to retry every failure (e.g. a test helper) can pass a
+ * permissive `shouldRetry: () => true`.
+ */
+export async function withRetry<T>(
+  fn: (attempt: number) => Promise<T>,
+  options: RetryOptions = {}
+): Promise<T> {
+  const maxAttempts = options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+  const shouldRetry = options.shouldRetry ?? isTransientHttpError;
+  const sleep = options.sleep ?? defaultSleep;
+  const { signal, onRetry } = options;
+
+  if (signal?.aborted) throw abortError();
+
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await fn(attempt);
+    } catch (error) {
+      lastError = error;
+
+      if (signal?.aborted) throw abortError();
+      if (attempt >= maxAttempts) throw error;
+      if (!shouldRetry(error, attempt)) throw error;
+
+      const retryAfterMs = extractRetryAfterMs(error);
+      const delayMs = computeBackoffDelay(attempt, options, retryAfterMs);
+
+      onRetry?.({ attempt, delayMs, error, retryAfterMs });
+
+      await sleep(delayMs);
+
+      if (signal?.aborted) throw abortError();
+    }
+  }
+
+  // Unreachable: the loop either returns or throws. Rethrow the last seen
+  // error as a safety net for future refactors.
+  throw lastError;
+}
+
+/**
+ * `fetch` wrapper that retries transient failures (429 / 5xx / network) and
+ * returns non-transient responses (200s, 401, 404, ...) untouched. The caller
+ * keeps full control of its `!response.ok` branch — retry is invisible to
+ * downstream error handling.
+ *
+ * Signal precedence: if `init.signal` is provided it wins, because merging
+ * two signals requires `AbortSignal.any` (Node 20+) and we want one simple
+ * contract. If `init.signal` is absent and `options.signal` is provided, the
+ * outer signal is threaded through.
+ */
+export async function fetchWithRetry(
+  input: Parameters<typeof fetch>[0],
+  init?: Parameters<typeof fetch>[1],
+  options: RetryOptions = {}
+): Promise<Response> {
+  const effectiveInit: RequestInit = {
+    ...(init ?? {}),
+  };
+  if (!effectiveInit.signal && options.signal) {
+    effectiveInit.signal = options.signal;
+  }
+
+  const maxAttempts = options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+
+  let lastResponse: Response | undefined;
+
+  try {
+    await withRetry<Response>(async (attempt) => {
+      const response = await fetch(input, effectiveInit);
+      if (response.ok || !shouldRetryResponse(response)) {
+        lastResponse = response;
+        return response;
+      }
+
+      lastResponse = response;
+
+      if (attempt >= maxAttempts) {
+        // Out of budget: return the response so the caller's existing
+        // !ok branch runs just like before retry existed.
+        return response;
+      }
+
+      const retryAfterMs = parseRetryAfter(response.headers.get("Retry-After"));
+      throw new HttpRetryError(
+        response.status,
+        retryAfterMs,
+        `HTTP ${response.status} from ${safeUrl(input)}`
+      );
+    }, options);
+  } catch (error) {
+    // If the final attempt produced a transient Response we want to surface
+    // it rather than throw — matches the pre-retry contract. A thrown
+    // network error, by contrast, must propagate.
+    if (lastResponse && !lastResponse.ok && shouldRetryResponse(lastResponse)) {
+      return lastResponse;
+    }
+    throw error;
+  }
+
+  if (!lastResponse) {
+    // Unreachable: `withRetry` either resolves (setting lastResponse) or
+    // throws. Guard the type narrowing anyway.
+    throw new Error("fetchWithRetry: no response produced");
+  }
+  return lastResponse;
+}
+
+function shouldRetryResponse(response: Response): boolean {
+  if (response.ok) return false;
+  return response.status === 429 || response.status >= 500;
+}
+
+function safeUrl(input: Parameters<typeof fetch>[0]): string {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.toString();
+  if (input instanceof Request) return input.url;
+  return "<request>";
+}

--- a/src/lib/http/retry.ts
+++ b/src/lib/http/retry.ts
@@ -96,15 +96,20 @@ export function isTransientHttpError(error: unknown): boolean {
     if (error.status === 429) return true;
     return error.status >= 500 && error.status < 600;
   }
-  // `fetch` throws TypeError for DNS / TCP / CORS / offline failures. Abort is
-  // explicitly NOT transient — the caller asked to stop.
-  if (error instanceof TypeError) return true;
   if (
     error instanceof Error &&
     (error.name === "AbortError" || error.name === "TimeoutError")
   ) {
     return false;
   }
+  // `fetch` throws TypeError for DNS / TCP / CORS / offline failures — and
+  // also for programming errors like invalid URLs or bad header values. The
+  // network cases all mention "fetch" in the message across Node ("fetch
+  // failed"), Chrome ("Failed to fetch"), and Firefox ("NetworkError when
+  // attempting to fetch resource"); programming errors say things like
+  // "Invalid URL" and should fail fast, not retry. Narrow the match so bugs
+  // surface instead of burning retry budget.
+  if (error instanceof TypeError && /fetch/i.test(error.message)) return true;
   return false;
 }
 
@@ -255,13 +260,24 @@ export async function fetchWithRetry(
     effectiveInit.signal = options.signal;
   }
 
+  // `fetchWithRetry` reads its own copy of maxAttempts so the inner function
+  // can decide between "throw HttpRetryError" (ask `withRetry` to retry) and
+  // "return the transient response as-is" (we're out of budget, let the
+  // caller's existing !ok branch run). `withRetry` reads the same option too;
+  // sharing the options object keeps them in lock-step.
   const maxAttempts = options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
 
   let lastResponse: Response | undefined;
 
   try {
     await withRetry<Response>(async (attempt) => {
-      const response = await fetch(input, effectiveInit);
+      // A Request body is a ReadableStream that is consumed on first read;
+      // calling `fetch(request)` twice would send an empty body on retry.
+      // Clone per attempt when the caller passed a Request so retries carry
+      // the original payload. String/URL inputs are not consumable and do
+      // not need cloning.
+      const perAttemptInput = input instanceof Request ? input.clone() : input;
+      const response = await fetch(perAttemptInput, effectiveInit);
       if (response.ok || !shouldRetryResponse(response)) {
         lastResponse = response;
         return response;
@@ -283,10 +299,18 @@ export async function fetchWithRetry(
       );
     }, options);
   } catch (error) {
-    // If the final attempt produced a transient Response we want to surface
-    // it rather than throw — matches the pre-retry contract. A thrown
-    // network error, by contrast, must propagate.
-    if (lastResponse && !lastResponse.ok && shouldRetryResponse(lastResponse)) {
+    // Only substitute the stored transient response when the retry loop
+    // escalated *this* attempt via HttpRetryError. If the final attempt
+    // threw a network error (TypeError) or AbortError, lastResponse may be
+    // a stale Response from an earlier attempt whose body is already
+    // consumed — returning it would silently corrupt the caller's error
+    // handling. Propagate the thrown error instead.
+    if (
+      error instanceof HttpRetryError &&
+      lastResponse &&
+      !lastResponse.ok &&
+      shouldRetryResponse(lastResponse)
+    ) {
       return lastResponse;
     }
     throw error;


### PR DESCRIPTION
## Summary

Addresses the first bullet of #68 — _retry logic for network errors_.

Ships a pure `withRetry` / `fetchWithRetry` utility and will wire it into the three Google Tasks server routes so that rate limits (429) and transient 5xx / network failures are transparently retried with exponential backoff + jitter, instead of being surfaced to the user as a one-shot error.

Closes #68 (partial — see "Deferred" below).

## What's in the PR (phase 1 — landed)

### `src/lib/http/retry.ts`

- **`withRetry<T>(fn, options)`** — generic retry wrapper with exponential backoff + configurable jitter (`full` / `none`), `AbortSignal` support, an `onRetry` observer, and injectable `sleep` / `random` primitives for deterministic tests.
- **`fetchWithRetry(input, init, options)`** — drop-in `fetch` replacement. Retries transient failures; leaves 2xx, 401, 404, etc. untouched so callers keep their existing `!response.ok` branches.
- **`isTransientHttpError`** — strict classifier: 429 + 5xx + `fetch` `TypeError` (network failures) only. Non-429 4xx stays permanent so retries never mask auth / validation bugs. AbortError is explicitly _not_ transient — if the caller aborted, we stop.
- **`parseRetryAfter`** — handles delay-seconds _and_ HTTP-date forms, clamps past-dates to 0, rejects malformed inputs like `"-5"` (which `Date.parse` happily accepts as year -5).
- **`HttpRetryError`** — typed error threading status + Retry-After through the retry loop.

### Test coverage

40 Vitest cases in `src/lib/http/__tests__/retry.test.ts` cover every branch:

- Backoff math: exponential growth, `maxDelayMs` cap, full-jitter bounds, Retry-After override + cap, negative Retry-After clamped to 0.
- `parseRetryAfter`: null / empty / whitespace / integer / float / negative / invalid date / past date / future date.
- Classification: 429, 5xx range (500–599), 4xx non-429, network errors, AbortError, non-Error values.
- `withRetry`: first-success path (no sleep), exhaustion, non-transient short-circuit, custom `shouldRetry`, `onRetry` observer metadata, Retry-After honoured, pre-armed abort, mid-loop abort, default `maxAttempts: 3`.
- `fetchWithRetry`: ok passthrough, non-transient passthrough, 5xx retry succeeds, 429 Retry-After respected, all-retries-exhausted still returns final transient Response, network-error retry, network-error re-thrown after exhaustion, outer vs inner signal precedence.

All 1051 tests pass (`pnpm test`).

## Phase 2 (next commit on this PR)

Integrate `fetchWithRetry` into the three Google Tasks server routes:

- `src/app/api/tasks/route.ts` (GET + POST)
- `src/app/api/tasks/lists/route.ts` (GET)
- `src/app/api/tasks/[taskId]/route.ts` (PATCH)

Plus tests asserting that transient failures retry and non-transient ones don't.

## Scope guardrail

Three open PRs touch the calendar / auth surfaces where retry would also be valuable:

- #158 (encrypt OAuth tokens at rest) — `src/lib/auth/auth.ts`, token-refresh path
- #159 (Google Calendar types + mappers) — `src/app/api/calendar/**`, `src/lib/google-calendar.ts`
- #155 (duplicate-Google-account guard) — `src/lib/auth/auth.ts`

To avoid conflicts with that in-flight work, this PR deliberately leaves calendar + auth call sites alone and integrates only into the Google Tasks routes, which no open PR touches.

## Deferred (follow-ups)

- Adopt `fetchWithRetry` in `src/app/api/calendar/events/route.ts` and sibling calendar routes once #159 lands.
- Adopt `fetchWithRetry` in the Google OAuth token-refresh `fetch` inside `src/lib/auth/auth.ts` once #158 lands.
- IndexedDB quota management + in-memory fallback (separate concern, client-side — worth a dedicated issue).
- Simultaneous-auth-request queue.

## Test plan

- [x] `pnpm vitest run src/lib/http` — 40/40 pass
- [x] `pnpm test` — 1051/1051 pass
- [x] `pnpm lint:fix && pnpm format:fix && pnpm check-types` — clean
- [ ] Phase 2 commit integrates the utility + adds route-level retry tests

Closes #68