### PR TITLE
fix(calendar): repair PR #145 merge regressions

### DIFF
--- a/src/app/api/profiles/[id]/reset-pin/route.ts
+++ b/src/app/api/profiles/[id]/reset-pin/route.ts
@@ -5,8 +5,8 @@
 import { getSession } from "@/lib/auth";
 import { prisma } from "@/lib/db";
 import { logger } from "@/lib/logger";
-import { verifyAdminWithPin } from "@/lib/services/admin-verification";
 import { validatePinFormat } from "@/lib/pin-utils";
+import { verifyAdminWithPin } from "@/lib/services/admin-verification";
 import { NextRequest, NextResponse } from "next/server";
 import bcrypt from "bcrypt";
 

--- a/src/app/calendar/__tests__/page.test.tsx
+++ b/src/app/calendar/__tests__/page.test.tsx
@@ -26,6 +26,18 @@ vi.mock("@/components/calendar/SimpleCalendar", () => ({
   SimpleCalendar: () => <div data-testid="mock-simple-calendar" />,
 }));
 
+vi.mock("@/components/calendar/DayCalendar", () => ({
+  DayCalendar: () => <div data-testid="mock-day-calendar" />,
+}));
+
+vi.mock("@/components/calendar/WeekCalendar", () => ({
+  WeekCalendar: () => <div data-testid="mock-week-calendar" />,
+}));
+
+vi.mock("@/components/calendar/YearCalendar", () => ({
+  YearCalendar: () => <div data-testid="mock-year-calendar" />,
+}));
+
 vi.mock("@/components/calendar/AgendaCalendar", () => ({
   AgendaCalendar: () => <div data-testid="mock-agenda-calendar" />,
 }));

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -6,8 +6,8 @@ import { DayCalendar } from "@/components/calendar/DayCalendar";
 import { MiniCalendarSidebar } from "@/components/calendar/MiniCalendarSidebar";
 import { SimpleCalendar } from "@/components/calendar/SimpleCalendar";
 import { ViewSwitcher } from "@/components/calendar/ViewSwitcher";
-import { YearCalendar } from "@/components/calendar/YearCalendar";
 import { WeekCalendar } from "@/components/calendar/WeekCalendar";
+import { YearCalendar } from "@/components/calendar/YearCalendar";
 import {
   CalendarProvider,
   useCalendar,
@@ -19,20 +19,17 @@ import type { TCalendarView } from "@/types/calendar";
 import { useState } from "react";
 import { Settings } from "lucide-react";
 
-/**
- * Route to the correct calendar view. Year falls back to month until
- * #83 / #117 ship a dedicated year view.
- */
 function CalendarView({ view }: { view: TCalendarView }) {
   switch (view) {
     case "day":
       return <DayCalendar />;
     case "week":
       return <WeekCalendar />;
+    case "year":
+      return <YearCalendar />;
     case "agenda":
       return <AgendaCalendar />;
     case "month":
-    case "year":
     default:
       return <SimpleCalendar />;
   }
@@ -81,16 +78,22 @@ function CalendarContent() {
         {/* View Switcher */}
         <ViewSwitcher />
 
-        {/* Calendar - Conditional rendering based on view
+        {/* Calendar + mini-calendar sidebar.
          * The mini-calendar is hidden on month view where it duplicates the
-         * main grid; on day/week/agenda it acts as a date-picker / at-a-glance
-         * overview. See issue #146. */}
-        <div className="border-border bg-card rounded-lg border p-6">
-          {view === "month" && <SimpleCalendar />}
-          {view === "year" && <YearCalendar />}
-          {view === "agenda" && <AgendaCalendar />}
+         * main grid; on day/week/year/agenda it acts as a date-picker /
+         * at-a-glance overview. See issue #146. */}
+        <div
+          className={
+            view === "month"
+              ? "grid gap-6"
+              : "grid gap-6 lg:grid-cols-[1fr_280px]"
+          }
+        >
+          <div className="border-border bg-card rounded-lg border p-6">
+            <CalendarView view={view} />
+          </div>
+          {view !== "month" && <MiniCalendarSidebar />}
         </div>
-        {view !== "month" && view !== "year" && <MiniCalendarSidebar />}
       </div>
     </div>
   );

--- a/src/app/test/calendar/page.tsx
+++ b/src/app/test/calendar/page.tsx
@@ -6,6 +6,7 @@ import { MiniCalendarSidebar } from "@/components/calendar/MiniCalendarSidebar";
 import { SimpleCalendar } from "@/components/calendar/SimpleCalendar";
 import { ViewSwitcher } from "@/components/calendar/ViewSwitcher";
 import { WeekCalendar } from "@/components/calendar/WeekCalendar";
+import { YearCalendar } from "@/components/calendar/YearCalendar";
 import {
   MockCalendarProvider,
   useCalendar,
@@ -296,14 +297,6 @@ const mockEventSets: Record<string, IEvent[]> = {
   ],
 };
 
-/**
- * Calendar display component that renders based on current view.
- *
- * `day`, `week`, and `year` views do not yet have production components
- * (tracked in #70 / #83 and friends). For those we render a labelled
- * placeholder so layout-rule tests (e.g. sidebar visibility on #146) can
- * still exercise the view while the main-panel content isn't yet wired up.
- */
 function CalendarDisplay() {
   const { view } = useCalendar();
 
@@ -314,14 +307,6 @@ function CalendarDisplay() {
       {view === "month" && <SimpleCalendar />}
       {view === "year" && <YearCalendar />}
       {view === "agenda" && <AgendaCalendar />}
-      {(view === "day" || view === "week" || view === "year") && (
-        <div
-          data-testid={`calendar-placeholder-${view}`}
-          className="text-muted-foreground rounded border border-dashed p-8 text-center"
-        >
-          {view.charAt(0).toUpperCase() + view.slice(1)} view placeholder
-        </div>
-      )}
     </div>
   );
 }

--- a/src/components/calendar/ViewSwitcher.tsx
+++ b/src/components/calendar/ViewSwitcher.tsx
@@ -3,10 +3,17 @@
 import { useCalendar } from "@/components/providers/CalendarProvider";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import type { TCalendarView } from "@/types/calendar";
-import { Calendar, CalendarDays, CalendarRange, List } from "lucide-react";
+import {
+  Calendar,
+  CalendarDays,
+  CalendarRange,
+  LayoutGrid,
+  List,
+} from "lucide-react";
+
 /**
  * View switcher component
- * Allows switching between Day, Week, Month, and Agenda calendar views.
+ * Allows switching between Day, Week, Month, Year, and Agenda calendar views.
  */
 export function ViewSwitcher() {
   const { view, setView } = useCalendar();
@@ -16,7 +23,7 @@ export function ViewSwitcher() {
       value={view}
       onValueChange={(value) => setView(value as TCalendarView)}
     >
-      <TabsList className="grid w-full max-w-xl grid-cols-4">
+      <TabsList className="grid w-full max-w-xl grid-cols-5">
         <TabsTrigger value="day" className="flex items-center gap-2">
           <CalendarDays className="h-4 w-4" />
           <span>Day</span>
@@ -30,7 +37,7 @@ export function ViewSwitcher() {
           <span>Month</span>
         </TabsTrigger>
         <TabsTrigger value="year" className="flex items-center gap-2">
-          <CalendarRange className="h-4 w-4" />
+          <LayoutGrid className="h-4 w-4" />
           <span>Year</span>
         </TabsTrigger>
         <TabsTrigger value="agenda" className="flex items-center gap-2">

--- a/src/components/calendar/__tests__/SimpleCalendar.test.tsx
+++ b/src/components/calendar/__tests__/SimpleCalendar.test.tsx
@@ -262,7 +262,7 @@ describe("SimpleCalendar", () => {
       expect(screen.getByTestId("calendar-add-event-btn")).toBeInTheDocument();
     });
   });
-  
+
   describe("Weekday headers", () => {
     it("renders weekday headers in WEEK_STARTS_ON order", () => {
       renderWithContext();

--- a/src/components/calendar/__tests__/ViewSwitcher.test.tsx
+++ b/src/components/calendar/__tests__/ViewSwitcher.test.tsx
@@ -41,6 +41,7 @@ function createMockContext(
     refreshEvents: vi.fn(),
     isLoading: false,
     isAuthenticated: true,
+    maxEventsPerDay: 3,
     ...overrides,
   };
 }

--- a/src/components/calendar/__tests__/YearCalendar.test.tsx
+++ b/src/components/calendar/__tests__/YearCalendar.test.tsx
@@ -60,6 +60,7 @@ function createMockContext(
     refreshEvents: vi.fn(),
     isLoading: false,
     isAuthenticated: true,
+    maxEventsPerDay: 3,
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

Fixes the CI failure on #145 plus a few related conflict-resolution regressions introduced when `main` was merged into the year-view branch (commit bfb21ff).

### Root cause — the actual CI lint error

`src/app/test/calendar/page.tsx:315` references `<YearCalendar />`, but the merge dropped the `import { YearCalendar } …` line. ESLint reports `'YearCalendar' is not defined` and the workflow exits non-zero before tests run.

### Other merge issues found by walking the three conflicted files

The user asked me to also examine the other files touched by the merge. The conflicts were in three files (`git diff-tree --cc bfb21ff`):

1. **`src/app/calendar/page.tsx`** — production calendar page.
   - Merge kept the `CalendarView` switch from `main` (handling Day/Week/Month/Agenda) **but** overrode the actual rendering inside `CalendarContent` with the PR branch's inline `view === "month" && …` / `view === "year" && …` conditionals. Result: Day/Week never rendered in prod, and `DayCalendar` / `WeekCalendar` imports were unused.
   - The mini-calendar sidebar was moved out of the responsive grid wrapper, so it stacked below the calendar instead of sitting in the `lg:grid-cols-[1fr_280px]` sidebar slot.
   - Fix: route Year through the `CalendarView` switch alongside the other views, and reinstate the sidebar grid layout. Sidebar visibility rule (`view !== "month"`) preserved to keep the existing #146 test green for `year`.

2. **`src/components/calendar/ViewSwitcher.tsx`** — view tabs.
   - Five tabs now (Day, Week, Month, Year, Agenda) but `TabsList` was still `grid-cols-4`, breaking the layout.
   - Year and Week both used the `CalendarRange` icon (Week added on main, Year added on the PR — neither was aware of the other).
   - Fix: `grid-cols-5` and Year switches to `LayoutGrid` (a 12-month overview reads as a grid; Week keeps `CalendarRange`).

3. **`src/app/test/calendar/page.tsx`** — E2E test harness.
   - Missing `YearCalendar` import (the CI failure).
   - Stale `CalendarDisplay` doc comment claimed Day/Week/Year had no production components, and the file rendered both the real component **and** a "view placeholder" for Day/Week/Year. No tests reference the `calendar-placeholder-*` testid (`grep` confirmed).
   - Fix: add the import; drop the dead placeholder block and stale comment.

### Type / test fallout from the fixes

- `ViewSwitcher.test.tsx` and `YearCalendar.test.tsx` mock contexts were drafted before #157 added `maxEventsPerDay: number` to `ICalendarContext` on main. After the merge, `tsc` fails on both. Added `maxEventsPerDay: 3` to each mock (matches the pattern in the SimpleCalendar / Agenda / Day test mocks).
- `src/app/calendar/__tests__/page.test.tsx` already mocks `SimpleCalendar` / `AgendaCalendar` / `MiniCalendarSidebar` etc.; with `CalendarView` now actually rendering Day/Week/Year, those need mocks too — otherwise they crash inside the component on `selectedDate.getFullYear()` / `events.filter(…)` because the test only stubs `useCalendar` to return `{ view }`. Added the three missing mocks (same shape as the existing ones).

## Test plan

- [x] `pnpm lint:fix` — clean (only the four pre-existing warnings on `account-section.tsx`, `profile-avatar.tsx`, `CalendarProvider.test.tsx`, and `route.test.ts`)
- [x] `pnpm format:fix` — clean
- [x] `pnpm check-types` — clean
- [x] `pnpm test` — **1341 / 1341 passing**

## Notes

- Targeting `claude/loving-faraday-V494z` (the head branch of #145) so the fix can land into the PR before it merges to `main`.
- The auto-import-order fix in `src/app/api/profiles/[id]/reset-pin/route.ts` and the trailing-whitespace fix in `SimpleCalendar.test.tsx` are from `pnpm format:fix` running over the staged files; pre-commit hooks would have produced them anyway.

https://claude.ai/code/session_01M8pen3T6b4mFT6PYGpv8s4

---
_Generated by [Claude Code](https://claude.ai/code/session_01M8pen3T6b4mFT6PYGpv8s4)_