### PR TITLE
chore: gitignore .claude/worktrees/ (browser-qa worktree dir)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ next-env.d.ts
 
 # Playwright MCP artifacts
 .playwright-mcp/
+
+# QA agent worktrees (git worktree add targets — managed by browser-qa skill)
+.claude/worktrees/


### PR DESCRIPTION
## Summary

- Adds `.claude/worktrees/` to `.gitignore` so the transient git worktrees created by the `browser-qa` skill are never accidentally staged or committed.

## Why

The `browser-qa` skill creates isolated git worktrees under `.claude/worktrees/qa-pr-<n>/` for each PR it validates. These directories are intentional but ephemeral — they are pruned at the start of each QA run. Without this entry the stop-hook git check fires a false positive after every QA session.

https://claude.ai/code/session_01QVGftFrof9jtKTECpywdD3

---
_Generated by [Claude Code](https://claude.ai/code/session_01QVGftFrof9jtKTECpywdD3)_