### PR TITLE
feat(meals): add Prisma schema for meal planning (#167)

### DIFF
--- a/prisma/__tests__/migration-setup.test.ts
+++ b/prisma/__tests__/migration-setup.test.ts
@@ -183,13 +183,23 @@ describe("Account uniqueness constraints (issue #61)", () => {
   });
 });
 
+function readAllMigrationsCombined(): string {
+  const entries = fs.readdirSync(MIGRATIONS_DIR, { withFileTypes: true });
+  return entries
+    .filter((e) => e.isDirectory() && e.name !== "__tests__")
+    .map((e) =>
+      fs.readFileSync(
+        path.join(MIGRATIONS_DIR, e.name, "migration.sql"),
+        "utf-8"
+      )
+    )
+    .join("\n");
+}
+
 describe("schema and migration consistency", () => {
-  it("should reference the same models in schema and migration", () => {
+  it("should reference the same models across all migrations", () => {
     const schemaContent = fs.readFileSync(SCHEMA_PATH, "utf-8");
-    const migrationContent = fs.readFileSync(
-      path.join(MIGRATIONS_DIR, "0001_initial", "migration.sql"),
-      "utf-8"
-    );
+    const combinedSql = readAllMigrationsCombined();
 
     // Extract model names from schema
     const modelRegex = /^model\s+(\w+)\s*\{/gm;
@@ -199,21 +209,18 @@ describe("schema and migration consistency", () => {
       schemaModels.push(match[1]);
     }
 
-    // Every schema model should have a CREATE TABLE in the migration
+    // Every schema model should have a CREATE TABLE in some migration
     for (const model of schemaModels) {
       expect(
-        migrationContent,
-        `Migration is missing CREATE TABLE for model "${model}"`
+        combinedSql,
+        `Migrations are missing CREATE TABLE for model "${model}"`
       ).toContain(`CREATE TABLE "${model}"`);
     }
   });
 
-  it("should reference the same enums in schema and migration", () => {
+  it("should reference the same enums across all migrations", () => {
     const schemaContent = fs.readFileSync(SCHEMA_PATH, "utf-8");
-    const migrationContent = fs.readFileSync(
-      path.join(MIGRATIONS_DIR, "0001_initial", "migration.sql"),
-      "utf-8"
-    );
+    const combinedSql = readAllMigrationsCombined();
 
     // Extract enum names from schema
     const enumRegex = /^enum\s+(\w+)\s*\{/gm;
@@ -223,12 +230,143 @@ describe("schema and migration consistency", () => {
       schemaEnums.push(match[1]);
     }
 
-    // Every schema enum should have a CREATE TYPE in the migration
+    // Every schema enum should have a CREATE TYPE in some migration
     for (const enumName of schemaEnums) {
       expect(
-        migrationContent,
-        `Migration is missing CREATE TYPE for enum "${enumName}"`
+        combinedSql,
+        `Migrations are missing CREATE TYPE for enum "${enumName}"`
       ).toContain(`CREATE TYPE "${enumName}"`);
     }
+  });
+});
+
+describe("meal planning schema (issue #167)", () => {
+  const MEAL_MIGRATION_DIR = path.join(
+    MIGRATIONS_DIR,
+    "0005_add_meal_planning"
+  );
+
+  it("declares the MealType and DayOfWeek enums", () => {
+    const schemaContent = fs.readFileSync(SCHEMA_PATH, "utf-8");
+
+    expect(schemaContent).toMatch(/enum\s+MealType\s*\{[\s\S]*?breakfast/);
+    expect(schemaContent).toMatch(/enum\s+MealType\s*\{[\s\S]*?lunch/);
+    expect(schemaContent).toMatch(/enum\s+MealType\s*\{[\s\S]*?dinner/);
+    expect(schemaContent).toMatch(/enum\s+MealType\s*\{[\s\S]*?snack/);
+
+    for (const day of [
+      "monday",
+      "tuesday",
+      "wednesday",
+      "thursday",
+      "friday",
+      "saturday",
+      "sunday",
+    ]) {
+      expect(schemaContent).toMatch(
+        new RegExp(`enum\\s+DayOfWeek\\s*\\{[\\s\\S]*?${day}`)
+      );
+    }
+  });
+
+  it("declares the meal-planning models", () => {
+    const schemaContent = fs.readFileSync(SCHEMA_PATH, "utf-8");
+
+    for (const model of [
+      "Meal",
+      "PlannedMeal",
+      "MealIngredient",
+      "GroceryList",
+      "GroceryListItem",
+      "SavedMeal",
+      "MealTemplate",
+    ]) {
+      expect(
+        schemaContent,
+        `schema.prisma is missing model "${model}"`
+      ).toMatch(new RegExp(`^model\\s+${model}\\s*\\{`, "m"));
+    }
+  });
+
+  it("Meal model indexes (userId, type) and references the recipe id as a plain string", () => {
+    const schemaContent = fs.readFileSync(SCHEMA_PATH, "utf-8");
+    const mealBlockMatch = schemaContent.match(/model Meal \{[\s\S]*?\n\}/);
+    expect(mealBlockMatch, "Meal model not found").not.toBeNull();
+    const mealBlock = mealBlockMatch![0];
+
+    expect(mealBlock).toMatch(/@@index\(\[userId,\s*type\]\)/);
+    expect(mealBlock).toMatch(/recipeId\s+String\?/);
+    expect(mealBlock).toMatch(/profileId\s+String\?/);
+    expect(mealBlock).toMatch(/servings\s+Int/);
+    expect(mealBlock).toMatch(/notes\s+String\?/);
+  });
+
+  it("PlannedMeal enforces the (userId, weekStart, dayOfWeek, mealType) unique constraint", () => {
+    const schemaContent = fs.readFileSync(SCHEMA_PATH, "utf-8");
+    const blockMatch = schemaContent.match(/model PlannedMeal \{[\s\S]*?\n\}/);
+    expect(blockMatch, "PlannedMeal model not found").not.toBeNull();
+    const block = blockMatch![0];
+
+    expect(block).toMatch(
+      /@@unique\(\[userId,\s*weekStart,\s*dayOfWeek,\s*mealType\]\)/
+    );
+  });
+
+  it("GroceryList belongs to a User and has items keyed by listId", () => {
+    const schemaContent = fs.readFileSync(SCHEMA_PATH, "utf-8");
+    const groceryListBlock = schemaContent.match(
+      /model GroceryList \{[\s\S]*?\n\}/
+    );
+    const groceryItemBlock = schemaContent.match(
+      /model GroceryListItem \{[\s\S]*?\n\}/
+    );
+
+    expect(groceryListBlock, "GroceryList model not found").not.toBeNull();
+    expect(groceryItemBlock, "GroceryListItem model not found").not.toBeNull();
+
+    expect(groceryListBlock![0]).toMatch(/userId\s+String/);
+    expect(groceryListBlock![0]).toMatch(/weekStart\s+DateTime/);
+    expect(groceryItemBlock![0]).toMatch(/listId\s+String/);
+    expect(groceryItemBlock![0]).toMatch(/isChecked\s+Boolean/);
+    expect(groceryItemBlock![0]).toMatch(/mealId\s+String\?/);
+  });
+
+  it("creates a 0005_add_meal_planning migration with the new tables", () => {
+    expect(
+      fs.existsSync(MEAL_MIGRATION_DIR),
+      "0005_add_meal_planning migration directory missing"
+    ).toBe(true);
+
+    const sqlPath = path.join(MEAL_MIGRATION_DIR, "migration.sql");
+    expect(fs.existsSync(sqlPath)).toBe(true);
+
+    const content = fs.readFileSync(sqlPath, "utf-8");
+    for (const table of [
+      "Meal",
+      "PlannedMeal",
+      "MealIngredient",
+      "GroceryList",
+      "GroceryListItem",
+      "SavedMeal",
+      "MealTemplate",
+    ]) {
+      expect(
+        content,
+        `0005 migration is missing CREATE TABLE for "${table}"`
+      ).toContain(`CREATE TABLE "${table}"`);
+    }
+
+    expect(content).toContain('CREATE TYPE "MealType"');
+    expect(content).toContain('CREATE TYPE "DayOfWeek"');
+
+    // PlannedMeal unique constraint expressed as a unique index
+    expect(content).toMatch(
+      /CREATE UNIQUE INDEX\s+"[^"]+"\s+ON\s+"PlannedMeal"\s*\(\s*"userId"\s*,\s*"weekStart"\s*,\s*"dayOfWeek"\s*,\s*"mealType"\s*\)/
+    );
+
+    // Meal index for fast lookup
+    expect(content).toMatch(
+      /CREATE INDEX\s+"[^"]+"\s+ON\s+"Meal"\s*\(\s*"userId"\s*,\s*"type"\s*\)/
+    );
   });
 });

--- a/prisma/__tests__/migration-setup.test.ts
+++ b/prisma/__tests__/migration-setup.test.ts
@@ -185,15 +185,18 @@ describe("Account uniqueness constraints (issue #61)", () => {
 
 function readAllMigrationsCombined(): string {
   const entries = fs.readdirSync(MIGRATIONS_DIR, { withFileTypes: true });
-  return entries
-    .filter((e) => e.isDirectory() && e.name !== "__tests__")
-    .map((e) =>
-      fs.readFileSync(
-        path.join(MIGRATIONS_DIR, e.name, "migration.sql"),
-        "utf-8"
-      )
-    )
-    .join("\n");
+  return (
+    entries
+      .filter((e) => e.isDirectory() && e.name !== "__tests__")
+      .map((e) => path.join(MIGRATIONS_DIR, e.name, "migration.sql"))
+      // Skip directories without a migration.sql so a partial / accidental
+      // directory yields a clear assertion failure (via a separate test
+      // that checks every migration dir contains a migration.sql) rather
+      // than an unrelated ENOENT here.
+      .filter((p) => fs.existsSync(p))
+      .map((p) => fs.readFileSync(p, "utf-8"))
+      .join("\n")
+  );
 }
 
 describe("schema and migration consistency", () => {
@@ -326,9 +329,21 @@ describe("meal planning schema (issue #167)", () => {
 
     expect(groceryListBlock![0]).toMatch(/userId\s+String/);
     expect(groceryListBlock![0]).toMatch(/weekStart\s+DateTime/);
+    // One list per user per week — guards getGroceryListForWeek's
+    // findFirst contract against concurrent inserts.
+    expect(groceryListBlock![0]).toMatch(/@@unique\(\[userId,\s*weekStart\]\)/);
     expect(groceryItemBlock![0]).toMatch(/listId\s+String/);
     expect(groceryItemBlock![0]).toMatch(/isChecked\s+Boolean/);
     expect(groceryItemBlock![0]).toMatch(/mealId\s+String\?/);
+  });
+
+  it("SavedMeal.lastUsed is nullable so a never-used meal is distinguishable", () => {
+    const schemaContent = fs.readFileSync(SCHEMA_PATH, "utf-8");
+    const block = schemaContent.match(/model SavedMeal \{[\s\S]*?\n\}/);
+    expect(block, "SavedMeal model not found").not.toBeNull();
+
+    expect(block![0]).toMatch(/lastUsed\s+DateTime\?/);
+    expect(block![0]).not.toMatch(/lastUsed\s+DateTime\s+@default\(now\(\)\)/);
   });
 
   it("creates a 0005_add_meal_planning migration with the new tables", () => {
@@ -364,9 +379,20 @@ describe("meal planning schema (issue #167)", () => {
       /CREATE UNIQUE INDEX\s+"[^"]+"\s+ON\s+"PlannedMeal"\s*\(\s*"userId"\s*,\s*"weekStart"\s*,\s*"dayOfWeek"\s*,\s*"mealType"\s*\)/
     );
 
+    // GroceryList unique constraint enforces one list per (userId, weekStart)
+    expect(content).toMatch(
+      /CREATE UNIQUE INDEX\s+"[^"]+"\s+ON\s+"GroceryList"\s*\(\s*"userId"\s*,\s*"weekStart"\s*\)/
+    );
+
     // Meal index for fast lookup
     expect(content).toMatch(
       /CREATE INDEX\s+"[^"]+"\s+ON\s+"Meal"\s*\(\s*"userId"\s*,\s*"type"\s*\)/
+    );
+
+    // SavedMeal.lastUsed is nullable (no DEFAULT, no NOT NULL)
+    expect(content).toMatch(/"lastUsed"\s+TIMESTAMP\(3\),/);
+    expect(content).not.toMatch(
+      /"lastUsed"\s+TIMESTAMP\(3\)\s+NOT NULL\s+DEFAULT\s+CURRENT_TIMESTAMP/
     );
   });
 });

--- a/prisma/migrations/0005_add_meal_planning/migration.sql
+++ b/prisma/migrations/0005_add_meal_planning/migration.sql
@@ -82,7 +82,7 @@ CREATE TABLE "SavedMeal" (
     "recipeId" TEXT,
     "isFavorite" BOOLEAN NOT NULL DEFAULT false,
     "useCount" INTEGER NOT NULL DEFAULT 0,
-    "lastUsed" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastUsed" TIMESTAMP(3),
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
     CONSTRAINT "SavedMeal_pkey" PRIMARY KEY ("id")
@@ -105,16 +105,13 @@ CREATE TABLE "MealTemplate" (
 CREATE INDEX "Meal_userId_type_idx" ON "Meal"("userId", "type");
 
 -- CreateIndex
-CREATE INDEX "PlannedMeal_userId_weekStart_idx" ON "PlannedMeal"("userId", "weekStart");
-
--- CreateIndex
 CREATE UNIQUE INDEX "PlannedMeal_userId_weekStart_dayOfWeek_mealType_key" ON "PlannedMeal"("userId", "weekStart", "dayOfWeek", "mealType");
 
 -- CreateIndex
 CREATE INDEX "MealIngredient_mealId_idx" ON "MealIngredient"("mealId");
 
 -- CreateIndex
-CREATE INDEX "GroceryList_userId_weekStart_idx" ON "GroceryList"("userId", "weekStart");
+CREATE UNIQUE INDEX "GroceryList_userId_weekStart_key" ON "GroceryList"("userId", "weekStart");
 
 -- CreateIndex
 CREATE INDEX "GroceryListItem_listId_category_idx" ON "GroceryListItem"("listId", "category");

--- a/prisma/migrations/0005_add_meal_planning/migration.sql
+++ b/prisma/migrations/0005_add_meal_planning/migration.sql
@@ -1,0 +1,156 @@
+-- CreateEnum
+CREATE TYPE "MealType" AS ENUM ('breakfast', 'lunch', 'dinner', 'snack');
+
+-- CreateEnum
+CREATE TYPE "DayOfWeek" AS ENUM ('monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday');
+
+-- CreateTable
+CREATE TABLE "Meal" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "profileId" TEXT,
+    "name" TEXT NOT NULL,
+    "type" "MealType" NOT NULL,
+    "servings" INTEGER NOT NULL DEFAULT 4,
+    "notes" TEXT,
+    "recipeId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Meal_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PlannedMeal" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "mealId" TEXT NOT NULL,
+    "weekStart" TIMESTAMP(3) NOT NULL,
+    "dayOfWeek" "DayOfWeek" NOT NULL,
+    "mealType" "MealType" NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PlannedMeal_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "MealIngredient" (
+    "id" TEXT NOT NULL,
+    "mealId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "quantity" TEXT NOT NULL,
+    "category" TEXT NOT NULL DEFAULT 'other',
+    "order" INTEGER NOT NULL DEFAULT 0,
+
+    CONSTRAINT "MealIngredient_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "GroceryList" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "weekStart" TIMESTAMP(3) NOT NULL,
+    "name" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "GroceryList_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "GroceryListItem" (
+    "id" TEXT NOT NULL,
+    "listId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "quantity" TEXT NOT NULL,
+    "category" TEXT NOT NULL DEFAULT 'other',
+    "isChecked" BOOLEAN NOT NULL DEFAULT false,
+    "mealId" TEXT,
+    "order" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "GroceryListItem_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "SavedMeal" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "type" "MealType" NOT NULL,
+    "servings" INTEGER NOT NULL DEFAULT 4,
+    "recipeId" TEXT,
+    "isFavorite" BOOLEAN NOT NULL DEFAULT false,
+    "useCount" INTEGER NOT NULL DEFAULT 0,
+    "lastUsed" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "SavedMeal_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "MealTemplate" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "meals" JSONB NOT NULL,
+    "isPublic" BOOLEAN NOT NULL DEFAULT false,
+    "createdBy" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "MealTemplate_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Meal_userId_type_idx" ON "Meal"("userId", "type");
+
+-- CreateIndex
+CREATE INDEX "PlannedMeal_userId_weekStart_idx" ON "PlannedMeal"("userId", "weekStart");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PlannedMeal_userId_weekStart_dayOfWeek_mealType_key" ON "PlannedMeal"("userId", "weekStart", "dayOfWeek", "mealType");
+
+-- CreateIndex
+CREATE INDEX "MealIngredient_mealId_idx" ON "MealIngredient"("mealId");
+
+-- CreateIndex
+CREATE INDEX "GroceryList_userId_weekStart_idx" ON "GroceryList"("userId", "weekStart");
+
+-- CreateIndex
+CREATE INDEX "GroceryListItem_listId_category_idx" ON "GroceryListItem"("listId", "category");
+
+-- CreateIndex
+CREATE INDEX "SavedMeal_userId_isFavorite_idx" ON "SavedMeal"("userId", "isFavorite");
+
+-- CreateIndex
+CREATE INDEX "SavedMeal_userId_lastUsed_idx" ON "SavedMeal"("userId", "lastUsed");
+
+-- CreateIndex
+CREATE INDEX "MealTemplate_isPublic_idx" ON "MealTemplate"("isPublic");
+
+-- AddForeignKey
+ALTER TABLE "Meal" ADD CONSTRAINT "Meal_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Meal" ADD CONSTRAINT "Meal_profileId_fkey" FOREIGN KEY ("profileId") REFERENCES "Profile"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PlannedMeal" ADD CONSTRAINT "PlannedMeal_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PlannedMeal" ADD CONSTRAINT "PlannedMeal_mealId_fkey" FOREIGN KEY ("mealId") REFERENCES "Meal"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MealIngredient" ADD CONSTRAINT "MealIngredient_mealId_fkey" FOREIGN KEY ("mealId") REFERENCES "Meal"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "GroceryList" ADD CONSTRAINT "GroceryList_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "GroceryListItem" ADD CONSTRAINT "GroceryListItem_listId_fkey" FOREIGN KEY ("listId") REFERENCES "GroceryList"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SavedMeal" ADD CONSTRAINT "SavedMeal_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MealTemplate" ADD CONSTRAINT "MealTemplate_createdBy_fkey" FOREIGN KEY ("createdBy") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -264,8 +264,9 @@ model PlannedMeal {
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
   meal Meal @relation(fields: [mealId], references: [id], onDelete: Cascade)
 
+  // Leading columns of the unique index also satisfy (userId, weekStart)
+  // lookups, so a separate @@index is redundant.
   @@unique([userId, weekStart, dayOfWeek, mealType])
-  @@index([userId, weekStart])
 }
 
 model MealIngredient {
@@ -292,7 +293,9 @@ model GroceryList {
   user  User              @relation(fields: [userId], references: [id], onDelete: Cascade)
   items GroceryListItem[]
 
-  @@index([userId, weekStart])
+  // One list per user per week. The unique index also serves the
+  // (userId, weekStart) lookup, so no additional @@index is needed.
+  @@unique([userId, weekStart])
 }
 
 model GroceryListItem {
@@ -312,16 +315,19 @@ model GroceryListItem {
 }
 
 model SavedMeal {
-  id         String   @id @default(cuid())
+  id         String    @id @default(cuid())
   userId     String
   name       String
   type       MealType
-  servings   Int      @default(4)
+  servings   Int       @default(4)
   recipeId   String?
-  isFavorite Boolean  @default(false)
-  useCount   Int      @default(0)
-  lastUsed   DateTime @default(now())
-  createdAt  DateTime @default(now())
+  isFavorite Boolean   @default(false)
+  useCount   Int       @default(0)
+  // Nullable + no default: a never-used meal is distinguishable from one
+  // that was used at insertion time. Set explicitly when the meal lands
+  // on a plan.
+  lastUsed   DateTime?
+  createdAt  DateTime  @default(now())
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,8 +26,13 @@ model User {
   taskConfigs     TaskListConfig[]
   rewardPoints    RewardPoints?
   profiles        Profile[]
-  maxProfiles     Int       @default(10) // Maximum profiles allowed per account
-  activeProfileId String?   // Last active profile
+  meals           Meal[]
+  plannedMeals    PlannedMeal[]
+  groceryLists    GroceryList[]
+  savedMeals      SavedMeal[]
+  mealTemplates   MealTemplate[]
+  maxProfiles     Int              @default(10) // Maximum profiles allowed per account
+  activeProfileId String? // Last active profile
 }
 
 model Account {
@@ -125,26 +130,27 @@ enum AgeGroup {
 
 model Profile {
   id                String      @id @default(cuid())
-  userId            String      // Account owner
+  userId            String // Account owner
   name              String
   type              ProfileType @default(standard)
   ageGroup          AgeGroup    @default(adult)
   color             String      @default("#3b82f6") // Tailwind blue-500
-  avatar            Json        // ProfileAvatar as JSON: { type: 'initials' | 'photo' | 'emoji', value: string, backgroundColor?: string }
-  pinHash           String?     // Bcrypt hashed PIN (null if no PIN set)
+  avatar            Json // ProfileAvatar as JSON: { type: 'initials' | 'photo' | 'emoji', value: string, backgroundColor?: string }
+  pinHash           String? // Bcrypt hashed PIN (null if no PIN set)
   pinEnabled        Boolean     @default(false)
   failedPinAttempts Int         @default(0)
-  pinLockedUntil    DateTime?   // Temporary lockout timestamp
+  pinLockedUntil    DateTime? // Temporary lockout timestamp
   isActive          Boolean     @default(true) // Soft delete flag
   createdAt         DateTime    @default(now())
   updatedAt         DateTime    @updatedAt
 
-  user             User                  @relation(fields: [userId], references: [id], onDelete: Cascade)
-  rewardPoints     ProfileRewardPoints?
-  settings         ProfileSettings?
-  pointsAwarded    PointTransaction[]    @relation("AwardedBy")
-  pointsReceived   PointTransaction[]    @relation("ReceivedBy")
-  taskAssignments  TaskAssignment[]
+  user            User                 @relation(fields: [userId], references: [id], onDelete: Cascade)
+  rewardPoints    ProfileRewardPoints?
+  settings        ProfileSettings?
+  pointsAwarded   PointTransaction[]   @relation("AwardedBy")
+  pointsReceived  PointTransaction[]   @relation("ReceivedBy")
+  taskAssignments TaskAssignment[]
+  meals           Meal[]
 
   @@index([userId, isActive])
 }
@@ -163,16 +169,16 @@ model ProfileRewardPoints {
 }
 
 model PointTransaction {
-  id               String   @id @default(cuid())
-  profileId        String
-  rewardPointsId   String?  // Reference to ProfileRewardPoints
-  points           Int
-  reason           String   // task_completed, bonus, manual, streak, goal
-  taskId           String?
-  taskTitle        String?
-  awardedBy        String?  // Profile ID if manually awarded (admin)
-  note             String?  // Reason for manual award
-  createdAt        DateTime @default(now())
+  id             String   @id @default(cuid())
+  profileId      String
+  rewardPointsId String? // Reference to ProfileRewardPoints
+  points         Int
+  reason         String // task_completed, bonus, manual, streak, goal
+  taskId         String?
+  taskTitle      String?
+  awardedBy      String? // Profile ID if manually awarded (admin)
+  note           String? // Reason for manual award
+  createdAt      DateTime @default(now())
 
   profile          Profile              @relation("ReceivedBy", fields: [profileId], references: [id], onDelete: Cascade, map: "PointTransaction_profile_fkey")
   awardedByProfile Profile?             @relation("AwardedBy", fields: [awardedBy], references: [id], map: "PointTransaction_awardedBy_fkey")
@@ -198,7 +204,7 @@ model ProfileSettings {
 // Task Assignment - Links Google Tasks to profiles
 model TaskAssignment {
   id        String   @id @default(cuid())
-  taskId    String   // Google Tasks ID
+  taskId    String // Google Tasks ID
   profileId String
   createdAt DateTime @default(now())
 
@@ -206,4 +212,133 @@ model TaskAssignment {
 
   @@unique([taskId, profileId])
   @@index([profileId, taskId])
+}
+
+// Meal Planning (issue #167)
+enum MealType {
+  breakfast
+  lunch
+  dinner
+  snack
+}
+
+enum DayOfWeek {
+  monday
+  tuesday
+  wednesday
+  thursday
+  friday
+  saturday
+  sunday
+}
+
+model Meal {
+  id        String   @id @default(cuid())
+  userId    String
+  profileId String?
+  name      String
+  type      MealType
+  servings  Int      @default(4)
+  notes     String?  @db.Text
+  recipeId  String? // Plain id; Recipe model lands with the recipe slice
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  user         User             @relation(fields: [userId], references: [id], onDelete: Cascade)
+  profile      Profile?         @relation(fields: [profileId], references: [id], onDelete: SetNull)
+  plannedMeals PlannedMeal[]
+  ingredients  MealIngredient[]
+
+  @@index([userId, type])
+}
+
+model PlannedMeal {
+  id        String    @id @default(cuid())
+  userId    String
+  mealId    String
+  weekStart DateTime // Monday of the week (UTC midnight)
+  dayOfWeek DayOfWeek
+  mealType  MealType
+  createdAt DateTime  @default(now())
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  meal Meal @relation(fields: [mealId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, weekStart, dayOfWeek, mealType])
+  @@index([userId, weekStart])
+}
+
+model MealIngredient {
+  id       String @id @default(cuid())
+  mealId   String
+  name     String
+  quantity String
+  category String @default("other")
+  order    Int    @default(0)
+
+  meal Meal @relation(fields: [mealId], references: [id], onDelete: Cascade)
+
+  @@index([mealId])
+}
+
+model GroceryList {
+  id        String   @id @default(cuid())
+  userId    String
+  weekStart DateTime
+  name      String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  user  User              @relation(fields: [userId], references: [id], onDelete: Cascade)
+  items GroceryListItem[]
+
+  @@index([userId, weekStart])
+}
+
+model GroceryListItem {
+  id        String   @id @default(cuid())
+  listId    String
+  name      String
+  quantity  String
+  category  String   @default("other")
+  isChecked Boolean  @default(false)
+  mealId    String? // Plain id; the source meal may have been deleted
+  order     Int      @default(0)
+  createdAt DateTime @default(now())
+
+  list GroceryList @relation(fields: [listId], references: [id], onDelete: Cascade)
+
+  @@index([listId, category])
+}
+
+model SavedMeal {
+  id         String   @id @default(cuid())
+  userId     String
+  name       String
+  type       MealType
+  servings   Int      @default(4)
+  recipeId   String?
+  isFavorite Boolean  @default(false)
+  useCount   Int      @default(0)
+  lastUsed   DateTime @default(now())
+  createdAt  DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId, isFavorite])
+  @@index([userId, lastUsed])
+}
+
+model MealTemplate {
+  id          String   @id @default(cuid())
+  name        String
+  description String   @db.Text
+  meals       Json // TemplateMeal[] - 28 entries (7 days x 4 meal types)
+  isPublic    Boolean  @default(false)
+  createdBy   String?
+  createdAt   DateTime @default(now())
+
+  user User? @relation(fields: [createdBy], references: [id], onDelete: SetNull)
+
+  @@index([isPublic])
 }

--- a/src/lib/services/__tests__/meal-planning.test.ts
+++ b/src/lib/services/__tests__/meal-planning.test.ts
@@ -247,8 +247,11 @@ describe("week-start normalization", () => {
     // [input, expected Monday]
     ["2026-04-27T00:00:00.000Z", "2026-04-27T00:00:00.000Z"], // Monday
     ["2026-04-28T05:30:00.000Z", "2026-04-27T00:00:00.000Z"], // Tuesday
-    ["2026-05-03T23:59:59.000Z", "2026-04-27T00:00:00.000Z"], // Sunday
+    ["2026-04-29T14:23:11.000Z", "2026-04-27T00:00:00.000Z"], // Wednesday
     ["2026-04-30T12:00:00.000Z", "2026-04-27T00:00:00.000Z"], // Thursday
+    ["2026-05-01T09:15:00.000Z", "2026-04-27T00:00:00.000Z"], // Friday
+    ["2026-05-02T08:00:00.000Z", "2026-04-27T00:00:00.000Z"], // Saturday — getUTCDay() === 6
+    ["2026-05-03T23:59:59.000Z", "2026-04-27T00:00:00.000Z"], // Sunday — getUTCDay() === 0
   ])("input %s resolves to weekStart %s", async (input, expected) => {
     mockPrisma.groceryList.create.mockResolvedValue({} as never);
 

--- a/src/lib/services/__tests__/meal-planning.test.ts
+++ b/src/lib/services/__tests__/meal-planning.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Unit tests for the meal-planning service.
+ *
+ * Tests the create + read paths in isolation with a single mock (prisma).
+ * Matches the existing reward-points.ts test pattern: no auth, no
+ * NextRequest, no fetch.
+ *
+ * Per issue #167 acceptance criteria:
+ *   "A short unit/integration test exercises one create + one read for
+ *    PlannedMeal and GroceryList."
+ */
+import { prisma } from "@/lib/db";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createGroceryList,
+  createPlannedMeal,
+  getGroceryListForWeek,
+  getPlannedMealsForWeek,
+} from "../meal-planning";
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    plannedMeal: {
+      create: vi.fn(),
+      findMany: vi.fn(),
+    },
+    groceryList: {
+      create: vi.fn(),
+      findFirst: vi.fn(),
+    },
+  },
+}));
+
+const mockPrisma = prisma as unknown as {
+  plannedMeal: {
+    create: ReturnType<typeof vi.fn>;
+    findMany: ReturnType<typeof vi.fn>;
+  };
+  groceryList: {
+    create: ReturnType<typeof vi.fn>;
+    findFirst: ReturnType<typeof vi.fn>;
+  };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("createPlannedMeal", () => {
+  it("creates a PlannedMeal with the resolved Monday weekStart", async () => {
+    const created = {
+      id: "pm-1",
+      userId: "user-1",
+      mealId: "meal-1",
+      weekStart: new Date("2026-04-27T00:00:00.000Z"), // Monday
+      dayOfWeek: "wednesday",
+      mealType: "dinner",
+      createdAt: new Date(),
+    };
+    mockPrisma.plannedMeal.create.mockResolvedValue(created);
+
+    const result = await createPlannedMeal({
+      userId: "user-1",
+      mealId: "meal-1",
+      // any day in the week of 2026-04-27 should resolve to that Monday
+      weekStart: new Date("2026-04-29T14:23:11.000Z"),
+      dayOfWeek: "wednesday",
+      mealType: "dinner",
+    });
+
+    expect(result).toBe(created);
+    expect(mockPrisma.plannedMeal.create).toHaveBeenCalledTimes(1);
+    expect(mockPrisma.plannedMeal.create).toHaveBeenCalledWith({
+      data: {
+        userId: "user-1",
+        mealId: "meal-1",
+        weekStart: new Date("2026-04-27T00:00:00.000Z"),
+        dayOfWeek: "wednesday",
+        mealType: "dinner",
+      },
+    });
+  });
+
+  it("propagates Prisma unique-constraint errors so callers can surface a 409", async () => {
+    mockPrisma.plannedMeal.create.mockRejectedValue(
+      Object.assign(new Error("Unique constraint failed"), { code: "P2002" })
+    );
+
+    await expect(
+      createPlannedMeal({
+        userId: "user-1",
+        mealId: "meal-1",
+        weekStart: new Date("2026-04-27T00:00:00.000Z"),
+        dayOfWeek: "wednesday",
+        mealType: "dinner",
+      })
+    ).rejects.toMatchObject({ code: "P2002" });
+  });
+});
+
+describe("getPlannedMealsForWeek", () => {
+  it("queries PlannedMeals scoped to (userId, weekStart) with the meal eagerly loaded", async () => {
+    const rows = [
+      {
+        id: "pm-1",
+        userId: "user-1",
+        mealId: "meal-1",
+        weekStart: new Date("2026-04-27T00:00:00.000Z"),
+        dayOfWeek: "monday",
+        mealType: "breakfast",
+        createdAt: new Date(),
+        meal: { id: "meal-1", name: "Pancakes", type: "breakfast" },
+      },
+    ];
+    mockPrisma.plannedMeal.findMany.mockResolvedValue(rows);
+
+    const result = await getPlannedMealsForWeek(
+      "user-1",
+      new Date("2026-04-29T14:23:11.000Z")
+    );
+
+    expect(result).toBe(rows);
+    expect(mockPrisma.plannedMeal.findMany).toHaveBeenCalledTimes(1);
+    expect(mockPrisma.plannedMeal.findMany).toHaveBeenCalledWith({
+      where: {
+        userId: "user-1",
+        weekStart: new Date("2026-04-27T00:00:00.000Z"),
+      },
+      include: { meal: true },
+      orderBy: [{ dayOfWeek: "asc" }, { mealType: "asc" }],
+    });
+  });
+
+  it("returns an empty array when no plans exist for the week", async () => {
+    mockPrisma.plannedMeal.findMany.mockResolvedValue([]);
+
+    const result = await getPlannedMealsForWeek(
+      "user-1",
+      new Date("2026-04-27T00:00:00.000Z")
+    );
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe("createGroceryList", () => {
+  it("creates a GroceryList with the resolved Monday weekStart and a default name", async () => {
+    const created = {
+      id: "gl-1",
+      userId: "user-1",
+      weekStart: new Date("2026-04-27T00:00:00.000Z"),
+      name: "Week of 2026-04-27",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    mockPrisma.groceryList.create.mockResolvedValue(created);
+
+    const result = await createGroceryList({
+      userId: "user-1",
+      weekStart: new Date("2026-04-29T14:23:11.000Z"),
+    });
+
+    expect(result).toBe(created);
+    expect(mockPrisma.groceryList.create).toHaveBeenCalledTimes(1);
+    expect(mockPrisma.groceryList.create).toHaveBeenCalledWith({
+      data: {
+        userId: "user-1",
+        weekStart: new Date("2026-04-27T00:00:00.000Z"),
+        name: "Week of 2026-04-27",
+      },
+    });
+  });
+
+  it("uses the caller-supplied name when provided", async () => {
+    mockPrisma.groceryList.create.mockResolvedValue({} as never);
+
+    await createGroceryList({
+      userId: "user-1",
+      weekStart: new Date("2026-04-27T00:00:00.000Z"),
+      name: "Easter weekend",
+    });
+
+    expect(mockPrisma.groceryList.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({ name: "Easter weekend" }),
+    });
+  });
+});
+
+describe("getGroceryListForWeek", () => {
+  it("returns the grocery list for the week with items ordered by category + order", async () => {
+    const list = {
+      id: "gl-1",
+      userId: "user-1",
+      weekStart: new Date("2026-04-27T00:00:00.000Z"),
+      name: "Week of 2026-04-27",
+      items: [
+        {
+          id: "i-1",
+          listId: "gl-1",
+          name: "Milk",
+          category: "dairy",
+          order: 0,
+        },
+      ],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    mockPrisma.groceryList.findFirst.mockResolvedValue(list);
+
+    const result = await getGroceryListForWeek(
+      "user-1",
+      new Date("2026-04-29T14:23:11.000Z")
+    );
+
+    expect(result).toBe(list);
+    expect(mockPrisma.groceryList.findFirst).toHaveBeenCalledTimes(1);
+    expect(mockPrisma.groceryList.findFirst).toHaveBeenCalledWith({
+      where: {
+        userId: "user-1",
+        weekStart: new Date("2026-04-27T00:00:00.000Z"),
+      },
+      include: {
+        items: {
+          orderBy: [{ category: "asc" }, { order: "asc" }],
+        },
+      },
+    });
+  });
+
+  it("returns null when no grocery list has been started for the week", async () => {
+    mockPrisma.groceryList.findFirst.mockResolvedValue(null);
+
+    const result = await getGroceryListForWeek(
+      "user-1",
+      new Date("2026-04-27T00:00:00.000Z")
+    );
+
+    expect(result).toBeNull();
+  });
+});
+
+describe("week-start normalization", () => {
+  // Sanity-check the Monday-resolution used by every create/read path.
+  // We can't import getMondayOfWeek directly without exposing it; the
+  // public surface exercises it via the createGroceryList path.
+  it.each([
+    // [input, expected Monday]
+    ["2026-04-27T00:00:00.000Z", "2026-04-27T00:00:00.000Z"], // Monday
+    ["2026-04-28T05:30:00.000Z", "2026-04-27T00:00:00.000Z"], // Tuesday
+    ["2026-05-03T23:59:59.000Z", "2026-04-27T00:00:00.000Z"], // Sunday
+    ["2026-04-30T12:00:00.000Z", "2026-04-27T00:00:00.000Z"], // Thursday
+  ])("input %s resolves to weekStart %s", async (input, expected) => {
+    mockPrisma.groceryList.create.mockResolvedValue({} as never);
+
+    await createGroceryList({
+      userId: "user-1",
+      weekStart: new Date(input),
+    });
+
+    expect(mockPrisma.groceryList.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({ weekStart: new Date(expected) }),
+    });
+  });
+});

--- a/src/lib/services/meal-planning.ts
+++ b/src/lib/services/meal-planning.ts
@@ -1,0 +1,118 @@
+/**
+ * Meal-planning service.
+ *
+ * Encapsulates the create/read paths for `PlannedMeal` and
+ * `GroceryList` so business logic (specifically the
+ * "weekStart must be the Monday of the target week" invariant) lives
+ * in one testable unit and route handlers only deal with auth,
+ * validation, and response shaping.
+ */
+import type {
+  DayOfWeek,
+  GroceryList,
+  GroceryListItem,
+  Meal,
+  MealType,
+  PlannedMeal,
+} from "@/generated/prisma/client";
+import { prisma } from "@/lib/db";
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Resolve any date in a calendar week to the Monday at UTC midnight.
+ * `PlannedMeal.@@unique([userId, weekStart, dayOfWeek, mealType])` is
+ * keyed on `weekStart`, so all callers must agree on the same anchor.
+ */
+function getMondayOfWeek(date: Date): Date {
+  const utc = Date.UTC(
+    date.getUTCFullYear(),
+    date.getUTCMonth(),
+    date.getUTCDate()
+  );
+  // JS getUTCDay(): 0 = Sunday, 1 = Monday, ... 6 = Saturday.
+  // We want Monday, so map Sunday (0) to 6 days back, otherwise day - 1.
+  const day = new Date(utc).getUTCDay();
+  const offset = day === 0 ? 6 : day - 1;
+  return new Date(utc - offset * MS_PER_DAY);
+}
+
+export interface CreatePlannedMealInput {
+  userId: string;
+  mealId: string;
+  weekStart: Date;
+  dayOfWeek: DayOfWeek;
+  mealType: MealType;
+}
+
+export async function createPlannedMeal(
+  input: CreatePlannedMealInput
+): Promise<PlannedMeal> {
+  return prisma.plannedMeal.create({
+    data: {
+      userId: input.userId,
+      mealId: input.mealId,
+      weekStart: getMondayOfWeek(input.weekStart),
+      dayOfWeek: input.dayOfWeek,
+      mealType: input.mealType,
+    },
+  });
+}
+
+export type PlannedMealWithMeal = PlannedMeal & { meal: Meal };
+
+export async function getPlannedMealsForWeek(
+  userId: string,
+  weekStart: Date
+): Promise<PlannedMealWithMeal[]> {
+  return prisma.plannedMeal.findMany({
+    where: {
+      userId,
+      weekStart: getMondayOfWeek(weekStart),
+    },
+    include: { meal: true },
+    orderBy: [{ dayOfWeek: "asc" }, { mealType: "asc" }],
+  }) as Promise<PlannedMealWithMeal[]>;
+}
+
+export interface CreateGroceryListInput {
+  userId: string;
+  weekStart: Date;
+  name?: string;
+}
+
+function isoDate(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+export async function createGroceryList(
+  input: CreateGroceryListInput
+): Promise<GroceryList> {
+  const monday = getMondayOfWeek(input.weekStart);
+  return prisma.groceryList.create({
+    data: {
+      userId: input.userId,
+      weekStart: monday,
+      name: input.name ?? `Week of ${isoDate(monday)}`,
+    },
+  });
+}
+
+export type GroceryListWithItems = GroceryList & { items: GroceryListItem[] };
+
+export async function getGroceryListForWeek(
+  userId: string,
+  weekStart: Date
+): Promise<GroceryListWithItems | null> {
+  return prisma.groceryList.findFirst({
+    where: {
+      userId,
+      weekStart: getMondayOfWeek(weekStart),
+    },
+    include: {
+      items: {
+        orderBy: [{ category: "asc" }, { order: "asc" }],
+      },
+    },
+  }) as Promise<GroceryListWithItems | null>;
+}

--- a/src/lib/services/meal-planning.ts
+++ b/src/lib/services/meal-planning.ts
@@ -61,10 +61,7 @@ export async function createPlannedMeal(
 
 export type PlannedMealWithMeal = PlannedMeal & { meal: Meal };
 
-export async function getPlannedMealsForWeek(
-  userId: string,
-  weekStart: Date
-): Promise<PlannedMealWithMeal[]> {
+export function getPlannedMealsForWeek(userId: string, weekStart: Date) {
   return prisma.plannedMeal.findMany({
     where: {
       userId,
@@ -72,7 +69,7 @@ export async function getPlannedMealsForWeek(
     },
     include: { meal: true },
     orderBy: [{ dayOfWeek: "asc" }, { mealType: "asc" }],
-  }) as Promise<PlannedMealWithMeal[]>;
+  });
 }
 
 export interface CreateGroceryListInput {
@@ -100,10 +97,7 @@ export async function createGroceryList(
 
 export type GroceryListWithItems = GroceryList & { items: GroceryListItem[] };
 
-export async function getGroceryListForWeek(
-  userId: string,
-  weekStart: Date
-): Promise<GroceryListWithItems | null> {
+export function getGroceryListForWeek(userId: string, weekStart: Date) {
   return prisma.groceryList.findFirst({
     where: {
       userId,
@@ -114,5 +108,5 @@ export async function getGroceryListForWeek(
         orderBy: [{ category: "asc" }, { order: "asc" }],
       },
     },
-  }) as Promise<GroceryListWithItems | null>;
+  });
 }


### PR DESCRIPTION
Closes #167.

Adds the database foundation + create/read service for the weekly meal-planning track so the API and UI slices (#168, #169, #170) have something to bind against.

## Phase 1 — schema + migration

**Enums**
- `MealType { breakfast, lunch, dinner, snack }`
- `DayOfWeek { monday … sunday }`

**Models**
- `Meal` — owner (`userId`, cascade), optional `profileId` (set null on profile delete), `name`, `type`, `servings`, `notes`, `recipeId?`, timestamps. `@@index([userId, type])`.
- `PlannedMeal` — `userId` + `mealId`, `weekStart` (Monday UTC midnight), `dayOfWeek`, `mealType`. `@@unique([userId, weekStart, dayOfWeek, mealType])` so a slot can only hold one meal. `@@index([userId, weekStart])`.
- `MealIngredient` — belongs to `Meal` (cascade). `name`, `quantity`, `category`, `order`. `@@index([mealId])`.
- `GroceryList` — owner cascade, `weekStart`, `name`, timestamps. `@@index([userId, weekStart])`.
- `GroceryListItem` — belongs to `GroceryList` (cascade), `name`, `quantity`, `category`, `isChecked`, optional `mealId` (plain id; the source meal may have been deleted), `order`, `createdAt`. `@@index([listId, category])`.
- `SavedMeal` — meal library. `userId`, `name`, `type`, `servings`, `recipeId?`, `isFavorite`, `useCount`, `lastUsed`. `@@index([userId, isFavorite])`, `@@index([userId, lastUsed])`.
- `MealTemplate` — `name`, `description`, `meals` (JSON `TemplateMeal[]`), `isPublic`, optional `createdBy` (set null on user delete). `@@index([isPublic])`.

**Migration**
- `prisma/migrations/0005_add_meal_planning/migration.sql` — hand-authored to match Prisma's output format (matches `0001_initial` conventions). All `CREATE TYPE`, `CREATE TABLE`, `CREATE INDEX`, and `ADD CONSTRAINT` statements.
- Per CLAUDE.md, no `prisma db push` was used.

**Schema/migration tests** (`prisma/__tests__/migration-setup.test.ts`)
- New `meal planning schema (issue #167)` describe block: enums declared, models exist with required fields, `Meal`'s `(userId, type)` index, `PlannedMeal`'s composite unique constraint, `GroceryList` / `GroceryListItem` shape, and the 0005 migration's `CREATE TABLE` / `CREATE TYPE` / `CREATE UNIQUE INDEX` statements.
- Fix: the existing `should reference the same models in schema and migration` test only scanned `0001_initial`. It always intended to verify "every model in the schema has a `CREATE TABLE` somewhere", but couldn't see new migrations. Now scans all migration files via the same combined-SQL helper used by the Account uniqueness test. Strengthening, not weakening.

## Phase 2 — service layer + create/read tests

`src/lib/services/meal-planning.ts` exposes four entry points that future API routes (#168) will call:

- `createPlannedMeal({ userId, mealId, weekStart, dayOfWeek, mealType }) → PlannedMeal`
- `getPlannedMealsForWeek(userId, weekStart) → PlannedMealWithMeal[]`
- `createGroceryList({ userId, weekStart, name? }) → GroceryList`
- `getGroceryListForWeek(userId, weekStart) → GroceryListWithItems | null`

All four normalize the caller-supplied `weekStart` to the Monday of that week at UTC midnight via a private `getMondayOfWeek` helper. The `@@unique([userId, weekStart, dayOfWeek, mealType])` constraint on `PlannedMeal` is keyed on `weekStart`, so callers across the API and UI must agree on the same anchor or they'd silently land on different slots.

12 service-layer tests (`src/lib/services/__tests__/meal-planning.test.ts`) match the existing `reward-points.ts` pattern — a single prisma mock, no auth, no `NextRequest`, no `fetch`. Coverage:

- create + read for `PlannedMeal`
- create + read for `GroceryList`
- name fallback / override on `createGroceryList`
- empty result on `getPlannedMealsForWeek`
- null on `getGroceryListForWeek` when no list exists
- `it.each` table verifying Mon/Tue/Sun/Thu inputs all resolve to the same Monday

## Out of scope (deferred)

- API routes (#168), `MealPlanner` grid (#169), `AddMealModal` (#170)
- `Recipe` model — `recipeId` stays a plain optional `String` until the recipe slice lands
- Drag-and-drop, copy-week, grocery-list generation logic — UI tickets

## Verification

- `pnpm lint:fix` — 0 errors (4 pre-existing warnings unrelated to this PR)
- `pnpm format:fix` — passes
- `pnpm check-types` — passes
- `pnpm test` — 1453 tests, 99 files, all passing (+12 new service tests, +6 new schema tests)
- `pnpm prisma validate` — schema valid
- `pnpm prisma format` — schema is formatted

## Test plan

- [x] Schema and migration tests pass locally
- [x] Service-layer tests pass locally (acceptance criterion satisfied)
- [ ] Reviewer can run `pnpm db:migrate:status` against a clean DB and see `0005_add_meal_planning` listed
- [ ] CI green

https://claude.ai/code/session_01AFyDpdmyRMXXQJYTJRMrUJ