### PR TITLE
fix(test): mock CalendarFilterPanel in CalendarPage layout test

### DIFF
--- a/src/app/calendar/__tests__/page.test.tsx
+++ b/src/app/calendar/__tests__/page.test.tsx
@@ -1,9 +1,10 @@
 /**
  * Tests for /calendar page layout.
  *
- * The mini-calendar sidebar is redundant on the month view (renders a mini
- * month grid next to the full month grid) and should only be shown on
- * views where it adds value: day, week, and agenda. See issue #146.
+ * The mini-calendar sidebar duplicates content the active view already
+ * provides on month (full month grid), year (twelve-month overview), and
+ * clock (built-in all-day aside), so it's hidden on those views and shown
+ * on day, week, and agenda. See issues #146 and #152.
  */
 import type { TCalendarView } from "@/types/calendar";
 import type { ReactNode } from "react";
@@ -54,6 +55,10 @@ vi.mock("@/components/calendar/ViewSwitcher", () => ({
   ViewSwitcher: () => <div data-testid="mock-view-switcher" />,
 }));
 
+vi.mock("@/components/calendar/CalendarFilterPanel", () => ({
+  CalendarFilterPanel: () => <div data-testid="mock-filter-panel" />,
+}));
+
 vi.mock("@/components/theme/theme-toggle", () => ({
   ThemeToggle: () => <div data-testid="mock-theme-toggle" />,
 }));
@@ -93,10 +98,12 @@ describe("CalendarPage — mini-calendar sidebar visibility", () => {
     expect(screen.getByTestId("mini-calendar-sidebar")).toBeInTheDocument();
   });
 
-  it("shows the mini-calendar sidebar when the active view is year", () => {
+  it("hides the mini-calendar sidebar when the active view is year", () => {
     setView("year");
     render(<CalendarPage />);
-    expect(screen.getByTestId("mini-calendar-sidebar")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("mini-calendar-sidebar")
+    ).not.toBeInTheDocument();
   });
 
   it("hides the mini-calendar sidebar when the active view is clock", () => {

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -2,8 +2,8 @@
 
 import { AccountManager } from "@/components/calendar/AccountManager";
 import { AgendaCalendar } from "@/components/calendar/AgendaCalendar";
-import { CalendarFilterPanel } from "@/components/calendar/CalendarFilterPanel";
 import { AnalogClockView } from "@/components/calendar/AnalogClockView";
+import { CalendarFilterPanel } from "@/components/calendar/CalendarFilterPanel";
 import { DayCalendar } from "@/components/calendar/DayCalendar";
 import { MiniCalendarSidebar } from "@/components/calendar/MiniCalendarSidebar";
 import { SimpleCalendar } from "@/components/calendar/SimpleCalendar";
@@ -50,7 +50,7 @@ function CalendarContent() {
   // Views that surface the mini-calendar sidebar. Month duplicates the main
   // grid (issue #146) and the Clock view ships its own all-day events aside,
   // so neither needs the shared sidebar.
-  const showSidebar = view !== "month" && view !== "clock" && view !== "year" ;
+  const showSidebar = view !== "month" && view !== "clock" && view !== "year";
 
   return (
     <div className="bg-background min-h-screen p-4 sm:p-8">

--- a/src/app/test/calendar/page.tsx
+++ b/src/app/test/calendar/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { AgendaCalendar } from "@/components/calendar/AgendaCalendar";
-import { CalendarFilterPanel } from "@/components/calendar/CalendarFilterPanel";
 import { AnalogClockView } from "@/components/calendar/AnalogClockView";
+import { CalendarFilterPanel } from "@/components/calendar/CalendarFilterPanel";
 import { DayCalendar } from "@/components/calendar/DayCalendar";
 import { MiniCalendarSidebar } from "@/components/calendar/MiniCalendarSidebar";
 import { SimpleCalendar } from "@/components/calendar/SimpleCalendar";


### PR DESCRIPTION
## Summary

`src/app/calendar/__tests__/page.test.tsx` had been broken on `main` since #148 (filter panel) merged. The suite renders the real `CalendarPage`, which now mounts `<CalendarFilterPanel>`; that panel reads `selectedColors`, `users`, `selectedUserId`, and `clearFilter` from `useCalendar()`. The test's `useCalendar` mock returns only `{ view }`, so all six layout tests crashed on `selectedColors.length`.

Two changes:

1. **Mock `CalendarFilterPanel`** the same way the other calendar components are mocked in this suite. The file is about page layout (sidebar visibility per view), not filter behavior, so a render-only stub is sufficient.
2. **Fix the year-view assertion.** Production `showSidebar` (in `src/app/calendar/page.tsx`) excludes `year` alongside `month` and `clock` — year view is a twelve-month overview that already duplicates the mini-calendar's purpose. Test now asserts the sidebar is **hidden** on year, matching the month and clock cases.

The bug went unnoticed on `main` because the workflow that runs on push to `main` only runs lint + type-check, not tests; PR CI does run tests, which is why this surfaced from the rebase pulses on #139 and #156.

Two trivial prettier fixes (import order, trailing space) piggybacked from `pnpm format:fix`.

## Test plan

- [x] `pnpm vitest run src/app/calendar/__tests__/page.test.tsx` — 6/6 pass (was 0/6)
- [x] `pnpm exec eslint src/app/calendar/__tests__/page.test.tsx` — clean
- [x] `pnpm exec prettier --check src/app/calendar/__tests__/page.test.tsx` — clean
- [x] `pnpm check-types` — clean

## Note for reviewer

PR is opened as draft per session policy; ready for review immediately — single-file fix with low blast radius.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CQQqYrVn7D3cqqW1f4JMdd)_