### PR TITLE
feat(calendar): wire week and day views to time grid (#113)

### DIFF
--- a/.claude/plans/wire-week-day-views.md
+++ b/.claude/plans/wire-week-day-views.md
@@ -1,0 +1,145 @@
+# Wire week and day views to CalendarProvider — issue #113
+
+## Goal
+
+Day and Week views currently consume `events` from `CalendarProvider` but
+render them as a simple per-day stacked list. Issue #113 calls for true
+time-grid views with hourly positioning, multi-day spanning bars in week
+view, and a live current-time indicator — all driven by the provider's
+existing data flow.
+
+The provider plumbing (`loadEventsForDate`, color/user filters,
+`refreshEvents`) is already in place from PR #114 (mini-calendar) and
+earlier wiring work. This issue focuses on the visual layer plus a small
+provider extension so day/week navigation does not over-fetch.
+
+## In scope
+
+1. **Hourly time-grid** for `DayCalendar` and `WeekCalendar`. Timed
+   events are absolutely positioned with `top` / `height` derived from
+   `startDate` / `endDate` against a 1440-minute axis.
+2. **All-day / multi-day row** above the hour grid in week view; events
+   spanning more than one day render as a single horizontal bar
+   clamped to the week boundary.
+3. **Live current-time indicator** — a horizontal line at the
+   wall-clock time, refreshed once per minute, only on today's column.
+4. **Provider regression tests** — lock in the existing
+   `loadEventsForDate` and filter behavior so this PR is the one that
+   formalizes "navigating between days/weeks triggers appropriate data
+   loading" and "events respect color and user filters".
+
+## Out of scope (deferred)
+
+- Drag-and-drop rescheduling (#84)
+- Inline event create / edit from the time grid (#82, #115, #116)
+- Per-user-configurable slot granularity beyond the 1-hour default
+- Replacing `loadEventsForDate`'s month-chunked fetch with a strict
+  view-window fetch — month chunks already cover any week/day view, so
+  the practical "narrow time range" win is small. Cross-references
+  the open work in #114's follow-ups if it ever becomes hot.
+
+## Acceptance map (issue #113 body → this plan)
+
+| Issue criterion                                  | Where it lands                    |
+| ------------------------------------------------ | --------------------------------- |
+| Day view displays events in correct time slots   | Phase 1                           |
+| Week view across 7 columns with time positioning | Phase 1                           |
+| Multi-day events as spanning bars in week view   | Phase 2                           |
+| Current time indicator                           | Phase 1                           |
+| Navigating triggers appropriate data loading     | Phase 3 — regression test         |
+| Events respect color/user filters                | Phase 3 — regression test         |
+| `refreshEvents` respects active view's range     | Already month-chunked — test only |
+
+## Phase 1 — Time-grid layouts + current-time line
+
+**New helpers** in `src/lib/calendar-helpers.ts`:
+
+- `getEventTimePosition(event, day)` → `{ top: number, height: number }`
+  in percent of the 1440-minute axis. Events that start before `day`
+  clamp `top` to 0; events that end after `day` clamp `height` to the
+  remaining axis.
+- `getCurrentTimePosition(now = new Date())` → `{ top: number }` percent
+  from start-of-day.
+
+**`DayCalendar.tsx`**:
+
+- Keep the header (date label, prev/today/next, event count).
+- Keep the existing all-day section unchanged when present.
+- Replace the timed-events card stack with a 24-row hourly grid
+  (`min-h-[1440px]` so 1 minute = 1px). Render hour labels in a fixed
+  left column.
+- Position timed events via `getEventTimePosition`. Adjacent overlaps
+  are laid out side-by-side using the existing `groupEvents` helper —
+  events in the same group share the column, distinct groups occupy
+  separate sub-columns.
+- A `<NowLine />` child renders when `isSameDay(selectedDate, today)`;
+  it owns a `useState`/`useEffect` pair that ticks every 60s.
+
+**`WeekCalendar.tsx`**:
+
+- Header unchanged.
+- Below: 7-column hour grid, same positioning logic per column.
+- All-day events rendered in a row above the grid (one cell per day).
+  Multi-day handling for week view ships in Phase 2 — for Phase 1, an
+  event spanning multiple days is duplicated into each day cell of the
+  all-day row. (Phase 2 swaps this for a single spanning bar.)
+- `<NowLine />` rendered absolutely-positioned over today's column.
+
+## Phase 2 — Multi-day spanning bars (week view)
+
+`WeekCalendar.tsx` gains a multi-day row above the hour grid. Bars
+render once across N columns where N = number of in-week days the event
+covers (clamped to `[0..6]`). Stacking handles overlapping bars by
+assigning each bar a row index (existing `calculateMonthEventPositions`
+solves the same problem for month view — extract a generic
+`assignBarRows(events, weekStart, weekEnd)` helper).
+
+The day view's all-day section grows a small "(through MMM d)" suffix
+on multi-day events so users at a single-day view still know an event
+is part of a longer span.
+
+## Phase 3 — Provider regression tests + final E2E
+
+- `src/components/providers/__tests__/CalendarProvider.test.tsx` (new):
+  - `setSelectedDate(farFutureDate)` triggers `loadEventsForDate`
+    (mock `fetch`, assert request fired with the expected `timeMin` /
+    `timeMax`).
+  - Filtered `events` reflects `selectedColors` / `selectedUserId`.
+- `src/components/calendar/__tests__/DayCalendar.test.tsx` and
+  `WeekCalendar.test.tsx` extended with positioning + now-line tests.
+- `e2e/week-day-views.spec.ts` extended:
+  - Time-positioned event lands on the correct row.
+  - Now line visible on today, not on a past/future day.
+  - Multi-day event renders as a spanning bar in week view (one bar,
+    not three duplicates).
+  - Filter changes (color filter) hide the right events in week and
+    day views — drives the existing provider wiring through the new UI.
+
+Video capture (`use: { video: "on" }`) is enabled only on the
+multi-day-spanning + now-line tests since those exercise the
+animated/timed paths; the rest stay on `retain-on-failure`.
+
+## Files
+
+```
+src/lib/calendar-helpers.ts                                    (extend)
+src/lib/__tests__/calendar-helpers.test.ts                     (new — helper tests)
+src/components/calendar/DayCalendar.tsx                        (rewrite body)
+src/components/calendar/WeekCalendar.tsx                       (rewrite body)
+src/components/calendar/__tests__/DayCalendar.test.tsx         (extend)
+src/components/calendar/__tests__/WeekCalendar.test.tsx        (extend)
+src/components/providers/__tests__/CalendarProvider.test.tsx   (new)
+src/app/test/calendar/page.tsx                                 (add multi-day mock)
+e2e/week-day-views.spec.ts                                     (extend)
+```
+
+## Risk notes
+
+- **Now line tick interval** — must be cleared on unmount or it leaks
+  across views. Tested with `vi.useFakeTimers()`.
+- **`new Date()` vs frozen clocks** — components must accept the
+  current time from a hook or default arg so tests can inject. Pattern
+  already used elsewhere (`startOfDay(new Date())` lifted to module
+  scope).
+- **Hour grid scroll position** — for usability, scroll to ~7am on
+  mount. Use a `ref` + `scrollIntoView` rather than CSS magic.

--- a/e2e/week-day-views.spec.ts
+++ b/e2e/week-day-views.spec.ts
@@ -35,9 +35,28 @@ test.describe("Week Calendar", () => {
     await expect(page.getByText("Client Call")).toBeVisible();
   });
 
-  test("shows '+X more' overflow indicator", async ({ page }) => {
+  test("renders all events on a busy day in side-by-side columns", async ({
+    page,
+  }) => {
+    // The time-grid layout positions overlapping events in adjacent
+    // sub-columns rather than truncating with "+X more".
     await page.goto("/test/calendar?events=overflow&view=week");
-    await expect(page.getByText(/\+\d+ more/).first()).toBeVisible();
+    await expect(page.getByTestId("week-calendar-event").first()).toBeVisible();
+    const count = await page.getByTestId("week-calendar-event").count();
+    expect(count).toBeGreaterThanOrEqual(5);
+  });
+
+  test("renders multi-day events as a single spanning bar", async ({
+    page,
+  }) => {
+    await page.goto("/test/calendar?events=multiDay&view=week");
+    const bars = page.getByTestId("week-calendar-multi-day-bar");
+    await expect(bars.filter({ hasText: "Family Trip" })).toHaveCount(1);
+  });
+
+  test("shows the now-line indicator on today", async ({ page }) => {
+    await page.goto("/test/calendar?events=default&view=week");
+    await expect(page.getByTestId("week-calendar-now-line")).toBeVisible();
   });
 });
 
@@ -77,6 +96,24 @@ test.describe("Day Calendar", () => {
     page,
   }) => {
     await expect(page.getByText("Morning Standup")).toBeVisible();
+  });
+
+  test("positions a timed event in the time grid", async ({ page }) => {
+    await page.goto("/test/calendar?events=default&view=day");
+    await expect(page.getByTestId("day-calendar-event").first()).toBeVisible();
+  });
+
+  test("shows the now-line on today", async ({ page }) => {
+    await page.goto("/test/calendar?events=default&view=day");
+    await expect(page.getByTestId("day-calendar-now-line")).toBeVisible();
+  });
+
+  test("does not show the now-line on a non-today day", async ({ page }) => {
+    await page.goto("/test/calendar?events=default&view=day");
+    // Navigate forward 2 days
+    await page.getByTestId("day-calendar-next").click();
+    await page.getByTestId("day-calendar-next").click();
+    await expect(page.getByTestId("day-calendar-now-line")).toHaveCount(0);
   });
 });
 

--- a/src/app/test/calendar/page.tsx
+++ b/src/app/test/calendar/page.tsx
@@ -207,6 +207,32 @@ const mockEventSets: Record<string, IEvent[]> = {
     })
   ),
 
+  // Multi-day event scenario for week-view spanning bars
+  multiDay: [
+    createMockEvent({
+      id: "trip",
+      title: "Family Trip",
+      startDate: getRelativeDate(1, 0, 0),
+      endDate: getRelativeDate(4, 23, 59),
+      color: "purple",
+    }),
+    createMockEvent({
+      id: "all-day-holiday",
+      title: "Holiday",
+      startDate: getRelativeDate(0, 0, 0),
+      endDate: getRelativeDate(0, 23, 59),
+      color: "red",
+      isAllDay: true,
+    }),
+    createMockEvent({
+      id: "morning-meeting",
+      title: "Morning Standup",
+      startDate: getRelativeDate(0, 9, 0),
+      endDate: getRelativeDate(0, 9, 30),
+      color: "blue",
+    }),
+  ],
+
   // Family calendar scenario
   family: [
     createMockEvent({

--- a/src/components/calendar/DayCalendar.tsx
+++ b/src/components/calendar/DayCalendar.tsx
@@ -2,8 +2,14 @@
 
 import { useCalendar } from "@/components/providers/CalendarProvider";
 import { Button } from "@/components/ui/button";
-import { formatTime } from "@/lib/calendar-helpers";
+import {
+  formatTime,
+  getCurrentTimePosition,
+  getEventTimePosition,
+  groupEvents,
+} from "@/lib/calendar-helpers";
 import type { IEvent, TEventColor } from "@/types/calendar";
+import { useEffect, useState } from "react";
 import {
   addDays,
   format,
@@ -14,77 +20,70 @@ import {
 } from "date-fns";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 
-// Stable reference so relative labels ("Today" / "Tomorrow" / "Yesterday")
-// and the disabled state of the Today button don't drift across midnight
-// within a single render pass.
+const HOURS = Array.from({ length: 24 }, (_, i) => i);
+const HOUR_HEIGHT_PX = 48;
+const TIME_GRID_HEIGHT_PX = HOUR_HEIGHT_PX * 24;
+
 const today = startOfDay(new Date());
 
-function getColorClasses(color: TEventColor): string {
+function getEventBlockClasses(color: TEventColor): string {
   const classes: Record<TEventColor, string> = {
-    blue: "border-blue-500 bg-blue-50 dark:bg-blue-950",
-    green: "border-green-500 bg-green-50 dark:bg-green-950",
-    red: "border-red-500 bg-red-50 dark:bg-red-950",
-    yellow: "border-yellow-500 bg-yellow-50 dark:bg-yellow-950",
-    purple: "border-purple-500 bg-purple-50 dark:bg-purple-950",
-    orange: "border-orange-500 bg-orange-50 dark:bg-orange-950",
+    blue: "border-l-blue-500 bg-blue-100/80 text-blue-900 dark:bg-blue-900/40 dark:text-blue-100",
+    green:
+      "border-l-green-500 bg-green-100/80 text-green-900 dark:bg-green-900/40 dark:text-green-100",
+    red: "border-l-red-500 bg-red-100/80 text-red-900 dark:bg-red-900/40 dark:text-red-100",
+    yellow:
+      "border-l-yellow-500 bg-yellow-100/80 text-yellow-900 dark:bg-yellow-900/40 dark:text-yellow-100",
+    purple:
+      "border-l-purple-500 bg-purple-100/80 text-purple-900 dark:bg-purple-900/40 dark:text-purple-100",
+    orange:
+      "border-l-orange-500 bg-orange-100/80 text-orange-900 dark:bg-orange-900/40 dark:text-orange-100",
   };
   return classes[color];
 }
 
-function getBadgeClasses(color: TEventColor): string {
+function getAllDayPillClasses(color: TEventColor): string {
   const classes: Record<TEventColor, string> = {
-    blue: "bg-blue-500",
-    green: "bg-green-500",
-    red: "bg-red-500",
-    yellow: "bg-yellow-500",
-    purple: "bg-purple-500",
-    orange: "bg-orange-500",
+    blue: "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200",
+    green: "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
+    red: "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200",
+    yellow:
+      "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200",
+    purple:
+      "bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200",
+    orange:
+      "bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200",
   };
   return classes[color];
+}
+
+function NowLine({ day }: { day: Date }) {
+  const [now, setNow] = useState<Date>(() => new Date());
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), 60_000);
+    return () => clearInterval(id);
+  }, []);
+
+  if (!isSameDay(now, day)) return null;
+
+  const { top } = getCurrentTimePosition(now);
+
+  return (
+    <div
+      data-testid="day-calendar-now-line"
+      className="pointer-events-none absolute right-0 left-12 z-20 flex items-center"
+      style={{ top: `${top}%` }}
+      aria-hidden="true"
+    >
+      <span className="-ml-1.5 inline-block h-3 w-3 rounded-full bg-red-500" />
+      <span className="h-px flex-1 bg-red-500" />
+    </div>
+  );
 }
 
 function eventStartsOnDay(event: IEvent, day: Date): boolean {
   return isSameDay(parseISO(event.startDate), day);
-}
-
-function EventCard({
-  event,
-  use24HourFormat,
-}: {
-  event: IEvent;
-  use24HourFormat: boolean;
-}) {
-  const start = formatTime(event.startDate, use24HourFormat);
-  const end = formatTime(event.endDate, use24HourFormat);
-
-  return (
-    <div
-      className={`rounded-lg border-l-4 p-4 ${getColorClasses(event.color)}`}
-    >
-      <div className="flex items-start justify-between gap-4">
-        <div className="flex-1">
-          <h4
-            className="text-foreground font-semibold"
-            data-testid="day-calendar-event-title"
-          >
-            {event.title}
-          </h4>
-          <p className="text-muted-foreground mt-1 text-sm">
-            {event.isAllDay ? "All day" : `${start} – ${end}`}
-          </p>
-          {event.description && (
-            <p className="text-muted-foreground mt-2 text-sm">
-              {event.description}
-            </p>
-          )}
-        </div>
-        <div
-          aria-hidden="true"
-          className={`h-3 w-3 shrink-0 rounded-full ${getBadgeClasses(event.color)}`}
-        />
-      </div>
-    </div>
-  );
 }
 
 export function DayCalendar() {
@@ -105,13 +104,23 @@ export function DayCalendar() {
     );
   const total = dayEvents.length;
 
+  // Compute side-by-side columns for overlapping events using the existing
+  // `groupEvents` helper. Each group is one "column" of time-stacked events;
+  // events in different groups occupy adjacent sub-columns.
+  const groups = groupEvents(timedEvents);
+  const eventColumn: Record<string, { column: number; columns: number }> = {};
+  groups.forEach((group, groupIndex) => {
+    group.forEach((event) => {
+      eventColumn[event.id] = { column: groupIndex, columns: groups.length };
+    });
+  });
+
   const previousDay = () => setSelectedDate(subDays(selectedDate, 1));
   const nextDay = () => setSelectedDate(addDays(selectedDate, 1));
   const goToToday = () => setSelectedDate(new Date());
 
   return (
     <div className="w-full space-y-4">
-      {/* Header */}
       <div className="flex items-center justify-between">
         <div>
           <div className="flex items-center gap-3">
@@ -180,10 +189,11 @@ export function DayCalendar() {
         </div>
       )}
 
-      {/* All-day section */}
       {allDayEvents.length > 0 && (
         <section
-          className="border-border bg-card space-y-2 rounded-lg border p-4"
+          role="region"
+          aria-label="All day events"
+          className="border-border bg-card space-y-2 rounded-lg border p-3"
           aria-labelledby="day-calendar-allday-label"
         >
           <h3
@@ -192,42 +202,111 @@ export function DayCalendar() {
           >
             All day
           </h3>
-          <div className="space-y-2">
+          <ul className="flex flex-wrap gap-2">
             {allDayEvents.map((event) => (
-              <EventCard
+              <li
                 key={event.id}
-                event={event}
-                use24HourFormat={use24HourFormat}
-              />
+                className={`rounded px-2 py-1 text-xs ${getAllDayPillClasses(event.color)}`}
+              >
+                <span
+                  className="font-medium"
+                  data-testid="day-calendar-event-title"
+                >
+                  {event.title}
+                </span>
+              </li>
             ))}
-          </div>
+          </ul>
         </section>
       )}
 
-      {/* Timed events */}
-      {timedEvents.length > 0 ? (
-        <section
-          className="border-border bg-card space-y-2 rounded-lg border p-4"
-          aria-label="Scheduled events"
+      <div
+        className="border-border bg-card relative max-h-[calc(100vh-280px)] overflow-y-auto rounded-lg border"
+        data-testid="day-calendar-grid"
+        role="grid"
+        aria-label={`Time grid for ${format(selectedDate, "EEEE, MMMM d")}`}
+      >
+        <div
+          className="relative"
+          style={{ height: `${TIME_GRID_HEIGHT_PX}px` }}
         >
-          <div className="space-y-2">
-            {timedEvents.map((event) => (
-              <EventCard
-                key={event.id}
-                event={event}
-                use24HourFormat={use24HourFormat}
-              />
-            ))}
+          {HOURS.map((hour) => (
+            <div
+              key={hour}
+              className="border-border absolute right-0 left-0 border-b"
+              style={{
+                top: `${hour * HOUR_HEIGHT_PX}px`,
+                height: `${HOUR_HEIGHT_PX}px`,
+              }}
+              aria-hidden="true"
+            >
+              <span className="text-muted-foreground absolute -top-2 left-1 w-10 pr-1 text-right text-[10px]">
+                {use24HourFormat
+                  ? `${String(hour).padStart(2, "0")}:00`
+                  : hour === 0
+                    ? "12 AM"
+                    : hour < 12
+                      ? `${hour} AM`
+                      : hour === 12
+                        ? "12 PM"
+                        : `${hour - 12} PM`}
+              </span>
+            </div>
+          ))}
+
+          <NowLine day={selectedDate} />
+
+          <div className="absolute top-0 right-2 bottom-0 left-12">
+            {timedEvents.map((event) => {
+              const { top, height } = getEventTimePosition(event, selectedDate);
+              const slot = eventColumn[event.id] ?? { column: 0, columns: 1 };
+              const widthPct = 100 / slot.columns;
+              const leftPct = slot.column * widthPct;
+
+              return (
+                <div
+                  key={event.id}
+                  data-testid="day-calendar-event"
+                  role="button"
+                  aria-label={`${event.title}, ${formatTime(event.startDate, use24HourFormat)} to ${formatTime(event.endDate, use24HourFormat)}`}
+                  className={`absolute overflow-hidden rounded border-l-4 px-2 py-1 text-xs ${getEventBlockClasses(event.color)}`}
+                  style={{
+                    top: `${top}%`,
+                    height: `${height}%`,
+                    left: `${leftPct}%`,
+                    width: `calc(${widthPct}% - 0.25rem)`,
+                  }}
+                >
+                  <h4
+                    className="truncate font-semibold"
+                    data-testid="day-calendar-event-title"
+                    title={event.title}
+                  >
+                    {event.title}
+                  </h4>
+                  <p className="text-[11px] opacity-80">
+                    {formatTime(event.startDate, use24HourFormat)} –{" "}
+                    {formatTime(event.endDate, use24HourFormat)}
+                  </p>
+                  {event.description && (
+                    <p className="mt-1 hidden truncate text-[11px] opacity-70 sm:block">
+                      {event.description}
+                    </p>
+                  )}
+                </div>
+              );
+            })}
           </div>
-        </section>
-      ) : (
-        allDayEvents.length === 0 &&
-        !isLoading && (
-          <div className="border-border bg-card text-muted-foreground rounded-lg border py-12 text-center">
-            <p>No events scheduled for this day</p>
-          </div>
-        )
-      )}
+        </div>
+
+        {timedEvents.length === 0 &&
+          allDayEvents.length === 0 &&
+          !isLoading && (
+            <div className="text-muted-foreground pointer-events-none absolute inset-0 z-10 flex items-center justify-center bg-transparent text-sm">
+              No events scheduled for this day
+            </div>
+          )}
+      </div>
     </div>
   );
 }

--- a/src/components/calendar/DayCalendar.tsx
+++ b/src/components/calendar/DayCalendar.tsx
@@ -3,10 +3,10 @@
 import { useCalendar } from "@/components/providers/CalendarProvider";
 import { Button } from "@/components/ui/button";
 import {
+  computeEventColumns,
   formatTime,
   getCurrentTimePosition,
   getEventTimePosition,
-  groupEvents,
 } from "@/lib/calendar-helpers";
 import type { IEvent, TEventColor } from "@/types/calendar";
 import { useEffect, useState } from "react";
@@ -59,13 +59,18 @@ function getAllDayPillClasses(color: TEventColor): string {
 
 function NowLine({ day }: { day: Date }) {
   const [now, setNow] = useState<Date>(() => new Date());
+  const visible = isSameDay(now, day);
 
+  // Only tick when this day is the wall-clock day. When the user
+  // navigates to a non-today view we tear down the timer; when they
+  // come back the initial `useState` re-seeds with the current time.
   useEffect(() => {
+    if (!visible) return;
     const id = setInterval(() => setNow(new Date()), 60_000);
     return () => clearInterval(id);
-  }, []);
+  }, [visible]);
 
-  if (!isSameDay(now, day)) return null;
+  if (!visible) return null;
 
   const { top } = getCurrentTimePosition(now);
 
@@ -82,8 +87,17 @@ function NowLine({ day }: { day: Date }) {
   );
 }
 
-function eventStartsOnDay(event: IEvent, day: Date): boolean {
-  return isSameDay(parseISO(event.startDate), day);
+function eventCoversDay(event: IEvent, day: Date): boolean {
+  const dayStart = startOfDay(day);
+  const dayEnd = addDays(dayStart, 1);
+  const start = parseISO(event.startDate);
+  const end = parseISO(event.endDate);
+  return start < dayEnd && end >= dayStart;
+}
+
+function isMultiDay(event: IEvent): boolean {
+  if (event.isAllDay) return true;
+  return !isSameDay(parseISO(event.startDate), parseISO(event.endDate));
 }
 
 export function DayCalendar() {
@@ -93,27 +107,31 @@ export function DayCalendar() {
   const isToday = isSameDay(selectedDate, today);
 
   const dayEvents = events.filter((event) =>
-    eventStartsOnDay(event, selectedDate)
+    eventCoversDay(event, selectedDate)
   );
-  const allDayEvents = dayEvents.filter((event) => event.isAllDay);
+  // All-day section: every all-day event covering this day, plus any
+  // multi-day timed event so the user sees the broader span hint
+  // (e.g. a multi-day trip is acknowledged on each day it touches).
+  const allDayEvents = dayEvents.filter(
+    (event) => event.isAllDay || isMultiDay(event)
+  );
+  // Timed grid: only single-day timed events (multi-day are already
+  // covered above). This avoids drawing a 24-hour-tall block on the
+  // grid for an event that isn't actually scheduled at a specific
+  // hour on this day.
   const timedEvents = dayEvents
-    .filter((event) => !event.isAllDay)
+    .filter((event) => !event.isAllDay && !isMultiDay(event))
     .sort(
       (a, b) =>
         parseISO(a.startDate).getTime() - parseISO(b.startDate).getTime()
     );
   const total = dayEvents.length;
 
-  // Compute side-by-side columns for overlapping events using the existing
-  // `groupEvents` helper. Each group is one "column" of time-stacked events;
-  // events in different groups occupy adjacent sub-columns.
-  const groups = groupEvents(timedEvents);
-  const eventColumn: Record<string, { column: number; columns: number }> = {};
-  groups.forEach((group, groupIndex) => {
-    group.forEach((event) => {
-      eventColumn[event.id] = { column: groupIndex, columns: groups.length };
-    });
-  });
+  // Compute side-by-side columns for overlapping events. Concurrency
+  // is computed *per event* so an event with no overlapping neighbour
+  // gets full width even when other events stack two-deep elsewhere
+  // in the day.
+  const eventColumn = computeEventColumns(timedEvents);
 
   const previousDay = () => setSelectedDate(subDays(selectedDate, 1));
   const nextDay = () => setSelectedDate(addDays(selectedDate, 1));
@@ -203,19 +221,32 @@ export function DayCalendar() {
             All day
           </h3>
           <ul className="flex flex-wrap gap-2">
-            {allDayEvents.map((event) => (
-              <li
-                key={event.id}
-                className={`rounded px-2 py-1 text-xs ${getAllDayPillClasses(event.color)}`}
-              >
-                <span
-                  className="font-medium"
-                  data-testid="day-calendar-event-title"
+            {allDayEvents.map((event) => {
+              const eventEnd = parseISO(event.endDate);
+              const showSpanHint =
+                isMultiDay(event) && !isSameDay(eventEnd, selectedDate);
+              return (
+                <li
+                  key={event.id}
+                  className={`rounded px-2 py-1 text-xs ${getAllDayPillClasses(event.color)}`}
                 >
-                  {event.title}
-                </span>
-              </li>
-            ))}
+                  <span
+                    className="font-medium"
+                    data-testid="day-calendar-event-title"
+                  >
+                    {event.title}
+                  </span>
+                  {showSpanHint && (
+                    <span
+                      className="ml-1 text-[10px] opacity-70"
+                      data-testid="day-calendar-event-span-hint"
+                    >
+                      (through {format(eventEnd, "MMM d")})
+                    </span>
+                  )}
+                </li>
+              );
+            })}
           </ul>
         </section>
       )}

--- a/src/components/calendar/WeekCalendar.tsx
+++ b/src/components/calendar/WeekCalendar.tsx
@@ -4,16 +4,24 @@ import { useCalendar } from "@/components/providers/CalendarProvider";
 import { Button } from "@/components/ui/button";
 import {
   WEEK_STARTS_ON,
+  assignBarRows,
   formatTime,
+  getCurrentTimePosition,
+  getEventTimePosition,
   getEventsForWeek,
   getShortWeekdayLabels,
   getWeekDates,
+  groupEvents,
 } from "@/lib/calendar-helpers";
 import type { IEvent, TEventColor } from "@/types/calendar";
+import { useEffect, useState } from "react";
 import {
   addWeeks,
+  differenceInCalendarDays,
   endOfWeek,
   format,
+  isAfter,
+  isBefore,
   isSameDay,
   isSameWeek,
   parseISO,
@@ -23,35 +31,78 @@ import {
 } from "date-fns";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 
-const MAX_EVENTS_PER_DAY = 3;
+const HOURS = Array.from({ length: 24 }, (_, i) => i);
+const HOUR_HEIGHT_PX = 40;
+const TIME_GRID_HEIGHT_PX = HOUR_HEIGHT_PX * 24;
+const BAR_ROW_HEIGHT_PX = 22;
 
-// Stable reference so midnight-boundary comparisons don't drift between the
-// week-level `isSameWeek` check and the cell-level `isSameDay` check within
-// a single render.
 const today = startOfDay(new Date());
 
-function getEventPillClasses(color: TEventColor): string {
+function getEventBlockClasses(color: TEventColor): string {
   const classes: Record<TEventColor, string> = {
-    blue: "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200",
-    green: "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
-    red: "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200",
+    blue: "border-l-blue-500 bg-blue-100/80 text-blue-900 dark:bg-blue-900/40 dark:text-blue-100",
+    green:
+      "border-l-green-500 bg-green-100/80 text-green-900 dark:bg-green-900/40 dark:text-green-100",
+    red: "border-l-red-500 bg-red-100/80 text-red-900 dark:bg-red-900/40 dark:text-red-100",
     yellow:
-      "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200",
+      "border-l-yellow-500 bg-yellow-100/80 text-yellow-900 dark:bg-yellow-900/40 dark:text-yellow-100",
     purple:
-      "bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200",
+      "border-l-purple-500 bg-purple-100/80 text-purple-900 dark:bg-purple-900/40 dark:text-purple-100",
     orange:
-      "bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200",
+      "border-l-orange-500 bg-orange-100/80 text-orange-900 dark:bg-orange-900/40 dark:text-orange-100",
   };
   return classes[color];
 }
 
-function getEventsStartingOnDay(events: IEvent[], day: Date): IEvent[] {
-  return events
-    .filter((event) => isSameDay(parseISO(event.startDate), day))
-    .sort(
-      (a, b) =>
-        parseISO(a.startDate).getTime() - parseISO(b.startDate).getTime()
-    );
+function getBarPillClasses(color: TEventColor): string {
+  const classes: Record<TEventColor, string> = {
+    blue: "bg-blue-500 text-white",
+    green: "bg-green-500 text-white",
+    red: "bg-red-500 text-white",
+    yellow: "bg-yellow-500 text-yellow-950",
+    purple: "bg-purple-500 text-white",
+    orange: "bg-orange-500 text-white",
+  };
+  return classes[color];
+}
+
+function NowLine({ weekStart, weekEnd }: { weekStart: Date; weekEnd: Date }) {
+  const [now, setNow] = useState<Date>(() => new Date());
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), 60_000);
+    return () => clearInterval(id);
+  }, []);
+
+  if (isBefore(now, weekStart) || isAfter(now, weekEnd)) return null;
+
+  const dayIndex = differenceInCalendarDays(now, weekStart);
+  if (dayIndex < 0 || dayIndex > 6) return null;
+
+  const { top } = getCurrentTimePosition(now);
+  const widthPct = 100 / 7;
+  const leftPct = dayIndex * widthPct;
+
+  return (
+    <div
+      data-testid="week-calendar-now-line"
+      className="pointer-events-none absolute z-20 flex items-center"
+      style={{
+        top: `${top}%`,
+        left: `${leftPct}%`,
+        width: `${widthPct}%`,
+      }}
+      aria-hidden="true"
+    >
+      <span className="-ml-1.5 inline-block h-3 w-3 rounded-full bg-red-500" />
+      <span className="h-px flex-1 bg-red-500" />
+    </div>
+  );
+}
+
+function isMultiDayEvent(event: IEvent): boolean {
+  if (event.isAllDay) return true;
+  return !isSameDay(parseISO(event.startDate), parseISO(event.endDate));
 }
 
 export function WeekCalendar() {
@@ -74,9 +125,17 @@ export function WeekCalendar() {
   const nextWeek = () => setSelectedDate(addWeeks(selectedDate, 1));
   const goToToday = () => setSelectedDate(new Date());
 
+  // Split into multi-day vs single-day timed events.
+  const multiDayEvents = weekEvents.filter(isMultiDayEvent);
+  const timedEvents = weekEvents.filter((e) => !isMultiDayEvent(e));
+  const barRows = assignBarRows(multiDayEvents, weekStart, weekEnd);
+  const barRowCount =
+    Object.values(barRows).length === 0
+      ? 0
+      : Math.max(...Object.values(barRows)) + 1;
+
   return (
     <div className="w-full space-y-4">
-      {/* Header */}
       <div className="flex items-center justify-between">
         <div>
           <div className="flex items-center gap-3">
@@ -128,99 +187,222 @@ export function WeekCalendar() {
         </div>
       </div>
 
-      {/* Loading */}
       {isLoading && (
         <div className="text-muted-foreground text-center">
           Loading events...
         </div>
       )}
 
-      {/* Week grid */}
       <div
-        className="border-border bg-card rounded-lg border"
+        className="border-border bg-card overflow-hidden rounded-lg border"
         role="grid"
         aria-label={`Week of ${format(weekStart, "MMMM d, yyyy")}`}
       >
-        <div
-          className="border-border bg-muted grid grid-cols-7 border-b"
-          role="row"
-        >
-          {weekdayHeaders.map((label) => (
-            <div
-              key={label}
-              role="columnheader"
-              className="text-muted-foreground p-3 text-center text-sm font-semibold"
-            >
-              {label}
-            </div>
-          ))}
-        </div>
-
-        <div className="grid grid-cols-7" role="row">
-          {weekDates.map((day, index) => {
-            const dayEvents = getEventsStartingOnDay(weekEvents, day);
-            const isToday = isSameDay(day, today);
-            const visible = dayEvents.slice(0, MAX_EVENTS_PER_DAY);
-            const overflow = dayEvents.length - visible.length;
-
-            return (
-              <div
-                key={day.toISOString()}
-                role="gridcell"
-                aria-label={format(day, "EEEE, MMMM d")}
-                data-testid={isToday ? "week-calendar-today-cell" : undefined}
-                className={`border-border min-h-[240px] border-r border-b p-2 last:border-r-0 ${
-                  isToday ? "bg-blue-50 dark:bg-blue-950" : "bg-card"
-                }`}
-              >
-                <div className="mb-2 flex items-center justify-between">
-                  <span
-                    className="text-muted-foreground text-xs font-medium"
-                    aria-hidden="true"
-                  >
+        <div className="border-border bg-muted flex border-b" role="row">
+          <div className="w-12 shrink-0" aria-hidden="true" />
+          <div className="grid flex-1 grid-cols-7">
+            {weekDates.map((day, index) => {
+              const isTodayCell = isSameDay(day, today);
+              return (
+                <div
+                  key={day.toISOString()}
+                  role="columnheader"
+                  data-testid={
+                    isTodayCell ? "week-calendar-today-cell" : undefined
+                  }
+                  className={`flex flex-col items-center p-2 ${isTodayCell ? "bg-blue-50 dark:bg-blue-950" : ""}`}
+                >
+                  <span className="text-muted-foreground text-xs font-semibold">
                     {weekdayHeaders[index]}
                   </span>
                   <span
                     className={
-                      isToday
-                        ? "inline-flex h-6 w-6 items-center justify-center rounded-full bg-blue-600 text-sm text-white"
-                        : "text-foreground text-sm font-semibold"
+                      isTodayCell
+                        ? "mt-0.5 inline-flex h-7 w-7 items-center justify-center rounded-full bg-blue-600 text-sm text-white"
+                        : "text-foreground mt-0.5 text-sm font-semibold"
                     }
                   >
                     {format(day, "d")}
                   </span>
                 </div>
+              );
+            })}
+          </div>
+        </div>
 
-                <div className="space-y-1">
-                  {visible.map((event) => (
-                    <div
-                      key={event.id}
-                      role="listitem"
-                      aria-label={
-                        event.isAllDay
-                          ? `${event.title}, all day`
-                          : `${event.title}, ${formatTime(event.startDate, use24HourFormat)}`
-                      }
-                      className={`truncate rounded px-2 py-1 text-xs ${getEventPillClasses(event.color)}`}
-                      title={event.title}
-                    >
-                      {!event.isAllDay && (
-                        <span className="mr-1 font-medium">
-                          {formatTime(event.startDate, use24HourFormat)}
-                        </span>
-                      )}
+        {(barRowCount > 0 || multiDayEvents.length > 0) && (
+          <div
+            className="border-border flex border-b"
+            data-testid="week-calendar-multi-day-row"
+            role="row"
+            aria-label="All-day and multi-day events"
+          >
+            <div className="w-12 shrink-0" aria-hidden="true" />
+            <div
+              className="relative flex-1"
+              style={{
+                height: `${Math.max(barRowCount, 1) * BAR_ROW_HEIGHT_PX + 8}px`,
+              }}
+            >
+              {multiDayEvents.map((event) => {
+                const row = barRows[event.id];
+                if (row === undefined) return null;
+                const eventStart = parseISO(event.startDate);
+                const eventEnd = parseISO(event.endDate);
+                const visibleStart =
+                  eventStart < weekStart ? weekStart : eventStart;
+                const visibleEnd = eventEnd > weekEnd ? weekEnd : eventEnd;
+                const startCol = differenceInCalendarDays(
+                  visibleStart,
+                  weekStart
+                );
+                const span =
+                  differenceInCalendarDays(visibleEnd, visibleStart) + 1;
+                const widthPct = (span * 100) / 7;
+                const leftPct = (startCol * 100) / 7;
+
+                return (
+                  <div
+                    key={event.id}
+                    data-testid="week-calendar-multi-day-bar"
+                    className={`absolute mx-0.5 truncate rounded px-2 py-0.5 text-xs ${getBarPillClasses(event.color)}`}
+                    style={{
+                      top: `${row * BAR_ROW_HEIGHT_PX + 4}px`,
+                      left: `${leftPct}%`,
+                      width: `calc(${widthPct}% - 0.25rem)`,
+                      height: `${BAR_ROW_HEIGHT_PX - 4}px`,
+                    }}
+                    title={event.title}
+                  >
+                    <span data-testid="week-calendar-event-title">
                       {event.title}
-                    </div>
-                  ))}
-                  {overflow > 0 && (
-                    <div className="text-muted-foreground text-xs">
-                      +{overflow} more
-                    </div>
-                  )}
-                </div>
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        <div className="relative flex max-h-[calc(100vh-320px)] overflow-y-auto">
+          <div
+            className="w-12 shrink-0"
+            style={{ height: `${TIME_GRID_HEIGHT_PX}px` }}
+            aria-hidden="true"
+          >
+            {HOURS.map((hour) => (
+              <div
+                key={hour}
+                className="border-border relative border-b"
+                style={{ height: `${HOUR_HEIGHT_PX}px` }}
+              >
+                <span className="text-muted-foreground absolute -top-2 right-1 text-[10px]">
+                  {use24HourFormat
+                    ? `${String(hour).padStart(2, "0")}:00`
+                    : hour === 0
+                      ? "12 AM"
+                      : hour < 12
+                        ? `${hour} AM`
+                        : hour === 12
+                          ? "12 PM"
+                          : `${hour - 12} PM`}
+                </span>
               </div>
-            );
-          })}
+            ))}
+          </div>
+
+          <div
+            className="relative grid flex-1 grid-cols-7"
+            style={{ height: `${TIME_GRID_HEIGHT_PX}px` }}
+          >
+            {weekDates.map((day) => {
+              const isTodayCol = isSameDay(day, today);
+              const dayTimedEvents = timedEvents
+                .filter((e) => isSameDay(parseISO(e.startDate), day))
+                .sort(
+                  (a, b) =>
+                    parseISO(a.startDate).getTime() -
+                    parseISO(b.startDate).getTime()
+                );
+              const dayGroups = groupEvents(dayTimedEvents);
+              const eventColumn: Record<
+                string,
+                { column: number; columns: number }
+              > = {};
+              dayGroups.forEach((group, groupIndex) => {
+                group.forEach((event) => {
+                  eventColumn[event.id] = {
+                    column: groupIndex,
+                    columns: dayGroups.length,
+                  };
+                });
+              });
+
+              return (
+                <div
+                  key={day.toISOString()}
+                  role="gridcell"
+                  data-testid={`week-calendar-day-col-${format(day, "yyyy-MM-dd")}`}
+                  className={`border-border relative border-r last:border-r-0 ${
+                    isTodayCol ? "bg-blue-50/40 dark:bg-blue-950/40" : ""
+                  }`}
+                >
+                  {HOURS.map((hour) => (
+                    <div
+                      key={hour}
+                      className="border-border absolute right-0 left-0 border-b"
+                      style={{
+                        top: `${hour * HOUR_HEIGHT_PX}px`,
+                        height: `${HOUR_HEIGHT_PX}px`,
+                      }}
+                      aria-hidden="true"
+                    />
+                  ))}
+
+                  {dayTimedEvents.map((event) => {
+                    const { top, height } = getEventTimePosition(event, day);
+                    const slot = eventColumn[event.id] ?? {
+                      column: 0,
+                      columns: 1,
+                    };
+                    const widthPct = 100 / slot.columns;
+                    const leftPct = slot.column * widthPct;
+
+                    return (
+                      <div
+                        key={event.id}
+                        data-testid="week-calendar-event"
+                        role="button"
+                        aria-label={`${event.title}, ${formatTime(event.startDate, use24HourFormat)} to ${formatTime(event.endDate, use24HourFormat)}`}
+                        className={`absolute overflow-hidden rounded border-l-4 px-1 py-0.5 text-[10px] leading-tight ${getEventBlockClasses(event.color)}`}
+                        style={{
+                          top: `${top}%`,
+                          height: `${height}%`,
+                          left: `${leftPct}%`,
+                          width: `calc(${widthPct}% - 0.125rem)`,
+                        }}
+                      >
+                        <div
+                          className="truncate font-semibold"
+                          data-testid="week-calendar-event-title"
+                          title={event.title}
+                        >
+                          {event.title}
+                        </div>
+                        {!event.isAllDay && (
+                          <div className="truncate opacity-80">
+                            {formatTime(event.startDate, use24HourFormat)}
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              );
+            })}
+
+            <NowLine weekStart={weekStart} weekEnd={weekEnd} />
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/calendar/WeekCalendar.tsx
+++ b/src/components/calendar/WeekCalendar.tsx
@@ -5,13 +5,13 @@ import { Button } from "@/components/ui/button";
 import {
   WEEK_STARTS_ON,
   assignBarRows,
+  computeEventColumns,
   formatTime,
   getCurrentTimePosition,
   getEventTimePosition,
   getEventsForWeek,
   getShortWeekdayLabels,
   getWeekDates,
-  groupEvents,
 } from "@/lib/calendar-helpers";
 import type { IEvent, TEventColor } from "@/types/calendar";
 import { useEffect, useState } from "react";
@@ -68,13 +68,17 @@ function getBarPillClasses(color: TEventColor): string {
 
 function NowLine({ weekStart, weekEnd }: { weekStart: Date; weekEnd: Date }) {
   const [now, setNow] = useState<Date>(() => new Date());
+  const visible = !isBefore(now, weekStart) && !isAfter(now, weekEnd);
 
+  // Only tick when "now" is inside the displayed week. Past/future
+  // weeks don't need the indicator and shouldn't burn a timer.
   useEffect(() => {
+    if (!visible) return;
     const id = setInterval(() => setNow(new Date()), 60_000);
     return () => clearInterval(id);
-  }, []);
+  }, [visible]);
 
-  if (isBefore(now, weekStart) || isAfter(now, weekEnd)) return null;
+  if (!visible) return null;
 
   const dayIndex = differenceInCalendarDays(now, weekStart);
   if (dayIndex < 0 || dayIndex > 6) return null;
@@ -324,19 +328,7 @@ export function WeekCalendar() {
                     parseISO(a.startDate).getTime() -
                     parseISO(b.startDate).getTime()
                 );
-              const dayGroups = groupEvents(dayTimedEvents);
-              const eventColumn: Record<
-                string,
-                { column: number; columns: number }
-              > = {};
-              dayGroups.forEach((group, groupIndex) => {
-                group.forEach((event) => {
-                  eventColumn[event.id] = {
-                    column: groupIndex,
-                    columns: dayGroups.length,
-                  };
-                });
-              });
+              const eventColumn = computeEventColumns(dayTimedEvents);
 
               return (
                 <div

--- a/src/components/calendar/__tests__/DayCalendar.test.tsx
+++ b/src/components/calendar/__tests__/DayCalendar.test.tsx
@@ -321,4 +321,91 @@ describe("DayCalendar", () => {
       ).not.toBeInTheDocument();
     });
   });
+
+  describe("Time grid", () => {
+    it("renders timed events as positioned blocks with top/height", () => {
+      const selectedDate = startOfDay(new Date(2026, 3, 15));
+      renderWithContext({
+        selectedDate,
+        events: [
+          createMockEvent({
+            id: "morning",
+            title: "Morning Meeting",
+            startDate: at(selectedDate, 9),
+            endDate: at(selectedDate, 10),
+          }),
+        ],
+      });
+
+      const eventBlock = screen.getByTestId("day-calendar-event");
+      const style = eventBlock.getAttribute("style") || "";
+      // 9:00 / 24h = 37.5%
+      expect(style).toMatch(/top:\s*37\.5%/);
+      // 1h / 24h ≈ 4.166%
+      expect(style).toMatch(/height:\s*4\.16/);
+    });
+
+    it("places adjacent overlapping events into separate sub-columns", () => {
+      const selectedDate = startOfDay(new Date(2026, 3, 15));
+      renderWithContext({
+        selectedDate,
+        events: [
+          createMockEvent({
+            id: "a",
+            title: "A",
+            startDate: at(selectedDate, 10),
+            endDate: at(selectedDate, 11),
+          }),
+          createMockEvent({
+            id: "b",
+            title: "B",
+            startDate: at(selectedDate, 10, 30),
+            endDate: at(selectedDate, 11, 30),
+          }),
+        ],
+      });
+
+      const blocks = screen.getAllByTestId("day-calendar-event");
+      expect(blocks).toHaveLength(2);
+      const lefts = blocks.map((b) => {
+        const m = (b.getAttribute("style") || "").match(/left:\s*([0-9.]+)%/);
+        return m ? Number(m[1]) : Number.NaN;
+      });
+      // Two distinct column origins (0% and 50%)
+      expect(new Set(lefts).size).toBe(2);
+    });
+
+    it("renders the now line on today's view", () => {
+      renderWithContext({ selectedDate: new Date() });
+      expect(screen.getByTestId("day-calendar-now-line")).toBeInTheDocument();
+    });
+
+    it("does not render the now line on a non-today day", () => {
+      renderWithContext({ selectedDate: subDays(new Date(), 3) });
+      expect(
+        screen.queryByTestId("day-calendar-now-line")
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Filters", () => {
+    it("renders only events the provider has not filtered out", () => {
+      // Provider's `events` is already post-filter — DayCalendar must just
+      // render what it receives.
+      const selectedDate = startOfDay(new Date(2026, 3, 15));
+      renderWithContext({
+        selectedDate,
+        events: [
+          createMockEvent({
+            id: "kept",
+            title: "Visible",
+            startDate: at(selectedDate, 10),
+            endDate: at(selectedDate, 11),
+          }),
+        ],
+      });
+      expect(screen.getByText("Visible")).toBeInTheDocument();
+      expect(screen.queryByText("Hidden")).not.toBeInTheDocument();
+    });
+  });
 });

--- a/src/components/calendar/__tests__/DayCalendar.test.tsx
+++ b/src/components/calendar/__tests__/DayCalendar.test.tsx
@@ -388,6 +388,74 @@ describe("DayCalendar", () => {
     });
   });
 
+  describe("Multi-day events", () => {
+    it("shows a multi-day all-day event in the all-day section even when the user is mid-span", () => {
+      const selectedDate = startOfDay(new Date(2026, 3, 15)); // Wed
+      const start = subDays(selectedDate, 2); // Mon
+      const end = addDays(selectedDate, 2); // Fri
+      renderWithContext({
+        selectedDate,
+        events: [
+          createMockEvent({
+            id: "trip",
+            title: "Family Trip",
+            startDate: start.toISOString(),
+            endDate: end.toISOString(),
+            isAllDay: true,
+          }),
+        ],
+      });
+      expect(screen.getByText("Family Trip")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("day-calendar-event-span-hint")
+      ).toHaveTextContent(`(through ${format(end, "MMM d")})`);
+    });
+
+    it("omits the span hint when the multi-day event ends on the viewed day", () => {
+      const selectedDate = startOfDay(new Date(2026, 3, 15));
+      const start = subDays(selectedDate, 1);
+      renderWithContext({
+        selectedDate,
+        events: [
+          createMockEvent({
+            id: "ending",
+            title: "Wraps Today",
+            startDate: start.toISOString(),
+            endDate: selectedDate.toISOString(),
+            isAllDay: true,
+          }),
+        ],
+      });
+      expect(
+        screen.queryByTestId("day-calendar-event-span-hint")
+      ).not.toBeInTheDocument();
+    });
+
+    it("does not render multi-day events as full-height blocks on the time grid", () => {
+      const selectedDate = startOfDay(new Date(2026, 3, 15));
+      const start = subDays(selectedDate, 1);
+      const end = addDays(selectedDate, 1);
+      renderWithContext({
+        selectedDate,
+        events: [
+          createMockEvent({
+            id: "trip",
+            title: "Trip",
+            startDate: start.toISOString(),
+            endDate: end.toISOString(),
+            isAllDay: false,
+          }),
+        ],
+      });
+      // The multi-day event must appear once (in the all-day section)
+      // and not also on the time grid as a positioned block.
+      expect(
+        screen.queryByTestId("day-calendar-event")
+      ).not.toBeInTheDocument();
+      expect(screen.getByText("Trip")).toBeInTheDocument();
+    });
+  });
+
   describe("Filters", () => {
     it("renders only events the provider has not filtered out", () => {
       // Provider's `events` is already post-filter — DayCalendar must just

--- a/src/components/calendar/__tests__/WeekCalendar.test.tsx
+++ b/src/components/calendar/__tests__/WeekCalendar.test.tsx
@@ -277,25 +277,36 @@ describe("WeekCalendar", () => {
       expect(screen.getByText("Standup")).toBeInTheDocument();
     });
 
-    it("shows '+X more' when a day has more than 3 events", () => {
+    it("renders all timed events on a busy day in side-by-side columns", () => {
+      // Time-grid layout positions events absolutely, so there is no
+      // "+X more" overflow — overlapping events stack into adjacent
+      // sub-columns within the day cell. This replaces the row-list
+      // overflow assertion that was removed when WeekCalendar moved
+      // from a stacked list to a time grid.
       const selectedDate = midday(new Date(2026, 3, 15));
       const weekStart = startOfWeek(selectedDate, {
         weekStartsOn: WEEK_STARTS_ON,
       });
       const day = addDays(weekStart, 1);
 
-      const events = Array.from({ length: 5 }, (_, i) =>
-        createMockEvent({
+      const events = Array.from({ length: 5 }, (_, i) => {
+        const start = new Date(day);
+        start.setHours(10 + i, 0, 0, 0);
+        const end = new Date(day);
+        end.setHours(11 + i, 0, 0, 0);
+        return createMockEvent({
           id: `m-${i}`,
           title: `Event ${i + 1}`,
-          startDate: midday(day).toISOString(),
-          endDate: midday(day).toISOString(),
-        })
-      );
+          startDate: start.toISOString(),
+          endDate: end.toISOString(),
+        });
+      });
 
       renderWithContext({ selectedDate, events });
 
-      expect(screen.getByText("+2 more")).toBeInTheDocument();
+      for (let i = 1; i <= 5; i++) {
+        expect(screen.getByText(`Event ${i}`)).toBeInTheDocument();
+      }
     });
 
     it("shows all-day events with an 'All day' label", () => {
@@ -325,6 +336,106 @@ describe("WeekCalendar", () => {
     it("shows loading indicator when isLoading is true", () => {
       renderWithContext({ isLoading: true });
       expect(screen.getByText("Loading events...")).toBeInTheDocument();
+    });
+  });
+
+  describe("Time grid", () => {
+    it("positions a timed event at the correct top within its day column", () => {
+      const selectedDate = midday(new Date(2026, 3, 15));
+      const weekStart = startOfWeek(selectedDate, {
+        weekStartsOn: WEEK_STARTS_ON,
+      });
+      const day = addDays(weekStart, 2);
+      const start = new Date(day);
+      start.setHours(9, 0, 0, 0);
+      const end = new Date(day);
+      end.setHours(10, 0, 0, 0);
+
+      renderWithContext({
+        selectedDate,
+        events: [
+          createMockEvent({
+            id: "morning",
+            title: "Morning",
+            startDate: start.toISOString(),
+            endDate: end.toISOString(),
+          }),
+        ],
+      });
+
+      const event = screen.getByTestId("week-calendar-event");
+      const style = event.getAttribute("style") || "";
+      expect(style).toMatch(/top:\s*37\.5%/);
+      expect(style).toMatch(/height:\s*4\.16/);
+    });
+
+    it("renders the now line for today", () => {
+      renderWithContext({ selectedDate: new Date() });
+      expect(screen.getByTestId("week-calendar-now-line")).toBeInTheDocument();
+    });
+
+    it("does not render the now line for a past or future week", () => {
+      renderWithContext({ selectedDate: subWeeks(new Date(), 4) });
+      expect(
+        screen.queryByTestId("week-calendar-now-line")
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Multi-day spanning bars", () => {
+    it("renders a single bar for an event spanning multiple days", () => {
+      const selectedDate = midday(new Date(2026, 3, 15));
+      const weekStart = startOfWeek(selectedDate, {
+        weekStartsOn: WEEK_STARTS_ON,
+      });
+
+      renderWithContext({
+        selectedDate,
+        events: [
+          createMockEvent({
+            id: "trip",
+            title: "Family Trip",
+            startDate: addDays(weekStart, 1).toISOString(),
+            endDate: addDays(weekStart, 4).toISOString(),
+          }),
+        ],
+      });
+
+      const bars = screen.getAllByTestId("week-calendar-multi-day-bar");
+      expect(bars).toHaveLength(1);
+      expect(bars[0]).toHaveTextContent("Family Trip");
+    });
+
+    it("treats all-day events as multi-day bars", () => {
+      const selectedDate = midday(new Date(2026, 3, 15));
+      const weekStart = startOfWeek(selectedDate, {
+        weekStartsOn: WEEK_STARTS_ON,
+      });
+      const day = addDays(weekStart, 3);
+
+      renderWithContext({
+        selectedDate,
+        events: [
+          createMockEvent({
+            id: "holiday",
+            title: "Holiday",
+            startDate: day.toISOString(),
+            endDate: day.toISOString(),
+            isAllDay: true,
+          }),
+        ],
+      });
+
+      const bars = screen.getAllByTestId("week-calendar-multi-day-bar");
+      expect(bars).toHaveLength(1);
+      expect(bars[0]).toHaveTextContent("Holiday");
+    });
+
+    it("does not render the multi-day row when no spanning events exist", () => {
+      renderWithContext({ selectedDate: new Date(2026, 3, 15), events: [] });
+      expect(
+        screen.queryByTestId("week-calendar-multi-day-row")
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/src/components/providers/__tests__/CalendarProvider.test.tsx
+++ b/src/components/providers/__tests__/CalendarProvider.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * Regression tests for CalendarProvider behavior that day/week views
+ * depend on (issue #113):
+ *
+ * - `setSelectedDate(date)` triggers `loadEventsForDate` for any
+ *   navigation away from the originally loaded month — ensures the
+ *   week/day chevrons fetch needed data.
+ * - `events` exposed by the provider reflect color/user filters so
+ *   downstream views (`DayCalendar`, `WeekCalendar`) inherit filtering
+ *   without re-implementing it.
+ *
+ * The full provider exercises NextAuth, IndexedDB, and `fetch`. We
+ * mock those at the module boundary so the tests stay tight.
+ */
+import {
+  CalendarProvider,
+  useCalendar,
+} from "@/components/providers/CalendarProvider";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { addMonths } from "date-fns";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => ({
+    data: {
+      user: { name: "Test", email: "test@test.test" },
+      expires: new Date(Date.now() + 86_400_000).toISOString(),
+    },
+    status: "authenticated",
+  }),
+}));
+
+vi.mock("@/lib/calendar-storage", () => ({
+  loadColorMappings: () => [],
+  saveColorMappings: vi.fn(),
+  loadSettings: () => ({ refreshInterval: 60 }),
+  eventCache: {
+    getEvents: vi.fn().mockResolvedValue([]),
+    saveEvents: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock("@/lib/calendar-transform", () => ({
+  transformGoogleEvent: (
+    event: { id: string; summary?: string; start?: { dateTime?: string } },
+    _mappings: unknown
+  ) => ({
+    id: event.id,
+    title: event.summary ?? "Mock",
+    description: "",
+    startDate: event.start?.dateTime ?? new Date().toISOString(),
+    endDate: event.start?.dateTime ?? new Date().toISOString(),
+    color: "blue",
+    isAllDay: false,
+    calendarId: "primary",
+    user: { id: "u1", name: "Mock", picturePath: null },
+  }),
+}));
+
+function fetchOk(body: unknown): Response {
+  return {
+    ok: true,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+const baseEvent = (
+  id: string,
+  startISO: string,
+  user = { id: "u1", name: "Alice", picturePath: null }
+) => ({
+  id,
+  summary: id,
+  start: { dateTime: startISO },
+  end: { dateTime: startISO },
+  user,
+});
+
+function ProbeNav({ targetDate }: { targetDate: Date }) {
+  const { setSelectedDate } = useCalendar();
+  return (
+    <button onClick={() => setSelectedDate(targetDate)} type="button">
+      jump
+    </button>
+  );
+}
+
+function EventList() {
+  const { events } = useCalendar();
+  return (
+    <ul data-testid="provider-event-list">
+      {events.map((e) => (
+        <li key={e.id}>{e.title}</li>
+      ))}
+    </ul>
+  );
+}
+
+describe("CalendarProvider", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockImplementation((input: string | URL) => {
+      const url = String(input);
+      if (url.includes("/api/calendar/calendars")) {
+        return Promise.resolve(fetchOk({ calendars: [{ id: "primary" }] }));
+      }
+      if (url.includes("/api/calendar/colors")) {
+        return Promise.resolve(fetchOk({ colorMappings: [] }));
+      }
+      if (url.includes("/api/calendar/events")) {
+        return Promise.resolve(
+          fetchOk({
+            events: [baseEvent("seed-1", new Date().toISOString())],
+          })
+        );
+      }
+      return Promise.resolve(fetchOk({}));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("loads events on mount when authenticated", async () => {
+    render(
+      <CalendarProvider>
+        <EventList />
+      </CalendarProvider>
+    );
+
+    await waitFor(() => {
+      const calls = fetchMock.mock.calls.map((c) => String(c[0]));
+      expect(calls.some((u) => u.includes("/api/calendar/events"))).toBe(true);
+    });
+  });
+
+  it("triggers loadEventsForDate when selectedDate moves outside the loaded range", async () => {
+    render(
+      <CalendarProvider>
+        <ProbeNav targetDate={addMonths(new Date(), 9)} />
+      </CalendarProvider>
+    );
+
+    await waitFor(() => {
+      const calls = fetchMock.mock.calls.map((c) => String(c[0]));
+      expect(calls.some((u) => u.includes("/api/calendar/events"))).toBe(true);
+    });
+
+    const initialEventFetches = fetchMock.mock.calls
+      .map((c) => String(c[0]))
+      .filter((u) => u.includes("/api/calendar/events")).length;
+
+    await userEvent.setup().click(screen.getByText("jump"));
+
+    await waitFor(() => {
+      const eventFetches = fetchMock.mock.calls
+        .map((c) => String(c[0]))
+        .filter((u) => u.includes("/api/calendar/events")).length;
+      expect(eventFetches).toBeGreaterThan(initialEventFetches);
+    });
+  });
+});

--- a/src/components/providers/__tests__/CalendarProvider.test.tsx
+++ b/src/components/providers/__tests__/CalendarProvider.test.tsx
@@ -42,8 +42,16 @@ vi.mock("@/lib/calendar-storage", () => ({
 }));
 
 vi.mock("@/lib/calendar-transform", () => ({
+  // Honour `colorOverride` on the test fixture so the filter test
+  // can assert that filtering by color actually drops the right
+  // events. Defaults to "blue" when no override is given.
   transformGoogleEvent: (
-    event: { id: string; summary?: string; start?: { dateTime?: string } },
+    event: {
+      id: string;
+      summary?: string;
+      start?: { dateTime?: string };
+      colorOverride?: string;
+    },
     _mappings: unknown
   ) => ({
     id: event.id,
@@ -51,7 +59,7 @@ vi.mock("@/lib/calendar-transform", () => ({
     description: "",
     startDate: event.start?.dateTime ?? new Date().toISOString(),
     endDate: event.start?.dateTime ?? new Date().toISOString(),
-    color: "blue",
+    color: event.colorOverride ?? "blue",
     isAllDay: false,
     calendarId: "primary",
     user: { id: "u1", name: "Mock", picturePath: null },
@@ -139,10 +147,12 @@ describe("CalendarProvider", () => {
     });
   });
 
-  it("triggers loadEventsForDate when selectedDate moves outside the loaded range", async () => {
+  it("triggers loadEventsForDate with timeMin/timeMax for the navigation target", async () => {
+    const target = addMonths(new Date(), 9);
+
     render(
       <CalendarProvider>
-        <ProbeNav targetDate={addMonths(new Date(), 9)} />
+        <ProbeNav targetDate={target} />
       </CalendarProvider>
     );
 
@@ -151,17 +161,107 @@ describe("CalendarProvider", () => {
       expect(calls.some((u) => u.includes("/api/calendar/events"))).toBe(true);
     });
 
-    const initialEventFetches = fetchMock.mock.calls
+    const initialEventCalls = fetchMock.mock.calls
       .map((c) => String(c[0]))
       .filter((u) => u.includes("/api/calendar/events")).length;
 
     await userEvent.setup().click(screen.getByText("jump"));
 
     await waitFor(() => {
-      const eventFetches = fetchMock.mock.calls
+      const eventCalls = fetchMock.mock.calls
         .map((c) => String(c[0]))
-        .filter((u) => u.includes("/api/calendar/events")).length;
-      expect(eventFetches).toBeGreaterThan(initialEventFetches);
+        .filter((u) => u.includes("/api/calendar/events"));
+      expect(eventCalls.length).toBeGreaterThan(initialEventCalls);
+
+      // The most recent fetch must include the target month in its
+      // timeMin/timeMax — confirms the provider isn't just spamming
+      // the same range.
+      const lastUrl = eventCalls.at(-1) ?? "";
+      const params = new URLSearchParams(lastUrl.split("?")[1] ?? "");
+      const timeMin = params.get("timeMin") ?? "";
+      const timeMax = params.get("timeMax") ?? "";
+      expect(timeMin).toMatch(/^\d{4}-\d{2}-\d{2}/);
+      expect(timeMax).toMatch(/^\d{4}-\d{2}-\d{2}/);
+
+      const tMin = new Date(timeMin).getTime();
+      const tMax = new Date(timeMax).getTime();
+      expect(tMin).toBeLessThanOrEqual(target.getTime());
+      expect(tMax).toBeGreaterThanOrEqual(target.getTime());
+    });
+  });
+
+  it("filters events by selectedColors", async () => {
+    function ColorProbe() {
+      const { events, filterEventsBySelectedColors } = useCalendar();
+      return (
+        <div>
+          <button
+            type="button"
+            onClick={() => filterEventsBySelectedColors("blue")}
+          >
+            filter-blue
+          </button>
+          <ul data-testid="probe-events">
+            {events.map((e) => (
+              <li key={e.id}>{e.title}</li>
+            ))}
+          </ul>
+        </div>
+      );
+    }
+
+    fetchMock.mockImplementation((input: string | URL) => {
+      const url = String(input);
+      if (url.includes("/api/calendar/calendars")) {
+        return Promise.resolve(fetchOk({ calendars: [{ id: "primary" }] }));
+      }
+      if (url.includes("/api/calendar/colors")) {
+        return Promise.resolve(fetchOk({ colorMappings: [] }));
+      }
+      if (url.includes("/api/calendar/events")) {
+        return Promise.resolve(
+          fetchOk({
+            events: [
+              {
+                id: "blue-event",
+                summary: "Blue Event",
+                start: { dateTime: new Date().toISOString() },
+                end: { dateTime: new Date().toISOString() },
+                colorOverride: "blue",
+              },
+              {
+                id: "red-event",
+                summary: "Red Event",
+                start: { dateTime: new Date().toISOString() },
+                end: { dateTime: new Date().toISOString() },
+                colorOverride: "red",
+              },
+            ],
+          })
+        );
+      }
+      return Promise.resolve(fetchOk({}));
+    });
+
+    render(
+      <CalendarProvider>
+        <ColorProbe />
+      </CalendarProvider>
+    );
+
+    // Both events render initially.
+    await waitFor(() => {
+      expect(screen.getByText("Blue Event")).toBeInTheDocument();
+      expect(screen.getByText("Red Event")).toBeInTheDocument();
+    });
+
+    // Activate the blue filter.
+    await userEvent.setup().click(screen.getByText("filter-blue"));
+
+    // Red drops, blue stays.
+    await waitFor(() => {
+      expect(screen.getByText("Blue Event")).toBeInTheDocument();
+      expect(screen.queryByText("Red Event")).not.toBeInTheDocument();
     });
   });
 });

--- a/src/lib/__tests__/calendar-helpers.test.ts
+++ b/src/lib/__tests__/calendar-helpers.test.ts
@@ -2,10 +2,13 @@ import type { IEvent, TCalendarView } from "@/types/calendar";
 import { describe, expect, it } from "vitest";
 import {
   WEEK_STARTS_ON,
+  assignBarRows,
   formatTime,
   getBgColor,
   getCalendarCells,
   getColorClass,
+  getCurrentTimePosition,
+  getEventTimePosition,
   getEventsCount,
   getEventsForDay,
   getEventsForMonth,
@@ -459,5 +462,135 @@ describe("getBgColor", () => {
 
   it("returns empty string for unknown color", () => {
     expect(getBgColor("unknown")).toBe("");
+  });
+});
+
+describe("getEventTimePosition", () => {
+  const day = new Date(2026, 3, 15); // Apr 15 2026
+
+  it("positions a 9:00–10:00 event at top=37.5%, height=4.166...%", () => {
+    const event = createMockEvent({
+      startDate: new Date(2026, 3, 15, 9, 0).toISOString(),
+      endDate: new Date(2026, 3, 15, 10, 0).toISOString(),
+    });
+    const { top, height } = getEventTimePosition(event, day);
+    expect(top).toBeCloseTo((9 * 60 * 100) / 1440, 5); // 37.5
+    expect(height).toBeCloseTo((60 * 100) / 1440, 5); // ~4.166
+  });
+
+  it("positions an event at midnight start with top=0", () => {
+    const event = createMockEvent({
+      startDate: new Date(2026, 3, 15, 0, 0).toISOString(),
+      endDate: new Date(2026, 3, 15, 1, 0).toISOString(),
+    });
+    expect(getEventTimePosition(event, day).top).toBe(0);
+  });
+
+  it("clamps top to 0 when event starts before the day", () => {
+    const event = createMockEvent({
+      startDate: new Date(2026, 3, 14, 22, 0).toISOString(),
+      endDate: new Date(2026, 3, 15, 6, 0).toISOString(),
+    });
+    const { top, height } = getEventTimePosition(event, day);
+    expect(top).toBe(0);
+    // 6 hours of height = 25%
+    expect(height).toBeCloseTo(25, 5);
+  });
+
+  it("clamps height when event ends after the day", () => {
+    const event = createMockEvent({
+      startDate: new Date(2026, 3, 15, 22, 0).toISOString(),
+      endDate: new Date(2026, 3, 16, 4, 0).toISOString(),
+    });
+    const { top, height } = getEventTimePosition(event, day);
+    // top: 22*60 / 1440 * 100 = 91.666...
+    expect(top).toBeCloseTo((22 * 60 * 100) / 1440, 5);
+    // height clamped to remainder of the day = 2 hours / 24 = 8.33...%
+    expect(height).toBeCloseTo((2 * 60 * 100) / 1440, 5);
+  });
+
+  it("enforces a minimum height so very short events stay clickable", () => {
+    const event = createMockEvent({
+      startDate: new Date(2026, 3, 15, 9, 0).toISOString(),
+      endDate: new Date(2026, 3, 15, 9, 0).toISOString(),
+    });
+    expect(getEventTimePosition(event, day).height).toBeGreaterThan(0);
+  });
+});
+
+describe("getCurrentTimePosition", () => {
+  it("returns 0% at midnight", () => {
+    const now = new Date(2026, 3, 15, 0, 0);
+    expect(getCurrentTimePosition(now).top).toBe(0);
+  });
+
+  it("returns 50% at noon", () => {
+    const now = new Date(2026, 3, 15, 12, 0);
+    expect(getCurrentTimePosition(now).top).toBeCloseTo(50, 5);
+  });
+
+  it("returns ~99.93% at 23:59", () => {
+    const now = new Date(2026, 3, 15, 23, 59);
+    expect(getCurrentTimePosition(now).top).toBeCloseTo(
+      (23 * 60 + 59) / 14.4,
+      5
+    );
+  });
+});
+
+describe("assignBarRows", () => {
+  const weekStart = new Date(2026, 3, 12); // Sun Apr 12 2026
+  const weekEnd = new Date(2026, 3, 18); // Sat Apr 18 2026
+
+  it("assigns row 0 to a single multi-day event", () => {
+    const event = createMockEvent({
+      id: "e1",
+      startDate: new Date(2026, 3, 13).toISOString(),
+      endDate: new Date(2026, 3, 15).toISOString(),
+    });
+    const rows = assignBarRows([event], weekStart, weekEnd);
+    expect(rows[event.id]).toBe(0);
+  });
+
+  it("stacks two overlapping events into rows 0 and 1", () => {
+    const a = createMockEvent({
+      id: "a",
+      startDate: new Date(2026, 3, 13).toISOString(),
+      endDate: new Date(2026, 3, 15).toISOString(),
+    });
+    const b = createMockEvent({
+      id: "b",
+      startDate: new Date(2026, 3, 14).toISOString(),
+      endDate: new Date(2026, 3, 16).toISOString(),
+    });
+    const rows = assignBarRows([a, b], weekStart, weekEnd);
+    expect(rows[a.id]).toBe(0);
+    expect(rows[b.id]).toBe(1);
+  });
+
+  it("re-uses row 0 for two events that don't overlap", () => {
+    const a = createMockEvent({
+      id: "a",
+      startDate: new Date(2026, 3, 13).toISOString(),
+      endDate: new Date(2026, 3, 14).toISOString(),
+    });
+    const b = createMockEvent({
+      id: "b",
+      startDate: new Date(2026, 3, 16).toISOString(),
+      endDate: new Date(2026, 3, 17).toISOString(),
+    });
+    const rows = assignBarRows([a, b], weekStart, weekEnd);
+    expect(rows[a.id]).toBe(0);
+    expect(rows[b.id]).toBe(0);
+  });
+
+  it("ignores events fully outside the week", () => {
+    const event = createMockEvent({
+      id: "out",
+      startDate: new Date(2026, 4, 1).toISOString(),
+      endDate: new Date(2026, 4, 2).toISOString(),
+    });
+    const rows = assignBarRows([event], weekStart, weekEnd);
+    expect(rows[event.id]).toBeUndefined();
   });
 });

--- a/src/lib/__tests__/calendar-helpers.test.ts
+++ b/src/lib/__tests__/calendar-helpers.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   WEEK_STARTS_ON,
   assignBarRows,
+  computeEventColumns,
   formatTime,
   getBgColor,
   getCalendarCells,
@@ -535,6 +536,68 @@ describe("getCurrentTimePosition", () => {
       (23 * 60 + 59) / 14.4,
       5
     );
+  });
+});
+
+describe("computeEventColumns", () => {
+  const day = new Date(2026, 3, 15);
+
+  function eventAt(id: string, startHour: number, endHour: number): IEvent {
+    const start = new Date(day);
+    start.setHours(startHour, 0, 0, 0);
+    const end = new Date(day);
+    end.setHours(endHour, 0, 0, 0);
+    return createMockEvent({
+      id,
+      startDate: start.toISOString(),
+      endDate: end.toISOString(),
+    });
+  }
+
+  it("gives a single event 1 column at column 0", () => {
+    const result = computeEventColumns([eventAt("a", 9, 10)]);
+    expect(result["a"]).toEqual({ column: 0, columns: 1 });
+  });
+
+  it("gives an event with no time-overlapping neighbour full width even if other events stack elsewhere", () => {
+    // A(9-10) and B(9:30-10:30) overlap. C(11-12) is alone.
+    const events = [
+      eventAt("a", 9, 10),
+      eventAt("b", 9, 11),
+      eventAt("c", 11, 12),
+    ];
+    const result = computeEventColumns(events);
+    // A and B overlap each other but not C. C gets full width.
+    expect(result["c"]).toEqual({ column: 0, columns: 1 });
+  });
+
+  it("widens to the local concurrency for overlapping events", () => {
+    const events = [
+      eventAt("a", 9, 10),
+      eventAt("b", 9, 11), // overlaps a
+    ];
+    const result = computeEventColumns(events);
+    expect(result["a"].columns).toBe(2);
+    expect(result["b"].columns).toBe(2);
+    expect(result["a"].column).not.toBe(result["b"].column);
+  });
+
+  it("handles three concurrent events", () => {
+    const events = [
+      eventAt("a", 9, 10),
+      eventAt("b", 9, 10),
+      eventAt("c", 9, 10),
+    ];
+    const result = computeEventColumns(events);
+    expect(result["a"].columns).toBe(3);
+    expect(result["b"].columns).toBe(3);
+    expect(result["c"].columns).toBe(3);
+    const cols = new Set([
+      result["a"].column,
+      result["b"].column,
+      result["c"].column,
+    ]);
+    expect(cols.size).toBe(3);
   });
 });
 

--- a/src/lib/calendar-helpers.ts
+++ b/src/lib/calendar-helpers.ts
@@ -157,24 +157,6 @@ export function groupEvents(dayEvents: IEvent[]): IEvent[][] {
   return groups;
 }
 
-export function getEventBlockStyle(
-  event: IEvent,
-  day: Date,
-  groupIndex: number,
-  groupSize: number
-) {
-  const startDate = parseISO(event.startDate);
-  const dayStart = startOfDay(day); // Use startOfDay instead of manual reset
-  const eventStart = startDate < dayStart ? dayStart : startDate;
-  const startMinutes = differenceInMinutes(eventStart, dayStart);
-
-  const top = (startMinutes / 1440) * 100; // 1440 minutes in a day
-  const width = 100 / groupSize;
-  const left = groupIndex * width;
-
-  return { top: `${top}%`, width: `${width}%`, left: `${left}%` };
-}
-
 export function getCalendarCells(selectedDate: Date): ICalendarCell[] {
   const year = selectedDate.getFullYear();
   const month = selectedDate.getMonth();
@@ -519,6 +501,51 @@ export const getCurrentTimePosition = (
 ): { top: number } => {
   const minutes = now.getHours() * 60 + now.getMinutes();
   return { top: (minutes / MINUTES_PER_DAY) * 100 };
+};
+
+/**
+ * Lay out timed events in a single-day time grid. Returns a map of
+ * `eventId → { column, columns }` where `columns` is the *local*
+ * concurrency at this event's slot — i.e. the maximum number of
+ * events present at any moment during this event's duration — and
+ * `column` is the lane assigned by `groupEvents`.
+ *
+ * Local concurrency keeps an event full-width when it has no
+ * overlapping neighbour, even if other events later in the day
+ * stack two-deep elsewhere.
+ */
+export const computeEventColumns = (
+  events: IEvent[]
+): Record<string, { column: number; columns: number }> => {
+  const groups = groupEvents([...events]);
+  const lane: Record<string, number> = {};
+  groups.forEach((group, groupIndex) => {
+    group.forEach((event) => {
+      lane[event.id] = groupIndex;
+    });
+  });
+
+  const result: Record<string, { column: number; columns: number }> = {};
+
+  for (const event of events) {
+    const eventStart = parseISO(event.startDate).getTime();
+    const eventEnd = parseISO(event.endDate).getTime();
+    let maxLane = lane[event.id];
+
+    for (const other of events) {
+      if (other.id === event.id) continue;
+      const otherStart = parseISO(other.startDate).getTime();
+      const otherEnd = parseISO(other.endDate).getTime();
+      if (otherStart < eventEnd && otherEnd > eventStart) {
+        const otherLane = lane[other.id];
+        if (otherLane > maxLane) maxLane = otherLane;
+      }
+    }
+
+    result[event.id] = { column: lane[event.id], columns: maxLane + 1 };
+  }
+
+  return result;
 };
 
 /**

--- a/src/lib/calendar-helpers.ts
+++ b/src/lib/calendar-helpers.ts
@@ -472,3 +472,94 @@ export const toCapitalize = (str: string): string => {
   if (!str) return "";
   return str.charAt(0).toUpperCase() + str.slice(1);
 };
+
+const MINUTES_PER_DAY = 1440;
+const MIN_EVENT_HEIGHT_PCT = 1.5;
+
+/**
+ * Position an event on a 24-hour vertical time grid.
+ *
+ * Returns `top` and `height` in percent of the day axis (0–100).
+ * Events that start before `day` clamp `top` to 0; events that end
+ * after `day` clamp `height` to the remainder of the axis. A small
+ * minimum height keeps zero-duration events visible.
+ */
+export const getEventTimePosition = (
+  event: IEvent,
+  day: Date
+): { top: number; height: number } => {
+  const dayStart = startOfDay(day);
+  const dayEnd = addDays(dayStart, 1);
+  const start = parseISO(event.startDate);
+  const end = parseISO(event.endDate);
+
+  const visibleStart = start < dayStart ? dayStart : start;
+  const visibleEnd = end > dayEnd ? dayEnd : end;
+
+  const startMinutes = differenceInMinutes(visibleStart, dayStart);
+  const durationMinutes = Math.max(
+    0,
+    differenceInMinutes(visibleEnd, visibleStart)
+  );
+
+  const top = (startMinutes / MINUTES_PER_DAY) * 100;
+  const rawHeight = (durationMinutes / MINUTES_PER_DAY) * 100;
+  const height = Math.max(rawHeight, MIN_EVENT_HEIGHT_PCT);
+
+  return { top, height };
+};
+
+/**
+ * Position the "now" indicator on the same 24-hour axis as
+ * `getEventTimePosition`. `now` defaults to the wall-clock time so
+ * tests can inject a frozen Date.
+ */
+export const getCurrentTimePosition = (
+  now: Date = new Date()
+): { top: number } => {
+  const minutes = now.getHours() * 60 + now.getMinutes();
+  return { top: (minutes / MINUTES_PER_DAY) * 100 };
+};
+
+/**
+ * Assign each event a stacking row index for the week's multi-day
+ * spanning bar row. Events are sorted by start; the first available
+ * row is reused for non-overlapping events. Events that fall fully
+ * outside `[weekStart, weekEnd]` are dropped from the returned map.
+ */
+export const assignBarRows = (
+  events: IEvent[],
+  weekStart: Date,
+  weekEnd: Date
+): Record<string, number> => {
+  const result: Record<string, number> = {};
+  const rowEnds: Date[] = [];
+
+  const inWeek = events
+    .filter((e) => {
+      const start = parseISO(e.startDate);
+      const end = parseISO(e.endDate);
+      return start <= weekEnd && end >= weekStart;
+    })
+    .sort(
+      (a, b) =>
+        parseISO(a.startDate).getTime() - parseISO(b.startDate).getTime()
+    );
+
+  for (const event of inWeek) {
+    const start = parseISO(event.startDate);
+    const end = parseISO(event.endDate);
+    const visibleStart = start < weekStart ? weekStart : start;
+
+    let row = rowEnds.findIndex((rowEnd) => rowEnd <= visibleStart);
+    if (row === -1) {
+      row = rowEnds.length;
+      rowEnds.push(end);
+    } else {
+      rowEnds[row] = end;
+    }
+    result[event.id] = row;
+  }
+
+  return result;
+};


### PR DESCRIPTION
## Summary

- Replaces the stacked per-day lists in `WeekCalendar` and `DayCalendar` with hourly time-grid layouts driven by `CalendarProvider`.
- `WeekCalendar` gains a multi-day spanning row that renders an event spanning N days as a single bar across N columns (not N duplicates), with row stacking for overlapping bars.
- Both views render a live now-line indicator that ticks every 60s and only appears on today.

## Plan

Linked plan: [`.claude/plans/wire-week-day-views.md`](.claude/plans/wire-week-day-views.md)
Project: https://github.com/users/BenSeymourODB/projects/1

## Acceptance map (issue #113 -> this PR)

| Criterion | Where |
| --- | --- |
| Day view in time slots | `DayCalendar.tsx` 24-row grid + `getEventTimePosition` |
| Week view across 7 cols with time positioning | `WeekCalendar.tsx` 7-col grid |
| Multi-day events as spanning bars | `WeekCalendar.tsx` `assignBarRows` + multi-day row |
| Current time indicator | `<NowLine />` in both views |
| Navigation triggers data loading | `CalendarProvider.test.tsx` regression |
| Color/user filters apply | provider already filters; views render what they receive |

## Test plan

- [x] Unit: 1102 tests pass (`pnpm test`)
- [x] Lint / format / types: clean
- [x] E2E: 15/15 chromium tests pass on `e2e/week-day-views.spec.ts`
- [x] Browser smoke: `/test/calendar?events=multiDay&view=week` shows the spanning bar + now-line; `?events=overflow&view=day` shows overlap-stacking

Screenshots from local Playwright runs are saved under `test-results/issue-113/` (gitignored).

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)