### PR TITLE
fix(test): add maxEventsPerDay to AddEventButton test mock

### DIFF
--- a/src/components/calendar/__tests__/AddEventButton.test.tsx
+++ b/src/components/calendar/__tests__/AddEventButton.test.tsx
@@ -52,6 +52,7 @@ function makeContext(
     refreshEvents: vi.fn(),
     isLoading: false,
     isAuthenticated: true,
+    maxEventsPerDay: 3,
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

Fixes the `tsc` failure that's blocking CI on `main` (and therefore on every open PR that merges main, including #136).

`ICalendarContext` gained a required `maxEventsPerDay: number` field in #157, but `AddEventButton.test.tsx` (added in #143) wasn't updated, so its mock no longer satisfies the interface:

```
src/components/calendar/__tests__/AddEventButton.test.tsx(30,3): error TS2322:
  Type '{ ... maxEventsPerDay?: number | undefined; }' is not assignable to type 'ICalendarContext'.
    Types of property 'maxEventsPerDay' are incompatible.
      Type 'number | undefined' is not assignable to type 'number'.
```

The two PRs were green individually but red when combined — the bug landed on `main` itself, so PR #136's CI failure (https://github.com/BenSeymourODB/next-digital-wall-calendar/actions/runs/25057316830/job/73401160578) is just inheriting it via the merge commit on the PR branch.

## Fix

Add `maxEventsPerDay: 3` to the mock context in `AddEventButton.test.tsx` (3 matches the default used in `calendar-section.test.tsx`).

## Test plan

- [x] `pnpm check-types` — clean
- [x] `pnpm lint` — 0 errors (4 pre-existing warnings unrelated to this change)
- [x] `pnpm test:run src/components/calendar/__tests__/AddEventButton.test.tsx` — 6/6 pass

Once this lands on `main`, PR #136 just needs a rebase/merge-from-main to go green.

https://claude.ai/code/session_01H2Lt9fY7Ayct2UVCREtsAe

---
_Generated by [Claude Code](https://claude.ai/code/session_01H2Lt9fY7Ayct2UVCREtsAe)_