### PR TITLE
feat(tasks): add typed Google Tasks API wrapper (#162)

### DIFF
--- a/src/app/api/tasks/[taskId]/complete/__tests__/route.test.ts
+++ b/src/app/api/tasks/[taskId]/complete/__tests__/route.test.ts
@@ -135,10 +135,13 @@ describe("Task Complete API", () => {
     });
 
     it("returns error when Google API fails", async () => {
+      // 500 is transient — fetchWithRetry retries and reads Retry-After from
+      // headers each pass, so the mock must include a real Headers instance.
       mockFetch.mockResolvedValue({
         ok: false,
         status: 500,
-        json: () => Promise.resolve({ error: "Server error" }),
+        headers: new Headers(),
+        json: () => Promise.resolve({ error: { message: "Server error" } }),
       });
 
       const request = createRequest({

--- a/src/app/api/tasks/[taskId]/complete/__tests__/route.test.ts
+++ b/src/app/api/tasks/[taskId]/complete/__tests__/route.test.ts
@@ -7,18 +7,57 @@
  * focuses on the handler's concerns: auth, validation, the Google
  * Tasks call, and response shaping.
  */
+import { getAccessToken, getSession } from "@/lib/auth";
+import {
+  mockSession,
+  mockSessionWithError,
+} from "@/lib/auth/__tests__/fixtures";
 import { updateProfileStreak } from "@/lib/services/streak";
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { POST } from "../route";
 
-const mockGetSession = vi.fn();
-const mockGetAccessToken = vi.fn();
-
-vi.mock("@/lib/auth/helpers", () => ({
-  getSession: () => mockGetSession(),
-  getAccessToken: () => mockGetAccessToken(),
+vi.mock("@/lib/auth", () => ({
+  getSession: vi.fn(),
+  getAccessToken: vi.fn(),
+  AuthError: class AuthError extends Error {
+    status: number;
+    constructor(message: string, status: number = 401) {
+      super(message);
+      this.name = "AuthError";
+      this.status = status;
+    }
+  },
 }));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    error: vi.fn(),
+    log: vi.fn(),
+    event: vi.fn(),
+  },
+}));
+
+// Replace the real `sleep` inside fetchWithRetry with a no-op so transient-
+// status tests (5xx, 429) don't wait for real backoff delays.
+vi.mock("@/lib/http/retry", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/http/retry")>(
+      "@/lib/http/retry"
+    );
+  return {
+    ...actual,
+    fetchWithRetry: (
+      input: Parameters<typeof actual.fetchWithRetry>[0],
+      init?: Parameters<typeof actual.fetchWithRetry>[1],
+      options: Parameters<typeof actual.fetchWithRetry>[2] = {}
+    ) =>
+      actual.fetchWithRetry(input, init, {
+        ...options,
+        sleep: () => Promise.resolve(),
+      }),
+  };
+});
 
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
@@ -40,14 +79,10 @@ function createRequest(body?: unknown): NextRequest {
 }
 
 describe("Task Complete API", () => {
-  const mockSession = {
-    user: { id: "user-123", email: "test@example.com" },
-  };
-
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGetSession.mockResolvedValue(mockSession);
-    mockGetAccessToken.mockResolvedValue("mock-access-token");
+    vi.mocked(getSession).mockResolvedValue(mockSession);
+    vi.mocked(getAccessToken).mockResolvedValue("mock-access-token");
     mockFetch.mockResolvedValue({
       ok: true,
       json: () =>
@@ -62,7 +97,7 @@ describe("Task Complete API", () => {
 
   describe("authentication", () => {
     it("returns 401 when no session", async () => {
-      mockGetSession.mockResolvedValue(null);
+      vi.mocked(getSession).mockResolvedValue(null);
 
       const request = createRequest({
         listId: "list-1",
@@ -75,8 +110,8 @@ describe("Task Complete API", () => {
       expect(response.status).toBe(401);
     });
 
-    it("returns 401 when no access token", async () => {
-      mockGetAccessToken.mockResolvedValue(null);
+    it("returns 401 with requiresReauth when RefreshTokenError", async () => {
+      vi.mocked(getSession).mockResolvedValue(mockSessionWithError);
 
       const request = createRequest({
         listId: "list-1",
@@ -85,8 +120,11 @@ describe("Task Complete API", () => {
       const response = await POST(request, {
         params: Promise.resolve({ taskId: "task-123" }),
       });
+      const data = await response.json();
 
       expect(response.status).toBe(401);
+      expect(data.error).toBe("Session expired. Please sign in again.");
+      expect(data.requiresReauth).toBe(true);
     });
   });
 
@@ -134,9 +172,56 @@ describe("Task Complete API", () => {
       );
     });
 
-    it("returns error when Google API fails", async () => {
-      // 500 is transient — fetchWithRetry retries and reads Retry-After from
-      // headers each pass, so the mock must include a real Headers instance.
+    it("returns 401 with requiresReauth when Google API returns 403", async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 403,
+        headers: new Headers(),
+        json: () =>
+          Promise.resolve({ error: { message: "Insufficient Permission" } }),
+      });
+
+      const request = createRequest({
+        listId: "list-1",
+        profileId: "profile-1",
+      });
+      const response = await POST(request, {
+        params: Promise.resolve({ taskId: "task-123" }),
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(data.requiresReauth).toBe(true);
+      expect(data.error).toBe(
+        "Missing Google Tasks scope. Please sign in again to grant access."
+      );
+      expect(mockUpdateProfileStreak).not.toHaveBeenCalled();
+    });
+
+    it("returns generic error when Google API returns non-auth failure", async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 404,
+        headers: new Headers(),
+        json: () => Promise.resolve({ error: { message: "Not found" } }),
+      });
+
+      const request = createRequest({
+        listId: "list-1",
+        profileId: "profile-1",
+      });
+      const response = await POST(request, {
+        params: Promise.resolve({ taskId: "task-123" }),
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.error).toBe("Failed to complete task");
+      expect(mockUpdateProfileStreak).not.toHaveBeenCalled();
+    });
+
+    it("returns 500 when Google API fails with a server error", async () => {
+      // 500 is transient — fetchWithRetry retries (sleep is mocked to no-op).
       mockFetch.mockResolvedValue({
         ok: false,
         status: 500,

--- a/src/app/api/tasks/[taskId]/complete/route.ts
+++ b/src/app/api/tasks/[taskId]/complete/route.ts
@@ -4,9 +4,10 @@
  *
  * POST - Complete a task and update streak
  */
-import { getAccessToken, getSession } from "@/lib/auth/helpers";
+import { AuthError, getAccessToken, getSession } from "@/lib/auth";
 import { patchTask } from "@/lib/google/tasks-api";
 import { GoogleTasksApiError } from "@/lib/google/tasks-types";
+import { logger } from "@/lib/logger";
 import { updateProfileStreak } from "@/lib/services/streak";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -35,57 +36,96 @@ export async function POST(
   request: NextRequest,
   { params }: RouteContext
 ): Promise<NextResponse> {
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  const accessToken = await getAccessToken();
-  if (!accessToken) {
-    return NextResponse.json(
-      { error: "Unauthorized - No access token" },
-      { status: 401 }
-    );
-  }
-
-  const { taskId } = await params;
-
-  let body: RequestBody = {};
   try {
-    body = await request.json();
-  } catch {
-    // Empty body is fine
-  }
+    const session = await getSession();
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
 
-  const { listId, profileId } = body;
+    if (session.error === "RefreshTokenError") {
+      return NextResponse.json(
+        {
+          error: "Session expired. Please sign in again.",
+          requiresReauth: true,
+        },
+        { status: 401 }
+      );
+    }
 
-  if (!listId) {
-    return NextResponse.json({ error: "listId is required" }, { status: 400 });
-  }
+    const { taskId } = await params;
 
-  if (!profileId) {
-    return NextResponse.json(
-      { error: "profileId is required" },
-      { status: 400 }
-    );
-  }
+    let body: RequestBody = {};
+    try {
+      body = await request.json();
+    } catch {
+      // Empty body is fine
+    }
 
-  let task;
-  try {
-    task = await patchTask(accessToken, listId, taskId, {
+    const { listId, profileId } = body;
+
+    if (!listId) {
+      return NextResponse.json(
+        { error: "listId is required" },
+        { status: 400 }
+      );
+    }
+
+    if (!profileId) {
+      return NextResponse.json(
+        { error: "profileId is required" },
+        { status: 400 }
+      );
+    }
+
+    const accessToken = await getAccessToken();
+    const task = await patchTask(accessToken, listId, taskId, {
       status: "completed",
     });
+
+    const streak = await updateProfileStreak(profileId);
+
+    return NextResponse.json({ task, streak });
   } catch (error) {
-    if (error instanceof GoogleTasksApiError) {
+    if (error instanceof AuthError) {
       return NextResponse.json(
-        { error: error.message },
+        { error: error.message, requiresReauth: error.status === 401 },
         { status: error.status }
       );
     }
-    throw error;
+
+    if (error instanceof GoogleTasksApiError) {
+      logger.error(error, {
+        endpoint: "/api/tasks/[taskId]/complete",
+        status: error.status,
+      });
+
+      if (error.status === 401 || error.status === 403) {
+        return NextResponse.json(
+          {
+            error:
+              error.status === 403
+                ? "Missing Google Tasks scope. Please sign in again to grant access."
+                : "Google authentication failed. Please sign in again.",
+            requiresReauth: true,
+          },
+          { status: error.status }
+        );
+      }
+
+      return NextResponse.json(
+        { error: "Failed to complete task" },
+        { status: error.status }
+      );
+    }
+
+    logger.error(error as Error, {
+      endpoint: "/api/tasks/[taskId]/complete",
+      errorType: "complete_task",
+    });
+
+    return NextResponse.json(
+      { error: "An unexpected error occurred" },
+      { status: 500 }
+    );
   }
-
-  const streak = await updateProfileStreak(profileId);
-
-  return NextResponse.json({ task, streak });
 }

--- a/src/app/api/tasks/[taskId]/complete/route.ts
+++ b/src/app/api/tasks/[taskId]/complete/route.ts
@@ -5,18 +5,13 @@
  * POST - Complete a task and update streak
  */
 import { getAccessToken, getSession } from "@/lib/auth/helpers";
+import { patchTask } from "@/lib/google/tasks-api";
+import { GoogleTasksApiError } from "@/lib/google/tasks-types";
 import { updateProfileStreak } from "@/lib/services/streak";
 import { NextRequest, NextResponse } from "next/server";
 
 interface RouteContext {
   params: Promise<{ taskId: string }>;
-}
-
-interface GoogleTask {
-  id: string;
-  title: string;
-  status: "needsAction" | "completed";
-  updated?: string;
 }
 
 interface RequestBody {
@@ -75,28 +70,20 @@ export async function POST(
     );
   }
 
-  // Mark task as completed in Google Tasks API
-  const googleResponse = await fetch(
-    `https://tasks.googleapis.com/tasks/v1/lists/${listId}/tasks/${taskId}`,
-    {
-      method: "PATCH",
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ status: "completed" }),
+  let task;
+  try {
+    task = await patchTask(accessToken, listId, taskId, {
+      status: "completed",
+    });
+  } catch (error) {
+    if (error instanceof GoogleTasksApiError) {
+      return NextResponse.json(
+        { error: error.message },
+        { status: error.status }
+      );
     }
-  );
-
-  if (!googleResponse.ok) {
-    const error = await googleResponse.json();
-    return NextResponse.json(
-      { error: error.error?.message || "Failed to complete task" },
-      { status: googleResponse.status }
-    );
+    throw error;
   }
-
-  const task = (await googleResponse.json()) as GoogleTask;
 
   const streak = await updateProfileStreak(profileId);
 

--- a/src/app/api/tasks/[taskId]/route.ts
+++ b/src/app/api/tasks/[taskId]/route.ts
@@ -3,21 +3,14 @@
  * Uses server-side authentication with NextAuth.js
  */
 import { AuthError, getAccessToken, getSession } from "@/lib/auth";
-import { fetchWithRetry } from "@/lib/http/retry";
+import { patchTask } from "@/lib/google/tasks-api";
+import {
+  GoogleTasksApiError,
+  type PatchTaskInput,
+  TASK_STATUSES,
+} from "@/lib/google/tasks-types";
 import { logger } from "@/lib/logger";
 import { NextRequest, NextResponse } from "next/server";
-
-const GOOGLE_TASKS_API = "https://tasks.googleapis.com/tasks/v1";
-
-const VALID_STATUSES = ["needsAction", "completed"] as const;
-type TaskStatus = (typeof VALID_STATUSES)[number];
-
-interface TaskUpdateBody {
-  status?: TaskStatus;
-  title?: string;
-  notes?: string;
-  due?: string;
-}
 
 /**
  * PATCH /api/tasks/[taskId] - Update a task
@@ -60,10 +53,9 @@ export async function PATCH(
       );
     }
 
-    const body = (await request.json()) as TaskUpdateBody;
+    const body = (await request.json()) as PatchTaskInput;
 
-    // Validate status if provided
-    if (body.status && !VALID_STATUSES.includes(body.status)) {
+    if (body.status && !TASK_STATUSES.includes(body.status)) {
       return NextResponse.json(
         { error: "Invalid status. Must be 'needsAction' or 'completed'" },
         { status: 400 }
@@ -71,46 +63,7 @@ export async function PATCH(
     }
 
     const accessToken = await getAccessToken();
-
-    const response = await fetchWithRetry(
-      `${GOOGLE_TASKS_API}/lists/${encodeURIComponent(listId)}/tasks/${encodeURIComponent(taskId)}`,
-      {
-        method: "PATCH",
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(body),
-      }
-    );
-
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({}));
-      logger.error(new Error("Failed to update task"), {
-        status: response.status,
-        errorData,
-        taskId,
-        listId,
-        userId: session.user.id,
-      });
-
-      if (response.status === 401) {
-        return NextResponse.json(
-          {
-            error: "Google authentication failed. Please sign in again.",
-            requiresReauth: true,
-          },
-          { status: 401 }
-        );
-      }
-
-      return NextResponse.json(
-        { error: "Failed to update task" },
-        { status: response.status }
-      );
-    }
-
-    const updatedTask = await response.json();
+    const updatedTask = await patchTask(accessToken, listId, taskId, body);
 
     logger.event("TaskUpdated", {
       taskId,
@@ -124,6 +77,31 @@ export async function PATCH(
     if (error instanceof AuthError) {
       return NextResponse.json(
         { error: error.message, requiresReauth: error.status === 401 },
+        { status: error.status }
+      );
+    }
+
+    if (error instanceof GoogleTasksApiError) {
+      logger.error(error, {
+        endpoint: "/api/tasks/[taskId]",
+        status: error.status,
+      });
+
+      if (error.status === 401 || error.status === 403) {
+        return NextResponse.json(
+          {
+            error:
+              error.status === 403
+                ? "Missing Google Tasks scope. Please sign in again to grant access."
+                : "Google authentication failed. Please sign in again.",
+            requiresReauth: true,
+          },
+          { status: error.status }
+        );
+      }
+
+      return NextResponse.json(
+        { error: "Failed to update task" },
         { status: error.status }
       );
     }

--- a/src/app/api/tasks/lists/route.ts
+++ b/src/app/api/tasks/lists/route.ts
@@ -3,11 +3,10 @@
  * Uses server-side authentication with NextAuth.js
  */
 import { AuthError, getAccessToken, getSession } from "@/lib/auth";
-import { fetchWithRetry } from "@/lib/http/retry";
+import { listTaskLists } from "@/lib/google/tasks-api";
+import { GoogleTasksApiError } from "@/lib/google/tasks-types";
 import { logger } from "@/lib/logger";
 import { NextResponse } from "next/server";
-
-const GOOGLE_TASKS_API = "https://tasks.googleapis.com/tasks/v1";
 
 /**
  * GET /api/tasks/lists - List all task lists for the authenticated user
@@ -30,55 +29,43 @@ export async function GET() {
     }
 
     const accessToken = await getAccessToken();
+    const lists = await listTaskLists(accessToken);
 
-    const response = await fetchWithRetry(
-      `${GOOGLE_TASKS_API}/users/@me/lists`,
-      {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-          "Content-Type": "application/json",
-        },
-      }
-    );
+    logger.event("TaskListsFetched", {
+      listCount: lists.length,
+      userId: session.user.id,
+    });
 
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({}));
-      logger.error(new Error("Google Tasks API error"), {
-        status: response.status,
-        errorData,
-        userId: session.user.id,
+    return NextResponse.json({ lists });
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return NextResponse.json(
+        { error: error.message, requiresReauth: error.status === 401 },
+        { status: error.status }
+      );
+    }
+
+    if (error instanceof GoogleTasksApiError) {
+      logger.error(error, {
+        endpoint: "/api/tasks/lists",
+        status: error.status,
       });
 
-      if (response.status === 401) {
+      if (error.status === 401 || error.status === 403) {
         return NextResponse.json(
           {
-            error: "Google authentication failed. Please sign in again.",
+            error:
+              error.status === 403
+                ? "Missing Google Tasks scope. Please sign in again to grant access."
+                : "Google authentication failed. Please sign in again.",
             requiresReauth: true,
           },
-          { status: 401 }
+          { status: error.status }
         );
       }
 
       return NextResponse.json(
         { error: "Failed to fetch task lists" },
-        { status: response.status }
-      );
-    }
-
-    const data = await response.json();
-
-    logger.log("Task lists fetched", {
-      listCount: data.items?.length || 0,
-      userId: session.user.id,
-    });
-
-    return NextResponse.json({
-      lists: data.items || [],
-    });
-  } catch (error) {
-    if (error instanceof AuthError) {
-      return NextResponse.json(
-        { error: error.message, requiresReauth: error.status === 401 },
         { status: error.status }
       );
     }

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -3,11 +3,17 @@
  * Uses server-side authentication with NextAuth.js
  */
 import { AuthError, getAccessToken, getSession } from "@/lib/auth";
-import { fetchWithRetry } from "@/lib/http/retry";
+import { createTask, listTasks } from "@/lib/google/tasks-api";
+import { GoogleTasksApiError } from "@/lib/google/tasks-types";
 import { logger } from "@/lib/logger";
 import { NextRequest, NextResponse } from "next/server";
 
-const GOOGLE_TASKS_API = "https://tasks.googleapis.com/tasks/v1";
+interface CreateTaskBody {
+  listId?: string;
+  title?: string;
+  notes?: string;
+  due?: string;
+}
 
 /**
  * GET /api/tasks - List tasks from a task list
@@ -44,77 +50,25 @@ export async function GET(request: NextRequest) {
     }
 
     const showCompleted = searchParams.get("showCompleted") === "true";
-    const maxResults = searchParams.get("maxResults") || "100";
+    const maxResultsParam = searchParams.get("maxResults");
+    const maxResults = maxResultsParam ? Number(maxResultsParam) : undefined;
 
     const accessToken = await getAccessToken();
 
-    const apiUrl = new URL(
-      `${GOOGLE_TASKS_API}/lists/${encodeURIComponent(listId)}/tasks`
-    );
-    apiUrl.searchParams.set("maxResults", maxResults);
-    apiUrl.searchParams.set("showCompleted", String(showCompleted));
-
-    const response = await fetchWithRetry(apiUrl.toString(), {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        "Content-Type": "application/json",
-      },
+    const { tasks, nextPageToken } = await listTasks(accessToken, listId, {
+      showCompleted,
+      ...(maxResults !== undefined && { maxResults }),
     });
 
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({}));
-      logger.error(new Error("Google Tasks API error"), {
-        status: response.status,
-        errorData,
-        listId,
-        userId: session.user.id,
-      });
-
-      if (response.status === 401) {
-        return NextResponse.json(
-          {
-            error: "Google authentication failed. Please sign in again.",
-            requiresReauth: true,
-          },
-          { status: 401 }
-        );
-      }
-
-      return NextResponse.json(
-        { error: "Failed to fetch tasks" },
-        { status: response.status }
-      );
-    }
-
-    const data = await response.json();
-
-    logger.log("Tasks fetched", {
+    logger.event("TasksFetched", {
       listId,
-      taskCount: data.items?.length || 0,
+      taskCount: tasks.length,
       userId: session.user.id,
     });
 
-    return NextResponse.json({
-      tasks: data.items || [],
-      nextPageToken: data.nextPageToken,
-    });
+    return NextResponse.json({ tasks, nextPageToken });
   } catch (error) {
-    if (error instanceof AuthError) {
-      return NextResponse.json(
-        { error: error.message, requiresReauth: error.status === 401 },
-        { status: error.status }
-      );
-    }
-
-    logger.error(error as Error, {
-      endpoint: "/api/tasks",
-      errorType: "fetch_tasks",
-    });
-
-    return NextResponse.json(
-      { error: "An unexpected error occurred" },
-      { status: 500 }
-    );
+    return handleTasksApiError(error, "fetch_tasks");
   }
 }
 
@@ -139,7 +93,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const body = await request.json();
+    const body = (await request.json()) as CreateTaskBody;
     const { listId, title, notes, due } = body;
 
     if (!listId || !title) {
@@ -151,48 +105,7 @@ export async function POST(request: NextRequest) {
 
     const accessToken = await getAccessToken();
 
-    const response = await fetchWithRetry(
-      `${GOOGLE_TASKS_API}/lists/${encodeURIComponent(listId)}/tasks`,
-      {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          title,
-          notes,
-          due,
-        }),
-      }
-    );
-
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({}));
-      logger.error(new Error("Failed to create task"), {
-        status: response.status,
-        errorData,
-        listId,
-        userId: session.user.id,
-      });
-
-      if (response.status === 401) {
-        return NextResponse.json(
-          {
-            error: "Google authentication failed. Please sign in again.",
-            requiresReauth: true,
-          },
-          { status: 401 }
-        );
-      }
-
-      return NextResponse.json(
-        { error: "Failed to create task" },
-        { status: response.status }
-      );
-    }
-
-    const task = await response.json();
+    const task = await createTask(accessToken, listId, { title, notes, due });
 
     logger.event("TaskCreated", {
       listId,
@@ -202,21 +115,56 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({ task }, { status: 201 });
   } catch (error) {
-    if (error instanceof AuthError) {
+    return handleTasksApiError(error, "create_task");
+  }
+}
+
+function handleTasksApiError(
+  error: unknown,
+  errorType: "fetch_tasks" | "create_task"
+): NextResponse {
+  if (error instanceof AuthError) {
+    return NextResponse.json(
+      { error: error.message, requiresReauth: error.status === 401 },
+      { status: error.status }
+    );
+  }
+
+  if (error instanceof GoogleTasksApiError) {
+    logger.error(error, {
+      endpoint: "/api/tasks",
+      errorType,
+      status: error.status,
+    });
+
+    if (error.status === 401 || error.status === 403) {
       return NextResponse.json(
-        { error: error.message, requiresReauth: error.status === 401 },
+        {
+          error:
+            error.status === 403
+              ? "Missing Google Tasks scope. Please sign in again to grant access."
+              : "Google authentication failed. Please sign in again.",
+          requiresReauth: true,
+        },
         { status: error.status }
       );
     }
 
-    logger.error(error as Error, {
-      endpoint: "/api/tasks",
-      errorType: "create_task",
-    });
-
     return NextResponse.json(
-      { error: "An unexpected error occurred" },
-      { status: 500 }
+      {
+        error:
+          errorType === "create_task"
+            ? "Failed to create task"
+            : "Failed to fetch tasks",
+      },
+      { status: error.status }
     );
   }
+
+  logger.error(error as Error, { endpoint: "/api/tasks", errorType });
+
+  return NextResponse.json(
+    { error: "An unexpected error occurred" },
+    { status: 500 }
+  );
 }

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -51,7 +51,17 @@ export async function GET(request: NextRequest) {
 
     const showCompleted = searchParams.get("showCompleted") === "true";
     const maxResultsParam = searchParams.get("maxResults");
-    const maxResults = maxResultsParam ? Number(maxResultsParam) : undefined;
+    let maxResults: number | undefined;
+    if (maxResultsParam !== null) {
+      const parsed = Number(maxResultsParam);
+      if (!Number.isFinite(parsed) || parsed < 1) {
+        return NextResponse.json(
+          { error: "maxResults must be a positive integer" },
+          { status: 400 }
+        );
+      }
+      maxResults = Math.trunc(parsed);
+    }
 
     const accessToken = await getAccessToken();
 

--- a/src/lib/google/__tests__/tasks-api.test.ts
+++ b/src/lib/google/__tests__/tasks-api.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Unit tests for the typed Google Tasks API wrapper.
+ *
+ * These tests focus on URL/query construction, response parsing into the
+ * canonical types, and the error envelope. The retry behaviour itself is
+ * already covered by `src/lib/http/__tests__/retry.test.ts`, so we stub
+ * `fetchWithRetry` to a no-retry pass-through and exercise the wrapper in
+ * isolation.
+ */
+import { fetchWithRetry } from "@/lib/http/retry";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  GOOGLE_TASKS_API_BASE,
+  createTask,
+  deleteTask,
+  listTaskLists,
+  listTasks,
+  patchTask,
+} from "../tasks-api";
+import { GoogleTasksApiError } from "../tasks-types";
+
+vi.mock("@/lib/http/retry", () => ({
+  fetchWithRetry: vi.fn(),
+}));
+
+const ACCESS_TOKEN = "test-access-token";
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+}
+
+function noContentResponse(): Response {
+  return new Response(null, { status: 204 });
+}
+
+function lastFetchCall() {
+  const calls = vi.mocked(fetchWithRetry).mock.calls;
+  return calls[calls.length - 1];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("listTaskLists", () => {
+  it("returns parsed items array on success", async () => {
+    vi.mocked(fetchWithRetry).mockResolvedValue(
+      jsonResponse({
+        items: [
+          { id: "list-1", title: "Work" },
+          { id: "list-2", title: "Personal" },
+        ],
+      })
+    );
+
+    const lists = await listTaskLists(ACCESS_TOKEN);
+
+    expect(lists).toEqual([
+      { id: "list-1", title: "Work" },
+      { id: "list-2", title: "Personal" },
+    ]);
+  });
+
+  it("returns empty array when API returns no items", async () => {
+    vi.mocked(fetchWithRetry).mockResolvedValue(jsonResponse({}));
+
+    const lists = await listTaskLists(ACCESS_TOKEN);
+
+    expect(lists).toEqual([]);
+  });
+
+  it("calls the canonical lists endpoint with bearer auth", async () => {
+    vi.mocked(fetchWithRetry).mockResolvedValue(jsonResponse({ items: [] }));
+
+    await listTaskLists(ACCESS_TOKEN);
+
+    const [url, init] = lastFetchCall();
+    expect(url).toBe(`${GOOGLE_TASKS_API_BASE}/users/@me/lists`);
+    expect(init?.method).toBe("GET");
+    const headers = init?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe(`Bearer ${ACCESS_TOKEN}`);
+  });
+
+  it("throws GoogleTasksApiError with parsed message on non-OK response", async () => {
+    vi.mocked(fetchWithRetry).mockResolvedValue(
+      jsonResponse(
+        { error: { code: 403, message: "Insufficient Permission" } },
+        { status: 403 }
+      )
+    );
+
+    await expect(listTaskLists(ACCESS_TOKEN)).rejects.toMatchObject({
+      name: "GoogleTasksApiError",
+      status: 403,
+      message: "Insufficient Permission",
+    });
+  });
+
+  it("falls back to a default error message when body has none", async () => {
+    vi.mocked(fetchWithRetry).mockResolvedValue(
+      new Response(null, { status: 500 })
+    );
+
+    await expect(listTaskLists(ACCESS_TOKEN)).rejects.toMatchObject({
+      name: "GoogleTasksApiError",
+      status: 500,
+      message: "Google Tasks API error: 500",
+    });
+  });
+});
+
+describe("listTasks", () => {
+  it("returns tasks and nextPageToken on success", async () => {
+    vi.mocked(fetchWithRetry).mockResolvedValue(
+      jsonResponse({
+        items: [
+          {
+            id: "task-1",
+            title: "Buy milk",
+            status: "needsAction",
+          },
+        ],
+        nextPageToken: "next-page",
+      })
+    );
+
+    const result = await listTasks(ACCESS_TOKEN, "list-1");
+
+    expect(result.tasks).toHaveLength(1);
+    expect(result.tasks[0]).toEqual({
+      id: "task-1",
+      title: "Buy milk",
+      status: "needsAction",
+    });
+    expect(result.nextPageToken).toBe("next-page");
+  });
+
+  it("encodes the listId path component", async () => {
+    vi.mocked(fetchWithRetry).mockResolvedValue(jsonResponse({ items: [] }));
+
+    await listTasks(ACCESS_TOKEN, "list/with spaces");
+
+    const [url] = lastFetchCall();
+    const urlString = url as string;
+    expect(urlString).toContain("/lists/list%2Fwith%20spaces/tasks");
+  });
+
+  it("applies safe defaults for showCompleted/showDeleted/showHidden/maxResults", async () => {
+    vi.mocked(fetchWithRetry).mockResolvedValue(jsonResponse({ items: [] }));
+
+    await listTasks(ACCESS_TOKEN, "list-1");
+
+    const [url] = lastFetchCall();
+    const parsed = new URL(url as string);
+    expect(parsed.searchParams.get("showCompleted")).toBe("false");
+    expect(parsed.searchParams.get("showDeleted")).toBe("false");
+    expect(parsed.searchParams.get("showHidden")).toBe("false");
+    expect(parsed.searchParams.get("maxResults")).toBe("100");
+  });
+
+  it("propagates explicit query options including pagination + due window", async () => {
+    vi.mocked(fetchWithRetry).mockResolvedValue(jsonResponse({ items: [] }));
+
+    await listTasks(ACCESS_TOKEN, "list-1", {
+      showCompleted: true,
+      maxResults: 25,
+      pageToken: "page-2",
+      dueMin: "2026-05-01T00:00:00.000Z",
+      dueMax: "2026-05-08T00:00:00.000Z",
+      updatedMin: "2026-04-29T00:00:00.000Z",
+    });
+
+    const [url] = lastFetchCall();
+    const parsed = new URL(url as string);
+    expect(parsed.searchParams.get("showCompleted")).toBe("true");
+    expect(parsed.searchParams.get("maxResults")).toBe("25");
+    expect(parsed.searchParams.get("pageToken")).toBe("page-2");
+    expect(parsed.searchParams.get("dueMin")).toBe("2026-05-01T00:00:00.000Z");
+    expect(parsed.searchParams.get("dueMax")).toBe("2026-05-08T00:00:00.000Z");
+    expect(parsed.searchParams.get("updatedMin")).toBe(
+      "2026-04-29T00:00:00.000Z"
+    );
+  });
+
+  it("returns empty tasks array when items field is missing", async () => {
+    vi.mocked(fetchWithRetry).mockResolvedValue(jsonResponse({}));
+
+    const result = await listTasks(ACCESS_TOKEN, "list-1");
+    expect(result.tasks).toEqual([]);
+    expect(result.nextPageToken).toBeUndefined();
+  });
+});
+
+describe("createTask", () => {
+  it("POSTs the task body and returns the created task", async () => {
+    vi.mocked(fetchWithRetry).mockResolvedValue(
+      jsonResponse(
+        {
+          id: "task-new",
+          title: "Walk the dog",
+          status: "needsAction",
+        },
+        { status: 200 }
+      )
+    );
+
+    const created = await createTask(ACCESS_TOKEN, "list-1", {
+      title: "Walk the dog",
+      notes: "Before dinner",
+      due: "2026-05-03T00:00:00.000Z",
+    });
+
+    expect(created).toEqual({
+      id: "task-new",
+      title: "Walk the dog",
+      status: "needsAction",
+    });
+
+    const [url, init] = lastFetchCall();
+    expect(url).toBe(`${GOOGLE_TASKS_API_BASE}/lists/list-1/tasks`);
+    expect(init?.method).toBe("POST");
+    expect(init?.body).toBe(
+      JSON.stringify({
+        title: "Walk the dog",
+        notes: "Before dinner",
+        due: "2026-05-03T00:00:00.000Z",
+      })
+    );
+  });
+
+  it("raises GoogleTasksApiError on validation failures", async () => {
+    vi.mocked(fetchWithRetry).mockResolvedValue(
+      jsonResponse(
+        { error: { code: 400, message: "Invalid value at 'task.due'" } },
+        { status: 400 }
+      )
+    );
+
+    await expect(
+      createTask(ACCESS_TOKEN, "list-1", { title: "Bad due", due: "nope" })
+    ).rejects.toBeInstanceOf(GoogleTasksApiError);
+  });
+});
+
+describe("patchTask", () => {
+  it("PATCHes the partial body and encodes both path components", async () => {
+    vi.mocked(fetchWithRetry).mockResolvedValue(
+      jsonResponse({
+        id: "task-1",
+        title: "Buy milk",
+        status: "completed",
+      })
+    );
+
+    const updated = await patchTask(ACCESS_TOKEN, "list/1", "task/1", {
+      status: "completed",
+    });
+
+    expect(updated.status).toBe("completed");
+    const [url, init] = lastFetchCall();
+    expect(url).toBe(`${GOOGLE_TASKS_API_BASE}/lists/list%2F1/tasks/task%2F1`);
+    expect(init?.method).toBe("PATCH");
+    expect(init?.body).toBe(JSON.stringify({ status: "completed" }));
+  });
+});
+
+describe("deleteTask", () => {
+  it("issues DELETE and resolves on 204", async () => {
+    vi.mocked(fetchWithRetry).mockResolvedValue(noContentResponse());
+
+    await expect(
+      deleteTask(ACCESS_TOKEN, "list-1", "task-1")
+    ).resolves.toBeUndefined();
+
+    const [url, init] = lastFetchCall();
+    expect(url).toBe(`${GOOGLE_TASKS_API_BASE}/lists/list-1/tasks/task-1`);
+    expect(init?.method).toBe("DELETE");
+  });
+
+  it("surfaces 404 as GoogleTasksApiError with the API message", async () => {
+    vi.mocked(fetchWithRetry).mockResolvedValue(
+      jsonResponse(
+        { error: { code: 404, message: "Not Found" } },
+        { status: 404 }
+      )
+    );
+
+    await expect(
+      deleteTask(ACCESS_TOKEN, "list-1", "missing")
+    ).rejects.toMatchObject({
+      name: "GoogleTasksApiError",
+      status: 404,
+      message: "Not Found",
+    });
+  });
+});

--- a/src/lib/google/tasks-api.ts
+++ b/src/lib/google/tasks-api.ts
@@ -1,0 +1,200 @@
+/**
+ * Typed thin wrapper over the Google Tasks REST API
+ * (https://tasks.googleapis.com/tasks/v1).
+ *
+ * The wrapper owns:
+ *   - URL construction + query-string encoding
+ *   - Bearer-token attachment
+ *   - Transient-failure retry via {@link fetchWithRetry}
+ *   - Response parsing into the canonical {@link tasks-types} shapes
+ *   - Non-OK responses raised as {@link GoogleTasksApiError}
+ *
+ * It deliberately stays caller-agnostic: it accepts an `accessToken` (which
+ * route handlers fetch via `getAccessToken()`) and never touches NextAuth or
+ * Prisma directly. Higher-level concerns (auth checks, request logging, error
+ * shaping for clients) belong in the route handlers that call these helpers.
+ */
+import { fetchWithRetry } from "@/lib/http/retry";
+import {
+  type CreateTaskInput,
+  type GoogleTask,
+  type GoogleTaskCollection,
+  type GoogleTaskList,
+  GoogleTasksApiError,
+  type ListTasksOptions,
+  type ListTasksResult,
+  type PatchTaskInput,
+} from "./tasks-types";
+
+export const GOOGLE_TASKS_API_BASE = "https://tasks.googleapis.com/tasks/v1";
+
+interface CallOptions {
+  /** Forwarded to `fetchWithRetry` (and ultimately the `fetch` call). */
+  signal?: AbortSignal;
+}
+
+interface RequestInitWithBody extends RequestInit {
+  bodyJson?: unknown;
+}
+
+async function tasksRequest<T>(
+  accessToken: string,
+  url: URL,
+  init: RequestInitWithBody = {}
+): Promise<T> {
+  const { bodyJson, headers, ...rest } = init;
+
+  const response = await fetchWithRetry(url.toString(), {
+    ...rest,
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+      ...headers,
+    },
+    body: bodyJson === undefined ? rest.body : JSON.stringify(bodyJson),
+  });
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  // Google Tasks responses are always JSON for both success and error bodies.
+  // Some error responses (or aborted requests) may have empty bodies, so fall
+  // back to `null` rather than letting `JSON.parse` throw.
+  const parsed = await response.json().catch(() => null as unknown);
+
+  if (!response.ok) {
+    const apiMessage =
+      parsed &&
+      typeof parsed === "object" &&
+      "error" in parsed &&
+      typeof (parsed as { error?: { message?: string } }).error?.message ===
+        "string"
+        ? (parsed as { error: { message: string } }).error.message
+        : null;
+    throw new GoogleTasksApiError(
+      response.status,
+      apiMessage ?? `Google Tasks API error: ${response.status}`,
+      parsed
+    );
+  }
+
+  return (parsed ?? (undefined as unknown)) as T;
+}
+
+function buildUrl(path: string): URL {
+  return new URL(`${GOOGLE_TASKS_API_BASE}${path}`);
+}
+
+/** GET /users/@me/lists — return all task lists the user owns. */
+export async function listTaskLists(
+  accessToken: string,
+  options: CallOptions = {}
+): Promise<GoogleTaskList[]> {
+  const url = buildUrl("/users/@me/lists");
+  const data = await tasksRequest<GoogleTaskCollection<GoogleTaskList>>(
+    accessToken,
+    url,
+    { method: "GET", signal: options.signal }
+  );
+  return data?.items ?? [];
+}
+
+/**
+ * GET /lists/{listId}/tasks — return tasks in a list.
+ *
+ * Defaults match the most common UI use case: hide completed/deleted/hidden,
+ * cap at 100 items. Caller can override any of these via {@link ListTasksOptions}.
+ */
+export async function listTasks(
+  accessToken: string,
+  listId: string,
+  opts: ListTasksOptions = {},
+  callOptions: CallOptions = {}
+): Promise<ListTasksResult> {
+  const url = buildUrl(`/lists/${encodeURIComponent(listId)}/tasks`);
+  appendListTasksParams(url, opts);
+
+  const data = await tasksRequest<GoogleTaskCollection<GoogleTask>>(
+    accessToken,
+    url,
+    { method: "GET", signal: callOptions.signal }
+  );
+
+  return {
+    tasks: data?.items ?? [],
+    nextPageToken: data?.nextPageToken,
+  };
+}
+
+function appendListTasksParams(url: URL, opts: ListTasksOptions): void {
+  const showCompleted = opts.showCompleted ?? false;
+  const showDeleted = opts.showDeleted ?? false;
+  const showHidden = opts.showHidden ?? false;
+  const maxResults = opts.maxResults ?? 100;
+
+  url.searchParams.set("showCompleted", String(showCompleted));
+  url.searchParams.set("showDeleted", String(showDeleted));
+  url.searchParams.set("showHidden", String(showHidden));
+  url.searchParams.set("maxResults", String(maxResults));
+
+  if (opts.pageToken) url.searchParams.set("pageToken", opts.pageToken);
+  if (opts.dueMin) url.searchParams.set("dueMin", opts.dueMin);
+  if (opts.dueMax) url.searchParams.set("dueMax", opts.dueMax);
+  if (opts.completedMin)
+    url.searchParams.set("completedMin", opts.completedMin);
+  if (opts.completedMax)
+    url.searchParams.set("completedMax", opts.completedMax);
+  if (opts.updatedMin) url.searchParams.set("updatedMin", opts.updatedMin);
+}
+
+/** POST /lists/{listId}/tasks — create a new task. */
+export async function createTask(
+  accessToken: string,
+  listId: string,
+  task: CreateTaskInput,
+  options: CallOptions = {}
+): Promise<GoogleTask> {
+  const url = buildUrl(`/lists/${encodeURIComponent(listId)}/tasks`);
+  return await tasksRequest<GoogleTask>(accessToken, url, {
+    method: "POST",
+    bodyJson: task,
+    signal: options.signal,
+  });
+}
+
+/** PATCH /lists/{listId}/tasks/{taskId} — partial update of a task. */
+export async function patchTask(
+  accessToken: string,
+  listId: string,
+  taskId: string,
+  updates: PatchTaskInput,
+  options: CallOptions = {}
+): Promise<GoogleTask> {
+  const url = buildUrl(
+    `/lists/${encodeURIComponent(listId)}/tasks/${encodeURIComponent(taskId)}`
+  );
+  return await tasksRequest<GoogleTask>(accessToken, url, {
+    method: "PATCH",
+    bodyJson: updates,
+    signal: options.signal,
+  });
+}
+
+/** DELETE /lists/{listId}/tasks/{taskId} — permanently delete a task. */
+export async function deleteTask(
+  accessToken: string,
+  listId: string,
+  taskId: string,
+  options: CallOptions = {}
+): Promise<void> {
+  const url = buildUrl(
+    `/lists/${encodeURIComponent(listId)}/tasks/${encodeURIComponent(taskId)}`
+  );
+  await tasksRequest<void>(accessToken, url, {
+    method: "DELETE",
+    signal: options.signal,
+  });
+}
+
+export { GoogleTasksApiError };

--- a/src/lib/google/tasks-types.ts
+++ b/src/lib/google/tasks-types.ts
@@ -1,0 +1,107 @@
+/**
+ * Typed shapes for Google Tasks API v1 responses and request payloads.
+ *
+ * Universal module: no browser globals, no server-only deps. Safe to import
+ * from both route handlers and shared lib code.
+ *
+ * Schema mirrored from https://developers.google.com/tasks/reference/rest/v1.
+ */
+
+/** Status values returned by Google Tasks API. */
+export const TASK_STATUSES = ["needsAction", "completed"] as const;
+export type TaskStatus = (typeof TASK_STATUSES)[number];
+
+/** Raw task list resource as returned by Google Tasks API. */
+export interface GoogleTaskList {
+  kind?: "tasks#taskList";
+  id: string;
+  etag?: string;
+  title: string;
+  updated?: string;
+  selfLink?: string;
+}
+
+/** Embedded link on a task (Google docs, etc.). */
+export interface GoogleTaskLink {
+  type: string;
+  description: string;
+  link: string;
+}
+
+/** Raw task resource as returned by Google Tasks API. */
+export interface GoogleTask {
+  kind?: "tasks#task";
+  id: string;
+  etag?: string;
+  title: string;
+  updated?: string;
+  selfLink?: string;
+  parent?: string;
+  position?: string;
+  notes?: string;
+  status: TaskStatus;
+  due?: string;
+  completed?: string;
+  deleted?: boolean;
+  hidden?: boolean;
+  links?: GoogleTaskLink[];
+}
+
+/** Wire-format collection envelope returned by list endpoints. */
+export interface GoogleTaskCollection<T> {
+  kind?: string;
+  etag?: string;
+  nextPageToken?: string;
+  items?: T[];
+}
+
+/** Options accepted by `listTasks`. Mirrors the relevant query params. */
+export interface ListTasksOptions {
+  showCompleted?: boolean;
+  showDeleted?: boolean;
+  showHidden?: boolean;
+  maxResults?: number;
+  pageToken?: string;
+  dueMin?: string;
+  dueMax?: string;
+  completedMin?: string;
+  completedMax?: string;
+  updatedMin?: string;
+}
+
+/** Result envelope returned by `listTasks`. */
+export interface ListTasksResult {
+  tasks: GoogleTask[];
+  nextPageToken?: string;
+}
+
+/** Payload accepted by `createTask`. */
+export interface CreateTaskInput {
+  title: string;
+  notes?: string;
+  due?: string;
+  status?: TaskStatus;
+  parent?: string;
+  previous?: string;
+}
+
+/** Payload accepted by `patchTask`. Any subset of the writable task fields. */
+export type PatchTaskInput = Partial<
+  Pick<GoogleTask, "title" | "notes" | "due" | "status" | "completed">
+>;
+
+/**
+ * Error thrown when a Google Tasks API call returns a non-OK response. Mirrors
+ * the auth error shape used elsewhere so route handlers can switch on `status`.
+ */
+export class GoogleTasksApiError extends Error {
+  readonly status: number;
+  readonly body: unknown;
+
+  constructor(status: number, message: string, body: unknown = null) {
+    super(message);
+    this.name = "GoogleTasksApiError";
+    this.status = status;
+    this.body = body;
+  }
+}


### PR DESCRIPTION
## Summary

Closes the remaining work for #162 — the OAuth scope was already added in `src/lib/auth/auth.ts:23`, but the typed helper module the rest of the Tasks track needs to bind against did not exist. This PR adds it and refactors the four existing `/api/tasks/*` routes onto it, removing duplicated direct-fetch + error-handling boilerplate.

## What's new

- `src/lib/google/tasks-types.ts` — canonical TypeScript shapes for Google Tasks v1 (`GoogleTask`, `GoogleTaskList`, `ListTasksOptions`, `CreateTaskInput`, `PatchTaskInput`) plus `GoogleTasksApiError` and the `TASK_STATUSES` const.
- `src/lib/google/tasks-api.ts` — typed thin wrapper exposing the helpers the issue calls out: `listTaskLists`, `listTasks`, `createTask`, `patchTask`, `deleteTask`. Owns URL/query construction, bearer-token attachment, `fetchWithRetry` integration, response parsing, and error envelope.
- 15 new unit tests in `src/lib/google/__tests__/tasks-api.test.ts` covering URL/query construction (encoding, defaults, full option set), response parsing (success + missing `items`), and the `GoogleTasksApiError` shape (parsed message vs. fallback).

## Refactors

- `/api/tasks` (GET + POST), `/api/tasks/lists` (GET), `/api/tasks/[taskId]` (PATCH), and `/api/tasks/[taskId]/complete` (POST) now delegate the HTTP call to the wrapper and translate `GoogleTasksApiError` into the existing 401/403/4xx response shapes.
- 403 from upstream now surfaces as `requiresReauth: true` so clients can prompt re-consent when the user authenticated before the Tasks scope was added — that satisfies the "existing users are prompted to re-consent on first Tasks API use" line of the acceptance criteria.

## Why this is the next issue

`#162` is the unblocked root of the Tasks track (Days 7-8). It unblocks 4 downstream Tasks issues (#163 API routes, #164 TaskList components, #165 NewTaskModal, #166 multi-profile wiring) and indirectly the Rewards UI (#173) and multi-profile Phase 4. Highest fan-out among the three unblocked roots (#162, #167, #171).

## Test plan

- [x] `pnpm test:run` — 1435 tests pass across 98 files
- [x] `pnpm lint:fix` — 0 errors (4 pre-existing warnings unrelated to this PR)
- [x] `pnpm format:fix` — clean
- [x] `pnpm check-types` — clean
- [ ] Manual smoke test once a Tasks UI exists in a downstream PR (no UI in this PR)

Closes #162.

https://claude.ai/code/session_01Ejvz3w2D68ypMYYrCMpAWa

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ejvz3w2D68ypMYYrCMpAWa)_