### PR TITLE
feat(claude): add implement-issue + browser-qa skills, migrate dep tracking to Project board

### DIFF
--- a/.claude/commands/browser-qa.md
+++ b/.claude/commands/browser-qa.md
@@ -1,0 +1,241 @@
+# Browser QA tester
+
+You are a scheduled QA agent for the `next-digital-wall-calendar` repo, running **locally**. Each run picks one open PR, validates UI/UX changes by driving a real browser via Playwright, and either merges the PR or posts a review comment listing what needs to change.
+
+**Read `CLAUDE.md` first.** Hard rules (apply to anything you push):
+
+- pnpm only
+- standard Tailwind colors only
+- React Compiler — no manual memoization
+- strict TypeScript, no `any`
+- never commit `test-results/` / `playwright-report/` / `blob-report/`
+- never `--no-verify`, never force-push, never amend a published commit
+
+**Source of truth for sequencing:** the project at https://github.com/users/BenSeymourODB/projects/1
+(`PVT_kwHOA6v8084BV7nM`). Field IDs:
+
+- Status `PVTSSF_lAHOA6v8084BV7nMzhRTuK4` (Todo `a37f1872`, In Progress `b4b51a58`, Blocked `d653f3d8`, Done `98ba17af`)
+- Day `PVTSSF_lAHOA6v8084BV7nMzhRTu5s`
+- Priority `PVTSSF_lAHOA6v8084BV7nMzhRTu54`
+- Start (date) `PVTF_lAHOA6v8084BV7nMzhRT04E`
+- End (date) `PVTF_lAHOA6v8084BV7nMzhRT04I`
+
+Merge precedence comes from the project board, **not** from `docs/*issue*.md` — those files are now thin pointers to the project.
+
+## 0. Pre-flight
+
+```bash
+cd /home/bseymour/next-digital-wall-calendar
+git fetch --prune origin
+git checkout main && git pull --ff-only origin main
+git worktree prune
+git worktree list
+```
+
+Remove any worktree under `.claude/worktrees/qa-pr-<n>` whose PR is now merged or closed: `git worktree remove <path>`.
+
+## 1. Pick a PR
+
+```bash
+gh pr list --state open --json \
+  number,title,headRefName,isDraft,labels,createdAt,mergeStateStatus,reviewDecision,body
+```
+
+Eligibility filter:
+
+1. `isDraft == false`
+2. `mergeStateStatus` is one of `CLEAN`, `UNSTABLE`, `HAS_HOOKS`, or `BLOCKED` only when the block is "approval required" (your approval will clear it). Skip `BEHIND`, `DIRTY`, `CONFLICTING`, `DRAFT` — author work needed.
+3. The PR's `Closes #<n>` issue (parse the body) maps to a project item whose `blockedBy.nodes[].state` are all `CLOSED`. Use the same `fieldValueByName` query the hourly-run skill uses, focused on the closing issue.
+4. No "changes requested" review by anyone other than this agent.
+5. CI is green or running — not failed.
+6. No `🤖 qa-tester reviewing` claim comment newer than 2 hours.
+
+**Order:** ascending by closing-issue project `Day`, then ascending `Priority` (P0 first), then oldest `createdAt`. Pick the first match.
+
+If nothing's eligible, exit cleanly. Do NOT post a "nothing to review" comment — that just adds noise.
+
+Once selected, claim the PR:
+
+```bash
+gh pr comment <num> --body "🤖 qa-tester reviewing — local browser validation in progress."
+```
+
+## 2. Worktree per PR (concurrent runs can collide)
+
+```bash
+worktree=".claude/worktrees/qa-pr-<num>"
+if [ -d "$worktree" ]; then
+  cd "$worktree" && git fetch && git checkout "<head-branch>" && git pull --ff-only
+else
+  git fetch origin "pull/<num>/head:pr-<num>"
+  git worktree add "$worktree" "pr-<num>"
+  cd "$worktree"
+fi
+pnpm install --frozen-lockfile
+```
+
+`.claude/worktrees/` is intentionally untracked — leave the directory intact when exiting; pre-flight prunes stale ones.
+
+## 3. Find the acceptance contract
+
+Read in order:
+
+1. The PR body — note explicit goals and any "Test plan" checkbox list.
+2. The closing issue body (`gh issue view <n>`) — pull every acceptance bullet.
+3. The matching plan in `.claude/plans/` (filename usually matches the feature). Treat the plan's acceptance criteria as the contract — your test plan must cover all of them.
+
+Write the consolidated acceptance list down before you start testing. Every bullet needs a corresponding test result (pass / fail / N/A with reason).
+
+## 4. Decide if browser validation applies
+
+UI/UX-affecting changes include any of:
+
+- React component (new or changed)
+- CSS / Tailwind class
+- Page route or layout
+- User-facing copy (announcements, toasts, error messages, empty states)
+- Animations, transitions, or screen navigation
+
+If `gh pr diff <num>` touches none of the above (pure backend route, schema, internal helper, types-only), skip browser validation. Run `pnpm test` and check the diff against the acceptance bullets. Jump to step 6.
+
+## 5. Browser validation
+
+For each acceptance bullet (or each user-visible flow):
+
+1. Drive the path through Playwright. Add a spec under `e2e/` if there isn't one already covering the bullet.
+2. For animations / transitions / screen navigation, enable video capture for that spec only and ensure the test exercises the animated path:
+
+   ```ts
+   test.use({ video: "on" });
+   ```
+
+3. Capture screenshots at the key states:
+
+   ```ts
+   await page.screenshot({
+     path: "docs/screenshots/<feature>-<state>.png",
+     fullPage: true,
+   });
+   ```
+
+   Or use `await expect(page).toHaveScreenshot()` for visual regression where a baseline already exists.
+
+4. Run the suite:
+
+   ```bash
+   npx playwright install chrome    # first run only
+   pnpm test:e2e
+   ```
+
+5. Sanity-check the dev server flow when meaningful: `pnpm dev --port 3099` in a background process (per the existing test-page pattern), then drive the relevant `/test/<feature>` page through Playwright.
+
+**If a test you wrote needs a NEW fixture, page-object helper, mock seed, or test page** (`src/app/test/<feature>/page.tsx`, per the project's existing pattern), commit those alongside the test — they become part of the PR for future runs and other agents.
+
+**Do NOT push code that fixes the actual feature bug** — that's the author's responsibility. You only push test infrastructure (specs, fixtures, helpers, test pages, screenshot baselines).
+
+**Do NOT commit:**
+
+- `test-results/`, `playwright-report/`, `blob-report/` (already gitignored, but check `git status` before committing)
+- Generated screenshots that aren't deliberately checked in as fixtures (under `docs/screenshots/` is fine; under `test-results/` is not)
+- Generated video recordings — attach them to the review comment via `gh` upload instead
+
+## 6. Verdict
+
+### 6a. Pass
+
+Every acceptance bullet maps to a green test and the diff matches the plan:
+
+1. If you wrote any test infrastructure, commit and push it to the PR's head branch (HEREDOC body, standard `Co-Authored-By` line):
+
+   ```bash
+   git add e2e/ docs/screenshots/ src/app/test/
+   git commit -m "test(qa): ..."
+   git push origin <head-branch>
+   ```
+
+2. Post an approving review with screenshots and a Playwright command for repro:
+
+   ```bash
+   gh pr review <num> --approve --body "$(cat <<'EOF'
+   ## QA verdict — pass
+
+   Validated locally with Playwright against [list acceptance bullets, all passing].
+
+   **Repro:** `pnpm test:e2e -- e2e/<spec>.spec.ts`
+
+   **Screenshots:**
+   - ![state-1](https://...)
+   - ![state-2](https://...)
+
+   🤖 qa-tester
+   EOF
+   )"
+   ```
+
+3. Check merge readiness, then merge:
+
+   ```bash
+   gh pr view <num> --json mergeable,mergeStateStatus
+   gh pr merge <num> --squash --delete-branch
+   ```
+
+   Use `--squash` to match the project's prevailing merge style — verify with `gh pr list --state merged --limit 5 --json number,title,mergeCommit`. If the project uses merge commits, switch to `--merge`.
+
+4. After merge, GitHub auto-closes the linked issue. The project's "Item closed" workflow (if enabled) flips Status to `Done`. Verify; set manually otherwise via the same `updateProjectV2ItemFieldValue` mutation pattern from the hourly-run skill.
+
+### 6b. Changes needed
+
+A test fails OR an acceptance bullet is unmet OR the diff misses the plan:
+
+1. Push any test-infrastructure commits you wrote so the failing tests are visible on the PR and reusable next round.
+2. Post a single consolidated request-changes review:
+
+   ```bash
+   gh pr review <num> --request-changes --body "$(cat <<'EOF'
+   ## QA verdict — changes needed
+
+   ### What failed
+
+   - **Acceptance bullet:** "..." (from issue #<n> / plan)
+   - **Test:** `e2e/<spec>.spec.ts:<line>`
+   - **Repro:** `pnpm test:e2e -- e2e/<spec>.spec.ts -g "<test name>"`
+   - **Observed:** ...
+   - **Expected:** ...
+
+   ### Suggested fix (if obvious)
+
+   ...
+
+   ### Evidence
+
+   - ![failure-screenshot](https://...)
+   - Video: <link or attachment>
+
+   I've pushed the failing test infrastructure to this branch so it'll keep failing until the feature is fixed.
+
+   🤖 qa-tester
+   EOF
+   )"
+   ```
+
+3. If the project Status had drifted to something other than `In Progress`, set it back so the work is visibly active.
+
+## 7. Cleanup & exit
+
+- **Approved + merged:** worktree can be removed, but leaving it costs nothing — the next pre-flight prunes it.
+- **Changes requested:** leave the worktree intact at `.claude/worktrees/qa-pr-<num>` so the next QA run can re-test once the author pushes a fix.
+- **Crashed mid-run:** post a comment on the PR explaining where you got stuck. Do NOT leave a stale `🤖 qa-tester reviewing` claim — replace it with a status update so the next run can pick up cleanly.
+
+## Hard guardrails
+
+- **Never merge** a PR that:
+  - has `mergeStateStatus` of `BEHIND` (rebase needed), `DIRTY`, or `CONFLICTING`
+  - has unresolved change-requests from another reviewer
+  - is missing `Closes #<n>` in the body
+  - has any required CI check in `failure` or `cancelled` state
+  - bypasses signed commits / branch protection
+- **Never push code that changes feature behavior** — only test scaffolding.
+- **Never `--no-verify`**, **never force-push**, **never amend a published commit**.
+- If uncertain, request changes rather than approve — the cost of a second QA round is much lower than the cost of merging a regression.
+
+Begin.

--- a/.claude/commands/browser-qa.md
+++ b/.claude/commands/browser-qa.md
@@ -45,7 +45,7 @@ Eligibility filter:
 
 1. `isDraft == false`
 2. `mergeStateStatus` is one of `CLEAN`, `UNSTABLE`, `HAS_HOOKS`, or `BLOCKED` only when the block is "approval required" (your approval will clear it). Skip `BEHIND`, `DIRTY`, `CONFLICTING`, `DRAFT` — author work needed.
-3. The PR's `Closes #<n>` issue (parse the body) maps to a project item whose `blockedBy.nodes[].state` are all `CLOSED`. Use the same `fieldValueByName` query the hourly-run skill uses, focused on the closing issue.
+3. The PR's `Closes #<n>` issue (parse the body) maps to a project item whose `blockedBy.nodes[].state` are all `CLOSED`. Use the same `fieldValueByName` query the `implement-issue` skill uses, focused on the closing issue.
 4. No "changes requested" review by anyone other than this agent.
 5. CI is green or running — not failed.
 6. No `🤖 qa-tester reviewing` claim comment newer than 2 hours.
@@ -181,7 +181,7 @@ Every acceptance bullet maps to a green test and the diff matches the plan:
 
    Use `--squash` to match the project's prevailing merge style — verify with `gh pr list --state merged --limit 5 --json number,title,mergeCommit`. If the project uses merge commits, switch to `--merge`.
 
-4. After merge, GitHub auto-closes the linked issue. The project's "Item closed" workflow (if enabled) flips Status to `Done`. Verify; set manually otherwise via the same `updateProjectV2ItemFieldValue` mutation pattern from the hourly-run skill.
+4. After merge, GitHub auto-closes the linked issue. The project's "Item closed" workflow (if enabled) flips Status to `Done`. Verify; set manually otherwise via the same `updateProjectV2ItemFieldValue` mutation pattern from the `implement-issue` skill.
 
 ### 6b. Changes needed
 

--- a/.claude/commands/hourly-run.md
+++ b/.claude/commands/hourly-run.md
@@ -1,0 +1,253 @@
+# Hourly run
+
+You are a scheduled agent for the `next-digital-wall-calendar` repo, running **locally** on an hourly cron. Each run picks one eligible ticket from the repo's GitHub Project and delivers it end-to-end. Think deeply with extended thinking before non-trivial decisions — this is a high-effort run.
+
+**Read `CLAUDE.md` first.** Hard rules: TDD mandatory, standard Tailwind colors only, React Compiler (no manual memoization), pnpm only, strict TypeScript (no `any`), never commit `test-results/` / `playwright-report/` / `blob-report/`, never `--no-verify`, never force-push, never amend a published commit.
+
+The repo's GitHub Project is the source of truth for sequencing:
+
+- URL: https://github.com/users/BenSeymourODB/projects/1
+- Project ID: `PVT_kwHOA6v8084BV7nM`
+- Field IDs:
+  - Status `PVTSSF_lAHOA6v8084BV7nMzhRTuK4` (Todo `a37f1872`, In Progress `b4b51a58`, Blocked `d653f3d8`, Done `98ba17af`)
+  - Day `PVTSSF_lAHOA6v8084BV7nMzhRTu5s`
+  - Phase `PVTSSF_lAHOA6v8084BV7nMzhRTu5w`
+  - Cluster `PVTSSF_lAHOA6v8084BV7nMzhRTu50`
+  - Priority `PVTSSF_lAHOA6v8084BV7nMzhRTu54`
+  - Start (date) `PVTF_lAHOA6v8084BV7nMzhRT04E`
+  - End (date) `PVTF_lAHOA6v8084BV7nMzhRT04I`
+
+## 0. Pre-flight
+
+```bash
+cd /home/bseymour/next-digital-wall-calendar
+git fetch --prune origin
+git checkout main && git pull --ff-only origin main
+```
+
+If `git status -s` shows uncommitted state on `main` or the checkout fails, a previous run left local state dirty. Post a comment on the most recent in-progress issue describing what was found, then exit cleanly — manual cleanup is needed before scheduled work resumes.
+
+Then prune stale worktrees so concurrent runs don't accumulate:
+
+```bash
+git worktree prune
+git worktree list
+```
+
+If a listed worktree's branch has a merged PR, remove it: `git worktree remove <path>`.
+
+## 1. Unblock pass
+
+`Status = Blocked` is set statically and can drift after PRs merge. Before triage, flip items whose blockers have all closed:
+
+```bash
+gh api graphql -f query='
+{ user(login: "BenSeymourODB") { projectV2(number: 1) {
+  items(first: 100) { nodes {
+    id
+    content { ... on Issue { number state blockedBy(first: 20) { nodes { number state } } } }
+    status: fieldValueByName(name: "Status") { ... on ProjectV2ItemFieldSingleSelectValue { name } }
+  } } } } }'
+```
+
+For each item where Status is `Blocked` AND every `blockedBy.nodes[].state == "CLOSED"`, set Status to `Todo`:
+
+```graphql
+mutation {
+  updateProjectV2ItemFieldValue(
+    input: {
+      projectId: "PVT_kwHOA6v8084BV7nM"
+      itemId: "<itemId>"
+      fieldId: "PVTSSF_lAHOA6v8084BV7nMzhRTuK4"
+      value: { singleSelectOptionId: "a37f1872" }
+    }
+  ) {
+    projectV2Item {
+      id
+    }
+  }
+}
+```
+
+This pass is fast (one query, a handful of mutations). Always run it before triage.
+
+## 2. Pick the next ticket
+
+```bash
+gh api graphql -f query='
+{ user(login: "BenSeymourODB") { projectV2(number: 1) {
+  items(first: 100) { nodes {
+    id
+    content { ... on Issue {
+      number title url state repository { nameWithOwner }
+      blockedBy(first: 20) { nodes { number state } }
+    } }
+    status:   fieldValueByName(name: "Status")   { ... on ProjectV2ItemFieldSingleSelectValue { name } }
+    day:      fieldValueByName(name: "Day")      { ... on ProjectV2ItemFieldSingleSelectValue { name } }
+    priority: fieldValueByName(name: "Priority") { ... on ProjectV2ItemFieldSingleSelectValue { name } }
+    start:    fieldValueByName(name: "Start")    { ... on ProjectV2ItemFieldDateValue { date } }
+    endDate:  fieldValueByName(name: "End")      { ... on ProjectV2ItemFieldDateValue { date } }
+  } } } } }'
+```
+
+Apply this filter (today = `$(date -I)`):
+
+1. `content.state == "OPEN"`.
+2. `status` is `Todo` (skip `Blocked`, `Done`, and — usually — `In Progress`; see step 4).
+3. `start <= today <= endDate` (skip Backlog items with no dates unless nothing else is eligible).
+4. Every `blockedBy.nodes[].state == "CLOSED"` (defensive — `Status` should already exclude blocked work, but stale state happens).
+5. No open PR with `Closes #N` or `Fixes #N` for this issue: `gh pr list --search "in:body Closes #<n>" --state open`.
+6. No claim comment from `hourly-run` newer than 6 hours: `gh issue view <n> --json comments | jq '.comments[] | select(.body | contains("hourly-run claiming"))'`.
+
+**Order:** by `day` ascending (Day 1 → Day 9 → Backlog), then `priority` ascending (P0 → P2), then issue number ascending. Pick the first match.
+
+**Resume case:** an item with `status == "In Progress"` but no open PR is a crashed prior run. Pick it up — `git worktree list` may already show a stale worktree from that run. Reuse it (`cd .claude/worktrees/issue-<n>-…` and `git fetch && git rebase origin/main`).
+
+**Nothing eligible?** Pick the highest-priority `Blocked` item, post a comment on it summarizing what's still blocking and what step would clear it, and exit cleanly.
+
+Once selected:
+
+1. Comment on the issue: `🤖 hourly-run claiming this for the next session.`
+2. Set project `Status = In Progress` for this item:
+   ```graphql
+   mutation {
+     updateProjectV2ItemFieldValue(
+       input: {
+         projectId: "PVT_kwHOA6v8084BV7nM"
+         itemId: "<itemId>"
+         fieldId: "PVTSSF_lAHOA6v8084BV7nMzhRTuK4"
+         value: { singleSelectOptionId: "b4b51a58" }
+       }
+     ) {
+       projectV2Item {
+         id
+       }
+     }
+   }
+   ```
+
+## 3. Worktree (local runs can collide)
+
+Each run uses its own git worktree so concurrent hourly runs cannot stomp on each other:
+
+```bash
+slug=$(echo "<issue-title>" | tr 'A-Z' 'a-z' | tr -cs 'a-z0-9' '-' | sed 's/^-//;s/-$//' | cut -c1-30)
+worktree=".claude/worktrees/issue-<n>-${slug}"
+branch="claude/issue-<n>-${slug}"
+
+if [ -d "$worktree" ]; then
+  cd "$worktree" && git fetch && git rebase origin/main
+else
+  git worktree add -b "$branch" "$worktree" origin/main
+  cd "$worktree"
+fi
+pnpm install --frozen-lockfile
+```
+
+If the branch already exists from a crashed prior run, reuse it: `git worktree add "$worktree" "$branch"` (no `-b`).
+
+`.claude/worktrees/` is intentionally untracked (and should be gitignored — add it if it isn't). Leave the directory intact when exiting; pre-flight prunes stale ones.
+
+## 4. Read the plan
+
+Look in `.claude/plans/` for a file matching the feature/issue. If a plan exists, read it before writing code. If none exists, enter planning mode and save a plan to `.claude/plans/<feature>.md` before implementing — per `CLAUDE.md`, never skip straight to implementation without a plan.
+
+## 5. Phases
+
+Break the work into 2–4 phases (typically schema → API → UI → tests). Commit and push at the end of each phase. The first push opens a draft PR; subsequent pushes update it.
+
+## 6. TDD
+
+Write tests first — unit, integration, component, E2E as appropriate. NEVER weaken or delete a test to make it pass. If a test reveals a real design problem, fix the design.
+
+## 7. Implement, validate, push (per phase)
+
+After tests pass:
+
+```bash
+pnpm lint:fix && pnpm format:fix && pnpm check-types && pnpm test
+```
+
+All four must succeed. Then commit (HEREDOC body, ending with the standard Co-Authored-By line) and push.
+
+On the first push:
+
+```bash
+gh pr create --draft \
+  --title "feat(<scope>): <summary> (#<n>)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+<1-3 bullets>
+
+## Plan
+
+Linked plan: `.claude/plans/<file>.md`
+Project: https://github.com/users/BenSeymourODB/projects/1
+
+## Test plan
+
+- [ ] ...
+
+Closes #<n>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+## 8. UI changes → Playwright (always run locally)
+
+Playwright is reliably available on this host (unlike the previous cloud setup). For any UI-affecting issue:
+
+- Write E2E tests covering the intended behavior and the realistic edge cases.
+- For animations, view transitions, or screen navigation: enable video capture for **that spec only** (`use: { video: 'on' }` inside the test) and design the test to drive the animated path so the recording is meaningful.
+- Run the project's E2E command from `package.json` (e.g. `pnpm test:e2e`); install browsers first if needed (`npx playwright install chrome`).
+- `git status` after a run — never commit `test-results/`, `playwright-report/`, or `blob-report/` even if `.gitignore` should already exclude them.
+- Include up to 4 representative screenshots from successful runs in the PR body (per `CLAUDE.md`).
+
+## 9. Finalize
+
+```bash
+pnpm lint:fix && pnpm format:fix && pnpm check-types && pnpm test
+gh pr ready <num>
+```
+
+Confirm the project item still has `Status = In Progress`. The "Item closed" project workflow (if enabled) auto-flips it to `Done` when the issue closes; if that workflow is disabled, set Status = Done manually after merge.
+
+## 10. First-pass review via Sonnet subagent
+
+Launch a review subagent with `subagent_type=general-purpose, model=sonnet`. Instruct it to:
+
+1. Try the `/ultrareview` skill against PR `<num>` (now reliably available locally — was not in the cloud env).
+2. If `/ultrareview` is unavailable, fall back to a manual deep review: read the full diff (`gh pr diff <num>`), check tests, check `CLAUDE.md` compliance, produce file-level comments with explicit `path` + `line` + `body`.
+3. Post comments via `gh api repos/BenSeymourODB/next-digital-wall-calendar/pulls/<num>/comments` (body must include `commit_id`, `path`, `line`, `side`, `body`) or `gh pr review <num> --comment -b "..."` for general comments.
+4. If the subagent can't post directly, it must return the comments verbatim. You then post them yourself with the same `gh` commands — do not paraphrase.
+
+## 11. Address review
+
+For each review comment:
+
+- If valid: change, commit, push (the PR updates automatically).
+- If no change needed: post a threaded reply via `gh api repos/BenSeymourODB/next-digital-wall-calendar/pulls/<num>/comments/<comment-id>/replies -f body="..."` explaining why.
+
+Post a second-round follow-up on every first-round comment so the user sees nothing left in mid-conversation.
+
+## 12. Cleanup & exit
+
+- **PR is ready-for-review and pushed:** leave the worktree intact for the user to merge / for follow-up runs.
+- **Exiting early due to an unrecoverable blocker:**
+  - Post a comment on the issue summarizing what's blocked and what would unblock it.
+  - Set the project Status back to `Todo` (or to `Blocked` with the new dependency captured) — never leave a crashed run as `In Progress` indefinitely.
+  - Leave the worktree intact so the next run can continue or clean up — do not delete partial work.
+  - Exit cleanly. Never force a state the next run cannot pick up.
+
+## Scope & guardrails
+
+- pnpm only.
+- If the chosen feature is too large for one session, scope to a meaningful slice and clearly note deferred work in the PR body. The hour cadence is forgiving — better to ship a clean slice than a broken full feature.
+- Never `--no-verify`, never force-push, never amend a published commit.
+- Standard Tailwind palette only; React Compiler does the memoization.
+- Every commit message ends with the standard Co-Authored-By line `CLAUDE.md` specifies.
+
+Begin.

--- a/.claude/commands/implement-issue.md
+++ b/.claude/commands/implement-issue.md
@@ -1,6 +1,6 @@
-# Hourly run
+# Implement issue
 
-You are a scheduled agent for the `next-digital-wall-calendar` repo, running **locally** on an hourly cron. Each run picks one eligible ticket from the repo's GitHub Project and delivers it end-to-end. Think deeply with extended thinking before non-trivial decisions — this is a high-effort run.
+You are an implementation agent for the `next-digital-wall-calendar` repo, running **locally**. You can be invoked manually as `/implement-issue` or by a cron driver (the original use case is hourly, but nothing here assumes a cadence). Each run picks one eligible ticket from the repo's GitHub Project and delivers it end-to-end. Think deeply with extended thinking before non-trivial decisions — this is a high-effort run.
 
 **Read `CLAUDE.md` first.** Hard rules: TDD mandatory, standard Tailwind colors only, React Compiler (no manual memoization), pnpm only, strict TypeScript (no `any`), never commit `test-results/` / `playwright-report/` / `blob-report/`, never `--no-verify`, never force-push, never amend a published commit.
 
@@ -97,7 +97,7 @@ Apply this filter (today = `$(date -I)`):
 3. `start <= today <= endDate` (skip Backlog items with no dates unless nothing else is eligible).
 4. Every `blockedBy.nodes[].state == "CLOSED"` (defensive — `Status` should already exclude blocked work, but stale state happens).
 5. No open PR with `Closes #N` or `Fixes #N` for this issue: `gh pr list --search "in:body Closes #<n>" --state open`.
-6. No claim comment from `hourly-run` newer than 6 hours: `gh issue view <n> --json comments | jq '.comments[] | select(.body | contains("hourly-run claiming"))'`.
+6. No claim comment from `implement-issue` newer than 6 hours: `gh issue view <n> --json comments | jq '.comments[] | select(.body | contains("implement-issue claiming"))'`.
 
 **Order:** by `day` ascending (Day 1 → Day 9 → Backlog), then `priority` ascending (P0 → P2), then issue number ascending. Pick the first match.
 
@@ -107,7 +107,7 @@ Apply this filter (today = `$(date -I)`):
 
 Once selected:
 
-1. Comment on the issue: `🤖 hourly-run claiming this for the next session.`
+1. Comment on the issue: `🤖 implement-issue claiming this for the next session.`
 2. Set project `Status = In Progress` for this item:
    ```graphql
    mutation {
@@ -128,7 +128,7 @@ Once selected:
 
 ## 3. Worktree (local runs can collide)
 
-Each run uses its own git worktree so concurrent hourly runs cannot stomp on each other:
+Each run uses its own git worktree so concurrent runs (cron-driven or manual) cannot stomp on each other:
 
 ```bash
 slug=$(echo "<issue-title>" | tr 'A-Z' 'a-z' | tr -cs 'a-z0-9' '-' | sed 's/^-//;s/-$//' | cut -c1-30)

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -54,7 +54,10 @@
       "Bash(git -C /home/bseymour/next-digital-wall-calendar log --oneline -10)",
       "Bash(git -C /home/bseymour/next-digital-wall-calendar diff --stat)",
       "Bash(pnpm dev:*)",
-      "mcp__next-devtools__browser_eval"
+      "mcp__next-devtools__browser_eval",
+      "Bash(gh issue *)",
+      "Bash(gh project *)",
+      "Bash(gh repo *)"
     ]
   },
   "enableAllProjectMcpServers": true,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,9 +43,14 @@ pnpm bump-ui             # Update shadcn components
 
 ### Starting a Task
 
-Work is tracked in **GitHub Issues**. At the start of every session:
+Work is tracked in **GitHub Issues** and the
+[project board](https://github.com/users/BenSeymourODB/projects/1)
+("Features Before Claude Subscription Close"). The project's `Day`,
+`Phase`, `Cluster`, and `Priority` fields plus GitHub's native
+`Blocked by` links are the source of truth for sequencing. At the start
+of every session:
 
-1. **Identify the issue** — read the linked GitHub issue (if provided) to understand requirements and acceptance criteria
+1. **Identify the issue** — read the linked GitHub issue (if provided) to understand requirements and acceptance criteria, and check its `Blocked by` list on github.com
 2. **Check for an existing plan** — look in `.claude/plans/` for a file matching the feature/issue
 3. **If a plan exists** — read it before writing any code; it contains specs, schemas, and testing strategies
 4. **If no plan exists** — enter planning mode first. Produce a plan based on the GitHub issue (or the session prompt if no issue is linked) and save it to `.claude/plans/` before implementing
@@ -88,6 +93,7 @@ All new features follow TDD (red-green-refactor):
 4. **Verify** — `pnpm test && pnpm lint:fix && pnpm format:fix && pnpm check-types`
 
 **Critical rules:**
+
 - NEVER remove or weaken tests without explicit user authorization
 - ALWAYS write tests before implementation
 - No feature is complete until all tests pass
@@ -101,6 +107,7 @@ When making UI changes, start the dev server and verify the feature in a browser
 ### Client-Side Storage
 
 **Backend (PostgreSQL) is the source of truth.** Client-side storage is for performance optimization only:
+
 - **IndexedDB** — cache API responses (calendar events, tasks, profiles)
 - **LocalStorage** — user preferences (theme, UI settings)
 - **Session Storage** — temporary UI state (form drafts, modals)
@@ -159,6 +166,7 @@ Automatically loaded: **Next.js DevTools** (runtime state, docs) | **Context7** 
 ## Checklist — Task Completion
 
 A task is **not complete** until:
+
 1. All tests pass (`pnpm test`)
 2. All code quality checks pass (`pnpm lint:fix && pnpm format:fix && pnpm check-types`)
 3. Feature matches the plan spec (if implementing from `.claude/plans/`)

--- a/docs/issue-cross-reference-updates.md
+++ b/docs/issue-cross-reference-updates.md
@@ -1,244 +1,29 @@
-# Issue Cross-Reference Updates
-
-> Append the text below to each issue's description to document dependencies and synergies.
-> Generated 2026-04-03. Updated 2026-04-13.
-
----
-
-## #92 — Evaluate adopting reference calendar component sets
-
-**Append to description:**
-
-```markdown
----
-
-### Cross-References (added 2026-04-03)
-
-**Informs implementation of:**
-
-- #70, #80, #81, #82, #83, #84 — Evaluation recommends cherry-picking from Jeraidi for all calendar UI components
-- ~~#94~~ ✅ — Jeraidi uses framer-motion for transitions; page transitions now implemented
-- #87 — Jeraidi has smooth view transitions directly applicable to calendar view animations
-- #113, #114, #115, #116, #117, #118 — UI component approach decision cascades to all API wiring issues
-
-**Priority:** HIGH — Decision issue. Reaching a conclusion here unblocks confident implementation of all calendar UI work.
-
-See [docs/issue-dependency-analysis.md](./docs/issue-dependency-analysis.md) for full dependency graph.
-```
-
----
-
-## #94 — ~~Add animated page transitions to screen rotation scheduler~~ ✅ CLOSED
-
-> Resolved. Page transitions implemented.
-
----
-
-## #95 — ~~Add persistent scheduler status indicator with composable positioning~~ ✅ CLOSED
-
-> Resolved. Status indicator implemented.
-
----
-
-## #108 — ~~Add user-configurable screen rotation settings~~ ✅ CLOSED
-
-> Resolved. User-configurable scheduler settings implemented. "Scheduler UX Polish" cluster (#94, #95, #108) is now complete.
-
----
-
-## #109 — ~~Set up Prisma migration workflow~~ ✅ CLOSED
-
-> Resolved (PR #120). Prisma migration workflow is in place. This unblocked #108 (also now closed) and enables safe schema changes for #115, #116, #118 and future DB-dependent features.
-
----
-
-## #112 — Wire radial clock event arcs to Google Calendar API and CalendarProvider
-
-**Append to description:**
-
-```markdown
----
-
-### Cross-References (added 2026-04-03)
-
-**Blocked by:**
-
-- ~~Radial clock UI components (`analog-clock.tsx`, `clock-face.tsx`, `event-arc.tsx`) — not yet built~~ **Unblocked:** UI components are being built in PR #130.
-
-**Independent of:**
-
-- #113, #114, #115, #116, #117, #118 — Different UI component with different data filtering (12-hour window vs date range)
-
-See [docs/issue-dependency-analysis.md](./docs/issue-dependency-analysis.md) for full dependency graph.
-```
-
----
-
-## #113 — Wire week and day views to CalendarProvider with time-range queries
-
-**Append to description:**
-
-```markdown
----
-
-### Cross-References (added 2026-04-03)
-
-**Blocked by:**
-
-- #70 — Week/day view UI components must exist before wiring
-
-**Synergies:**
-
-- #114 — Mini-calendar sidebar navigates to day/week views; both extend CalendarProvider date-range loading
-- #117 — Year view click-through navigates to day view; shared CalendarProvider extensions
-
-**Cluster:** Part of "CalendarProvider Extensions" cluster with #114 and #117. Consider implementing CalendarProvider changes holistically rather than three separate refactors.
-
-See [docs/issue-dependency-analysis.md](./docs/issue-dependency-analysis.md) for full dependency graph.
-```
-
----
-
-## #114 — Wire mini-calendar sidebar to CalendarProvider for event indicators and navigation
-
-**Append to description:**
-
-```markdown
----
-
-### Cross-References (added 2026-04-03)
-
-**Blocked by:**
-
-- #80 — Mini-calendar sidebar UI must exist before wiring
-
-**Synergies:**
-
-- #113 — Mini-calendar navigates to day/week views; both need CalendarProvider `selectedDate` and event-by-date queries
-- #117 — Both render event dot indicators per day; share the day-has-events aggregation logic
-
-**Cluster:** Part of "CalendarProvider Extensions" cluster with #113 and #117. Consider implementing CalendarProvider changes holistically rather than three separate refactors.
-
-See [docs/issue-dependency-analysis.md](./docs/issue-dependency-analysis.md) for full dependency graph.
-```
-
----
-
-## #115 — Wire event detail modal to Google Calendar API and local database for edit/delete
-
-**Append to description:**
-
-```markdown
----
-
-### Cross-References (added 2026-04-03)
-
-**Blocked by:**
-
-- #81 — Event detail modal UI must exist before wiring
-
-**Shared API route:**
-
-- #118 — Both use `PATCH /api/calendar/events/[id]`; this issue should define the route first
-
-**Synergies:**
-
-- #116 — Complementary CRUD operations; share API route file, validation patterns, optimistic update logic
-- #118 — All three (#115, #116, #118) write to Google Calendar API; share OAuth scope requirements and error handling
-
-**Benefits from:**
-
-- ~~#109~~ ✅ — Prisma migration workflow now in place (PR #120)
-
-**Cluster:** Part of "Calendar CRUD API Routes" cluster with #116 and #118. Design the API route structure here first, then #116 and #118 follow the same patterns.
-
-See [docs/issue-dependency-analysis.md](./docs/issue-dependency-analysis.md) for full dependency graph.
-```
-
----
-
-## #116 — Wire event creation dialog to Google Calendar API and local event database
-
-**Append to description:**
-
-```markdown
----
-
-### Cross-References (added 2026-04-03)
-
-**Blocked by:**
-
-- #82 — Event creation dialog UI must exist before wiring
-
-**Synergies:**
-
-- #115 — Complementary CRUD operations; share API route file, validation patterns, optimistic update logic
-- #118 — All three (#115, #116, #118) write to Google Calendar API; share OAuth scope requirements and error handling
-
-**Benefits from:**
-
-- ~~#109~~ ✅ — Prisma migration workflow now in place (PR #120)
-
-**Cluster:** Part of "Calendar CRUD API Routes" cluster with #115 and #118.
-
-See [docs/issue-dependency-analysis.md](./docs/issue-dependency-analysis.md) for full dependency graph.
-```
-
----
-
-## #117 — Wire year view to CalendarProvider with full-year event loading
-
-**Append to description:**
-
-```markdown
----
-
-### Cross-References (added 2026-04-03)
-
-**Blocked by:**
-
-- #83 — Year view UI must exist before wiring
-
-**Benefits from:**
-
-- #72 — Year view loads 365 days of events; performance optimization directly impacts feasibility
-
-**Synergies:**
-
-- #114 — Both render event dot indicators per day; share the day-has-events aggregation logic
-- #113 — Year view click-through navigates to day/month view via CalendarProvider
-
-**Cluster:** Part of "CalendarProvider Extensions" cluster with #113 and #114. Consider implementing CalendarProvider changes holistically rather than three separate refactors.
-
-See [docs/issue-dependency-analysis.md](./docs/issue-dependency-analysis.md) for full dependency graph.
-```
-
----
-
-## #118 — Wire drag-and-drop rescheduling to Google Calendar API and local database
-
-**Append to description:**
-
-```markdown
----
-
-### Cross-References (added 2026-04-03)
-
-**Blocked by:**
-
-- #84 — Drag-and-drop UI must exist before wiring
-- #115 — Shares `PATCH /api/calendar/events/[id]` route; #115 should define this route first
-
-**Synergies:**
-
-- #115, #116 — All three are Google Calendar write operations sharing OAuth scopes, error handling, optimistic updates
-
-**Benefits from:**
-
-- ~~#109~~ ✅ — Prisma migration workflow now in place (PR #120)
-
-**Cluster:** Part of "Calendar CRUD API Routes" cluster with #115 and #116.
-**Priority note:** Highest dependency count of all open issues (double-blocked by #84 + #115).
-
-See [docs/issue-dependency-analysis.md](./docs/issue-dependency-analysis.md) for full dependency graph.
-```
+# Issue Cross-References
+
+> **Superseded 2026-04-27.** Cross-references between issues are now
+> encoded with GitHub's native **Blocked by** relationships, visible on
+> each issue and the
+> [Features Before Claude Subscription Close](https://github.com/users/BenSeymourODB/projects/1)
+> project board.
+
+## Why this file existed
+
+When this repo had no GitHub Project, this file held copy-pasteable
+"append to issue X" recipes documenting which issues blocked, informed,
+or shared infrastructure with which others. That bookkeeping lived only
+here and drifted as work landed.
+
+## What replaces it
+
+- **Blocked by / Blocks** — added via the GraphQL `addBlockedBy` mutation
+  (or the issue UI's "Add a blocked-by relationship"). All previously
+  documented blockers were migrated on 2026-04-27.
+- **Synergy clusters** — encoded in the project's `Cluster` field. Items
+  that share API routes, providers, or settings UI sit in the same
+  cluster (e.g. `Calendar CRUD` for #115 / #116 / #118).
+- **Informational links** — for "informs" or "benefits from" relationships
+  where there's no hard blocker, mention the related issue in the
+  description and rely on GitHub's automatic Cross-references panel.
+
+If you want the original recipes, they're in this file's parent commit
+in git history.

--- a/docs/issue-dependency-analysis.md
+++ b/docs/issue-dependency-analysis.md
@@ -1,270 +1,80 @@
-# Open Issue Dependency Analysis
+# Issue Dependency Tracking
 
-> Generated 2026-04-03 | Updated 2026-04-12 | Covers all 12 open issues at time of analysis + newly completed issues
+> **Source of truth as of 2026-04-27:** the GitHub Project
+> [Features Before Claude Subscription Close](https://github.com/users/BenSeymourODB/projects/1).
+> Dependencies are encoded with GitHub's native **Blocked by** relationships
+> (visible on each issue and the project board). Use the `Day`, `Phase`,
+> `Cluster`, and `Priority` fields on the project to navigate the work.
 
-## Dependency Graph
+## Why this changed
 
-```
-TIER 0 — Foundation (no blockers, enables many others)
-═══════════════════════════════════════════════════════
-  #109  Set up Prisma migration workflow
-  #92   Evaluate adopting reference calendar component sets
+The earlier hand-maintained graph in this file fell out of sync as PRs
+landed. Native GitHub dependency tracking + the project's custom fields
+replace it without the bookkeeping:
 
-TIER 1a — Calendar UI Components (blocked by open UI issues, not yet in this list)
-══════════════════════════════════════════════════════════════════════════════════
-  These open UI issues are NOT in the 12 tracked here, but block Tier 2:
-    #70  Add week and day calendar views         → blocks #113
-    #80  Add mini-calendar sidebar               → blocks #114
-    #81  Add event detail modal                  → blocks #115
-    #82  Add event creation dialog               → blocks #116
-    #83  Add year view with event dot indicators  → blocks #117
-    #84  Add drag-and-drop event rescheduling    → blocks #118
+- **Blocked-by graph** — every issue surfaces its blockers and what it
+  blocks under "Tracked by" / "Blocked by" on github.com.
+- **9-day MVP plan** — encoded in the project's `Day` field
+  (`Day 1` through `Day 9` plus `Backlog`).
+- **Lifecycle** — encoded in `Phase`
+  (Foundation / UI / Wiring / Tasks / Meals / Rewards / Polish / Research).
+- **Synergy clusters** — encoded in `Cluster`
+  (Calendar CRUD / Provider Extensions / Scheduler Polish / Tasks /
+  Meals / Rewards / Tech Debt / Misc).
+- **Triage** — encoded in `Priority` (P0 / P1 / P2).
 
-TIER 1b — Scheduler Features (independent of calendar wiring)
-═════════════════════════════════════════════════════════════
-  #95   Add persistent scheduler status indicator
-  #94   Add animated page transitions
-  #108  Add user-configurable screen rotation settings
+## Working with the project
 
-TIER 2 — Calendar API Wiring (blocked by Tier 1a UI issues)
-═══════════════════════════════════════════════════════════
-  #113  Wire week/day views to CalendarProvider        ← blocked by #70
-  #114  Wire mini-calendar to CalendarProvider          ← blocked by #80
-  #115  Wire event detail modal to API                  ← blocked by #81
-  #116  Wire event creation dialog to API               ← blocked by #82
-  #117  Wire year view to CalendarProvider              ← blocked by #83, benefits from #72
-  #112  Wire radial clock event arcs to API             ← blocked by radial clock UI (untracked)
+- **What's blocking me right now?** Filter the project by
+  `Status = Blocked` and read the "Blocked by" list on each issue.
+- **What can I pick up next?** Filter by `Day = Day N` and
+  `Status = Todo`. Items move to `In Progress` once a PR is open.
+- **What does an MVP need?** Filter by `Day != Backlog`. Items in
+  `Backlog` are deliberately deferred past the 9-day MVP arc.
+- **What's the synergy here?** Group by `Cluster` to see issues that
+  share API routes, providers, or settings UI and should be designed
+  together.
 
-TIER 3 — Highest Dependencies
-═════════════════════════════
-  #118  Wire drag-and-drop rescheduling to API          ← blocked by #84 AND #115
-```
-
-## Detailed Connection Map
-
-### #109 — Set up Prisma migration workflow
-
-| Relationship | Issue                  | Nature                                                                          |
-| ------------ | ---------------------- | ------------------------------------------------------------------------------- |
-| **Enables**  | #108                   | #108 adds Prisma schema fields; proper migrations make this safe and repeatable |
-| **Enables**  | #115, #116, #118       | All "local database write path" work depends on reliable schema migration       |
-| **Enables**  | All future DB features | Profiles, rewards, meal planning, etc. all modify the schema                    |
-
-**Priority: HIGH** — Foundation infrastructure. No blockers. Should be done first.
-
----
-
-### #92 — Evaluate adopting reference calendar component sets
-
-| Relationship           | Issue        | Nature                                                                           |
-| ---------------------- | ------------ | -------------------------------------------------------------------------------- |
-| **Informs**            | #70, #80–#84 | Evaluation recommends cherry-picking from Jeraidi for all calendar UI work       |
-| **Informs**            | #94          | Jeraidi uses framer-motion for transitions, relevant to page transition approach |
-| **Informs**            | #87          | Jeraidi has smooth view transitions, directly applicable                         |
-| **Indirectly informs** | #113–#118    | UI component approach cascades to wiring work                                    |
-
-**Priority: HIGH** — Decision issue. Reaching a decision here unblocks confident implementation of #70, #80–#84.
-
----
-
-### #108 — Add user-configurable screen rotation settings ✅ IMPLEMENTED
-
-| Relationship      | Issue | Nature                                                                                                                                          |
-| ----------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Benefits from** | #109  | Adding `schedulerIntervalSeconds` and `schedulerPauseOnInteractionSeconds` to Prisma schema is safer with migration workflow                    |
-| **Synergy with**  | #94   | Both modify scheduler behavior; #94 adds `TransitionConfig` to `ScheduleConfig`, #108 adds interval/pause settings — coordinate the settings UI |
-| **Synergy with**  | #95   | Status indicator displays the interval countdown that #108 makes configurable                                                                   |
-
-**Status: COMPLETE** — Prisma migration, API validation, Settings UI (SchedulerSection), and scheduler integration all implemented. Defaults aligned to 10s interval / 30s pause.
-
----
-
-### #95 — Add persistent scheduler status indicator
-
-| Relationship     | Issue  | Nature                                                                                                      |
-| ---------------- | ------ | ----------------------------------------------------------------------------------------------------------- |
-| **Synergy with** | #108   | Indicator shows countdown based on `intervalSeconds` which #108 makes user-configurable                     |
-| **Synergy with** | #94    | Both enhance the scheduler visual experience; indicator positioning may interact with transition animations |
-| **Has open PR**  | PR #96 | Implementation may already be in progress                                                                   |
-
-**Priority: MEDIUM** — Has an open PR (#96). Low risk, self-contained.
-
----
-
-### #94 — Add animated page transitions ✅ IMPLEMENTED
-
-| Relationship     | Issue | Nature                                                                                                                                                                         |
-| ---------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Related to**   | #87   | #87 covers calendar _view_ transitions (month↔week↔day); #94 covers scheduler _page_ transitions (Calendar→Tasks→Recipes). Different scope but shared animation infrastructure |
-| **Synergy with** | #92   | Jeraidi reference uses framer-motion for view transitions — same library could power page transitions                                                                          |
-| **Synergy with** | #108  | Both extend `ScheduleConfig`; should coordinate the settings UI to avoid duplication                                                                                           |
-| **Synergy with** | #95   | Indicator must remain visible during page transitions                                                                                                                          |
-
-**Status: COMPLETE** — ScreenTransition component with slide/fade/slide-fade types, configurable duration (200-1000ms), prefers-reduced-motion support, TransitionSection settings UI, and direction-aware animations (forward/backward). Uses CSS transforms for GPU-composited 60fps performance.
-
----
-
-### #90 — Add dark/light/system theme toggle ✅ IMPLEMENTED
-
-| Relationship     | Issue | Nature                                                                                           |
-| ---------------- | ----- | ------------------------------------------------------------------------------------------------ |
-| **Independent**  | —     | No blockers; uses existing `next-themes` dependency and shadcn/ui dark mode support              |
-| **Synergy with** | #86   | Calendar settings panel could integrate the ThemeToggle dropdown; shares settings infrastructure |
-
-**Status: COMPLETE** — ThemeProvider (next-themes), ThemeToggle dropdown (Sun/Moon/Monitor icons), complete shadcn/ui CSS variable definitions for light and dark themes (oklch, slate base), semantic color tokens throughout all major components (SimpleCalendar, AgendaCalendar, AccountManager, Home, Settings, Calendar page). DisplaySection wired to `setTheme()` for instant switching. Theme options changed from "auto" to "system" (next-themes standard). API accepts both "auto" and "system" for backward compatibility. localStorage persistence via next-themes.
-
----
-
-### #113 — Wire week/day views to CalendarProvider
-
-| Relationship     | Issue | Nature                                                                                             |
-| ---------------- | ----- | -------------------------------------------------------------------------------------------------- |
-| **Blocked by**   | #70   | UI components must exist before wiring                                                             |
-| **Synergy with** | #114  | Mini-calendar sidebar navigates to day/week views; both extend CalendarProvider date-range loading |
-| **Synergy with** | #117  | Year view click-through navigates to day view; shared CalendarProvider extensions                  |
-
-**Priority: Blocked** — Waiting on #70.
-
----
-
-### #114 — Wire mini-calendar sidebar to CalendarProvider
-
-| Relationship     | Issue | Nature                                                                                                            |
-| ---------------- | ----- | ----------------------------------------------------------------------------------------------------------------- |
-| **Blocked by**   | #80   | UI component must exist before wiring                                                                             |
-| **Synergy with** | #113  | Mini-calendar navigates to day/week views — both need CalendarProvider's `selectedDate` and event-by-date queries |
-| **Synergy with** | #117  | Year view and mini-calendar both show event dot indicators using similar day-has-events logic                     |
-
-**Priority: Blocked** — Waiting on #80.
-
----
-
-### #115 — Wire event detail modal to API (edit/delete)
-
-| Relationship              | Issue | Nature                                                                                                                         |
-| ------------------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------ |
-| **Blocked by**            | #81   | UI component must exist before wiring                                                                                          |
-| **Shared API route with** | #118  | Both use `PATCH /api/calendar/events/[id]` — should be designed together                                                       |
-| **Synergy with**          | #116  | #116 creates events (`POST`), #115 edits/deletes them (`PATCH`/`DELETE`). Same API route file, same optimistic update patterns |
-| **Benefits from**         | #109  | Local database write paths need proper migration workflow                                                                      |
-
-**Priority: Blocked** — Waiting on #81. But API route design should be planned alongside #116 and #118.
-
----
-
-### #116 — Wire event creation dialog to API
-
-| Relationship      | Issue | Nature                                                                                                        |
-| ----------------- | ----- | ------------------------------------------------------------------------------------------------------------- |
-| **Blocked by**    | #82   | UI component must exist before wiring                                                                         |
-| **Synergy with**  | #115  | Complementary CRUD operations — share API route file, validation patterns, optimistic update logic            |
-| **Synergy with**  | #118  | All three (#115, #116, #118) write to Google Calendar API — share OAuth scope requirements and error handling |
-| **Benefits from** | #109  | Local database write paths need proper migration workflow                                                     |
-
-**Priority: Blocked** — Waiting on #82.
-
----
-
-### #117 — Wire year view to CalendarProvider
-
-| Relationship      | Issue | Nature                                                                                          |
-| ----------------- | ----- | ----------------------------------------------------------------------------------------------- |
-| **Blocked by**    | #83   | UI component must exist before wiring                                                           |
-| **Benefits from** | #72   | Year view loads 365 days of events; performance optimization (#72) directly impacts feasibility |
-| **Synergy with**  | #114  | Both render event dot indicators per day — share the day-has-events aggregation logic           |
-| **Synergy with**  | #113  | Year view click-through navigates to day/month view via CalendarProvider                        |
-
-**Priority: Blocked** — Waiting on #83. Significantly benefits from #72 landing first.
-
----
-
-### #112 — Wire radial clock event arcs to API
-
-| Relationship       | Issue            | Nature                                                                                   |
-| ------------------ | ---------------- | ---------------------------------------------------------------------------------------- |
-| **Blocked by**     | Radial clock UI  | `analog-clock.tsx`, `clock-face.tsx`, `event-arc.tsx` don't exist yet (no tracked issue) |
-| **Uses**           | CalendarProvider | Already exists — lower integration barrier than other wiring issues                      |
-| **Independent of** | #113–#118        | Different UI component, different data filtering (12-hour window vs date range)          |
-
-**Priority: Blocked** — Waiting on radial clock UI components (currently untracked as a separate issue).
-
----
-
-### #118 — Wire drag-and-drop rescheduling to API
-
-| Relationship      | Issue      | Nature                                                                                                  |
-| ----------------- | ---------- | ------------------------------------------------------------------------------------------------------- |
-| **Blocked by**    | #84        | Drag-and-drop UI must exist before wiring                                                               |
-| **Blocked by**    | #115       | Shares `PATCH /api/calendar/events/[id]` route — #115 should define this route first                    |
-| **Synergy with**  | #115, #116 | All three are Google Calendar write operations sharing OAuth scopes, error handling, optimistic updates |
-| **Benefits from** | #109       | Local database write paths need proper migration workflow                                               |
-
-**Priority: Blocked (double)** — Waiting on both #84 and #115. Highest dependency count of all open issues.
-
----
-
-## Recommended Implementation Order
+## Snapshot — 9-day MVP arc (set 2026-04-27)
 
 ```
-Phase 1 — Foundation (parallel)
-  #109  Prisma migration workflow
-  #92   Finalize reference component evaluation decision
+Day 1 — Land in-flight calendar / tech-debt PRs
+        #61 #68 #69 #70 #71 #76 #77 #124 #146 #152
 
-Phase 2 — Independent scheduler enhancements (parallel, after Phase 1)
-  #95   Scheduler status indicator (has PR #96) ✅ DONE
-  #108  Screen rotation settings (after #109) ✅ DONE
-  #94   Animated page transitions (after #92 informs animation library choice) ✅ DONE
+Day 2 — Land in-flight calendar UI PRs
+        #73 #81 #82 #83 #85 #86 #87 #88 #91
 
-Phase 3 — Calendar UI components (parallel, after #92 decision)
-  #70   Week and day views
-  #80   Mini-calendar sidebar
-  #81   Event detail modal
-  #82   Event creation dialog
-  #83   Year view
-  #84   Drag-and-drop UI
+Day 3 — Calendar CRUD wiring (defines API contract)
+        #115 #116
 
-Phase 4 — Calendar API wiring (after respective Phase 3 UI)
-  #113  Wire week/day views         (after #70)
-  #114  Wire mini-calendar          (after #80)
-  #115  Wire event detail modal     (after #81)  ← do before #118
-  #116  Wire event creation dialog  (after #82)
-  #117  Wire year view              (after #83 + #72)
-  #112  Wire radial clock           (after radial clock UI)
+Day 4 — CalendarProvider extensions cluster
+        #72 #112 #113 #114 #117
 
-Phase 5 — Final wiring
-  #118  Wire drag-and-drop          (after #84 + #115)
+Day 5 — Drag-and-drop UI + agenda toggle
+        #84 #150
+
+Day 6 — DnD wiring + tech-debt batch
+        #67 #74 #75 #79 #118
+
+Day 7 — Tasks track part 1 + Rewards schema
+        #162 #163 #164 #171
+
+Day 8 — Tasks track part 2 + Rewards UI
+        #165 #166 #172 #173
+
+Day 9 — Meals MVP
+        #167 #168 #169 #170
+
+Backlog — post-MVP
+        #78 #92 #131
 ```
 
-## Key Synergy Clusters
+The shape of the arc, not the exact numbers, is the important part — as
+PRs merge and new issues appear, update the project, not this file.
 
-### Cluster A: Calendar CRUD API Routes (#115 + #116 + #118)
+## Historical record
 
-These three issues all create server-side API routes for Google Calendar mutations. They should share:
-
-- API route file structure (`/api/calendar/events/` and `/api/calendar/events/[id]/`)
-- Optimistic update patterns in CalendarProvider
-- Error handling and rollback logic
-- Google Calendar OAuth scope requirements (`calendar.events`)
-- IndexedDB cache invalidation strategy
-
-**Recommendation:** Design the API route structure when implementing #115, then #116 and #118 follow the same patterns.
-
-### Cluster B: CalendarProvider Extensions (#113 + #114 + #117)
-
-These three issues all extend CalendarProvider's data loading:
-
-- #113 needs narrow time-range queries for day/week views
-- #114 needs day-has-events queries for dot indicators
-- #117 needs full-year event loading
-
-**Recommendation:** Implement CalendarProvider extensions holistically rather than three separate refactors.
-
-### Cluster C: Scheduler UX Polish (#94 + #95 + #108)
-
-All three enhance the screen rotation scheduler experience:
-
-- #95 adds a status indicator widget
-- #94 adds page transition animations
-- #108 makes timing configurable
-
-**Recommendation:** Can be developed in parallel but should share a settings UI section.
+The pre-2026-04-27 hand-rolled dependency graph and tier analysis lives
+in git history at this file's parent commit. It was useful for getting
+the project started, but the project board is more accurate going
+forward.


### PR DESCRIPTION
## Summary

Adds two sister Claude automation skills under `.claude/commands/`, both designed for local invocation (manual or via cron):

- **`implement-issue`** — picks the next eligible ticket from the [project board](https://github.com/users/BenSeymourODB/projects/1) and delivers it end-to-end (TDD, draft PR, Sonnet review, address feedback). Originally drafted as `hourly-run`; renamed because the logic is cadence-agnostic.
- **`browser-qa`** — picks an open PR whose linked issue has all blockers closed, drives the UI through Playwright with screenshot + video capture, and either merges the PR or posts a request-changes review with reproducible failure evidence.

Also replaces `docs/issue-dependency-analysis.md` and `docs/issue-cross-reference-updates.md` with thin pointers to the project, since GitHub-native `Blocked by` links and the `Day` / `Phase` / `Cluster` / `Priority` / `Start` / `End` fields now hold the sequencing source of truth. Updates `CLAUDE.md` step 1 of "Starting a Task" to read each issue'"'"'s `Blocked by` list before starting work, and adds `gh issue/project/repo` to the local Claude permissions so the skills run without prompts.

## implement-issue — pick → build → review

0. Pre-flight: fetch main, prune stale worktrees.
1. Unblock pass: flip `Status = Blocked` → `Todo` for items whose `blockedBy` issues are all closed.
2. Triage: filter for `state=OPEN, Status=Todo, Start ≤ today ≤ End`, all blockers closed, no open closing PR, no recent claim. Order by Day → Priority → number.
3. Worktree per run (`.claude/worktrees/issue-<n>-<slug>`) so concurrent runs cannot collide.
4. Read the linked plan in `.claude/plans/`.
5. Phases (2-4), TDD, `pnpm lint:fix && pnpm format:fix && pnpm check-types && pnpm test`.
6. Always run Playwright for UI changes (now reliable locally).
7. `gh pr ready`, then a Sonnet subagent runs `/ultrareview` and posts file-level comments. Address review, post follow-ups.
8. On crash, never leave `Status = In Progress` — flip back to `Todo`/`Blocked` and leave the worktree intact.

## browser-qa — pick PR → validate → merge or comment

0. Pre-flight: fetch main, prune stale worktrees.
1. Pick a PR: skip drafts, skip BEHIND/DIRTY/CONFLICTING, require linked-issue blockers all closed, require CI not failed, no recent qa-tester claim. Order by linked-issue Day → Priority → oldest createdAt.
2. Worktree per PR (`.claude/worktrees/qa-pr-<n>`).
3. Build the acceptance contract from the PR body, the linked issue, and `.claude/plans/<feature>.md`.
4. Skip browser validation for non-UI diffs (pure backend/schema/types).
5. For each acceptance bullet: drive Playwright, capture video for animations, capture screenshots at key states. If a test needs new fixtures / helpers / test pages (per the existing `src/app/test/<feature>/page.tsx` pattern), commit those alongside the test — never feature-fix code.
6. **Pass:** push test infra, post approving review with screenshots, `gh pr merge --squash --delete-branch`. **Changes needed:** push test infra (so failing tests stay visible), post a single consolidated request-changes review with repro command + evidence.
7. Cleanup: leave the worktree intact for the next QA round.

## Test plan

- [ ] Manually invoke `/implement-issue` once and confirm the unblock-pass and triage queries return expected items, and worktree creation works under `.claude/worktrees/issue-<n>-<slug>`.
- [ ] Manually invoke `/browser-qa` against an open UI-affecting PR and confirm the worktree checkout works, Playwright runs, and the verdict comment posts as expected.
- [ ] Confirm the project'"'"'s "Item closed" workflow is enabled so `Status` auto-flips to `Done` on issue close. If disabled, both skills will leave items stuck on `In Progress` after merge.
- [ ] Optional follow-up (not in this PR): add `.claude/worktrees/` and `blob-report/` to `.gitignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)