### PR TITLE
feat(rewards): API routes + PointsContext (#172)

### DIFF
--- a/prisma/migrations/0005_pointtransaction_unique_task_award/migration.sql
+++ b/prisma/migrations/0005_pointtransaction_unique_task_award/migration.sql
@@ -1,0 +1,7 @@
+-- Idempotent task-completion awards: prevent the same task from
+-- crediting the same profile more than once. PostgreSQL unique
+-- indexes treat NULLs as distinct by default, so this constraint
+-- does not affect manual / bonus / streak awards (which leave
+-- taskId NULL).
+CREATE UNIQUE INDEX "PointTransaction_profileId_taskId_reason_key"
+  ON "PointTransaction" ("profileId", "taskId", "reason");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -178,6 +178,7 @@ model PointTransaction {
   awardedByProfile Profile?             @relation("AwardedBy", fields: [awardedBy], references: [id], map: "PointTransaction_awardedBy_fkey")
   rewardPoints     ProfileRewardPoints? @relation(fields: [rewardPointsId], references: [id], onDelete: Cascade, map: "PointTransaction_rewardPoints_fkey")
 
+  @@unique([profileId, taskId, reason], map: "PointTransaction_profileId_taskId_reason_key")
   @@index([profileId, createdAt])
 }
 

--- a/src/app/api/points/__tests__/route.test.ts
+++ b/src/app/api/points/__tests__/route.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Integration tests for GET /api/points
+ *
+ * Returns the current profile's `totalPoints` together with the
+ * account-level `enabled` flag from `UserSettings`. When rewards are
+ * disabled the route always reports zero so disabled users never see
+ * stale point totals leaking through.
+ */
+import { getSession } from "@/lib/auth";
+import { mockSession } from "@/lib/auth/__tests__/fixtures";
+import { prisma } from "@/lib/db";
+import {
+  type ApiErrorResponse,
+  createMockRequest,
+  parseResponse,
+} from "@/lib/test-utils/api-test-helpers";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  mockAdminProfile,
+  mockStandardProfile,
+  mockUserId,
+} from "../../profiles/__tests__/fixtures";
+import { GET } from "../route";
+
+vi.mock("@/lib/auth", () => ({
+  getSession: vi.fn(),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    error: vi.fn(),
+    log: vi.fn(),
+    event: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    userSettings: {
+      findUnique: vi.fn(),
+    },
+    profile: {
+      findFirst: vi.fn(),
+    },
+    profileRewardPoints: {
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+const mockPrisma = prisma as unknown as {
+  userSettings: { findUnique: ReturnType<typeof vi.fn> };
+  profile: { findFirst: ReturnType<typeof vi.fn> };
+  profileRewardPoints: { findUnique: ReturnType<typeof vi.fn> };
+};
+
+interface PointsResponse {
+  totalPoints: number;
+  enabled: boolean;
+}
+
+describe("GET /api/points", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when no session", async () => {
+    vi.mocked(getSession).mockResolvedValue(null);
+
+    const request = createMockRequest(
+      `/api/points?profileId=${mockStandardProfile.id}`
+    );
+    const response = await GET(request);
+    const { status, data } = await parseResponse<ApiErrorResponse>(response);
+
+    expect(status).toBe(401);
+    expect(data.error).toBe("Unauthorized");
+  });
+
+  it("returns 400 when profileId query param is missing", async () => {
+    vi.mocked(getSession).mockResolvedValue(mockSession);
+
+    const request = createMockRequest("/api/points");
+    const response = await GET(request);
+    const { status, data } = await parseResponse<ApiErrorResponse>(response);
+
+    expect(status).toBe(400);
+    expect(data.error).toBe("profileId is required");
+  });
+
+  it("returns 404 when the profile does not belong to the user", async () => {
+    vi.mocked(getSession).mockResolvedValue(mockSession);
+    mockPrisma.profile.findFirst.mockResolvedValue(null);
+
+    const request = createMockRequest(
+      `/api/points?profileId=${mockStandardProfile.id}`
+    );
+    const response = await GET(request);
+    const { status, data } = await parseResponse<ApiErrorResponse>(response);
+
+    expect(status).toBe(404);
+    expect(data.error).toBe("Profile not found");
+    expect(mockPrisma.profile.findFirst).toHaveBeenCalledWith({
+      where: {
+        id: mockStandardProfile.id,
+        userId: mockUserId,
+        isActive: true,
+      },
+      select: { id: true },
+    });
+  });
+
+  it("returns zero points and enabled=false when rewards are disabled", async () => {
+    vi.mocked(getSession).mockResolvedValue(mockSession);
+    mockPrisma.profile.findFirst.mockResolvedValue({
+      id: mockStandardProfile.id,
+    });
+    mockPrisma.userSettings.findUnique.mockResolvedValue({
+      rewardSystemEnabled: false,
+    });
+
+    const request = createMockRequest(
+      `/api/points?profileId=${mockStandardProfile.id}`
+    );
+    const response = await GET(request);
+    const { status, data } = await parseResponse<PointsResponse>(response);
+
+    expect(status).toBe(200);
+    expect(data).toEqual({ totalPoints: 0, enabled: false });
+    expect(mockPrisma.profileRewardPoints.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("returns zero points and enabled=false when no UserSettings row exists", async () => {
+    vi.mocked(getSession).mockResolvedValue(mockSession);
+    mockPrisma.profile.findFirst.mockResolvedValue({
+      id: mockStandardProfile.id,
+    });
+    mockPrisma.userSettings.findUnique.mockResolvedValue(null);
+
+    const request = createMockRequest(
+      `/api/points?profileId=${mockStandardProfile.id}`
+    );
+    const response = await GET(request);
+    const { status, data } = await parseResponse<PointsResponse>(response);
+
+    expect(status).toBe(200);
+    expect(data).toEqual({ totalPoints: 0, enabled: false });
+  });
+
+  it("returns the profile's total points when rewards are enabled", async () => {
+    vi.mocked(getSession).mockResolvedValue(mockSession);
+    mockPrisma.profile.findFirst.mockResolvedValue({
+      id: mockStandardProfile.id,
+    });
+    mockPrisma.userSettings.findUnique.mockResolvedValue({
+      rewardSystemEnabled: true,
+    });
+    mockPrisma.profileRewardPoints.findUnique.mockResolvedValue({
+      totalPoints: 1250,
+    });
+
+    const request = createMockRequest(
+      `/api/points?profileId=${mockStandardProfile.id}`
+    );
+    const response = await GET(request);
+    const { status, data } = await parseResponse<PointsResponse>(response);
+
+    expect(status).toBe(200);
+    expect(data).toEqual({ totalPoints: 1250, enabled: true });
+    expect(mockPrisma.profileRewardPoints.findUnique).toHaveBeenCalledWith({
+      where: { profileId: mockStandardProfile.id },
+      select: { totalPoints: true },
+    });
+  });
+
+  it("returns zero points when rewards are enabled but no reward-points row exists", async () => {
+    vi.mocked(getSession).mockResolvedValue(mockSession);
+    mockPrisma.profile.findFirst.mockResolvedValue({
+      id: mockAdminProfile.id,
+    });
+    mockPrisma.userSettings.findUnique.mockResolvedValue({
+      rewardSystemEnabled: true,
+    });
+    mockPrisma.profileRewardPoints.findUnique.mockResolvedValue(null);
+
+    const request = createMockRequest(
+      `/api/points?profileId=${mockAdminProfile.id}`
+    );
+    const response = await GET(request);
+    const { status, data } = await parseResponse<PointsResponse>(response);
+
+    expect(status).toBe(200);
+    expect(data).toEqual({ totalPoints: 0, enabled: true });
+  });
+
+  it("returns 500 on unexpected errors", async () => {
+    vi.mocked(getSession).mockResolvedValue(mockSession);
+    mockPrisma.profile.findFirst.mockRejectedValue(new Error("db down"));
+
+    const request = createMockRequest(
+      `/api/points?profileId=${mockStandardProfile.id}`
+    );
+    const response = await GET(request);
+    const { status, data } = await parseResponse<ApiErrorResponse>(response);
+
+    expect(status).toBe(500);
+    expect(data.error).toBe("Failed to fetch points");
+  });
+});

--- a/src/app/api/points/award/__tests__/route.test.ts
+++ b/src/app/api/points/award/__tests__/route.test.ts
@@ -115,6 +115,44 @@ describe("POST /api/points/award", () => {
     expect(data.error).toBe("Invalid points value");
   });
 
+  it("returns 400 when points exceeds MAX_POINTS_PER_AWARD", async () => {
+    vi.mocked(getSession).mockResolvedValue(mockSession);
+
+    const request = createMockRequest("/api/points/award", {
+      method: "POST",
+      body: {
+        profileId: mockStandardProfile.id,
+        points: 10_001,
+        reason: "task_completed",
+        taskId: "task-abc",
+      },
+    });
+    const response = await POST(request);
+    const { status, data } = await parseResponse<ApiErrorResponse>(response);
+
+    expect(status).toBe(400);
+    expect(data.error).toBe("Invalid points value");
+  });
+
+  it("returns 400 when reason is task_completed but taskId is missing", async () => {
+    vi.mocked(getSession).mockResolvedValue(mockSession);
+
+    const request = createMockRequest("/api/points/award", {
+      method: "POST",
+      body: {
+        profileId: mockStandardProfile.id,
+        points: 10,
+        reason: "task_completed",
+      },
+    });
+    const response = await POST(request);
+    const { status, data } = await parseResponse<ApiErrorResponse>(response);
+
+    expect(status).toBe(400);
+    expect(data.error).toBe("taskId is required for task_completed awards");
+    expect(mockRecordPointAward).not.toHaveBeenCalled();
+  });
+
   it("returns 400 when points is not an integer", async () => {
     vi.mocked(getSession).mockResolvedValue(mockSession);
 
@@ -160,7 +198,7 @@ describe("POST /api/points/award", () => {
       body: {
         profileId: "someone-elses-profile",
         points: 10,
-        reason: "task_completed",
+        reason: "bonus",
       },
     });
     const response = await POST(request);
@@ -192,7 +230,7 @@ describe("POST /api/points/award", () => {
       body: {
         profileId: mockStandardProfile.id,
         points: 10,
-        reason: "task_completed",
+        reason: "bonus",
       },
     });
     const response = await POST(request);
@@ -215,7 +253,7 @@ describe("POST /api/points/award", () => {
       body: {
         profileId: mockStandardProfile.id,
         points: 10,
-        reason: "task_completed",
+        reason: "bonus",
       },
     });
     const response = await POST(request);
@@ -313,7 +351,7 @@ describe("POST /api/points/award", () => {
       body: {
         profileId: mockStandardProfile.id,
         points: 10,
-        reason: "task_completed",
+        reason: "bonus",
       },
     });
     const response = await POST(request);

--- a/src/app/api/points/award/__tests__/route.test.ts
+++ b/src/app/api/points/award/__tests__/route.test.ts
@@ -1,0 +1,325 @@
+/**
+ * Integration tests for POST /api/points/award
+ *
+ * Validates the request, checks rewards are enabled at the account
+ * level, then delegates the actual write to `recordPointAward`.
+ */
+import { getSession } from "@/lib/auth";
+import { mockSession } from "@/lib/auth/__tests__/fixtures";
+import { prisma } from "@/lib/db";
+import { recordPointAward } from "@/lib/services/reward-points";
+import {
+  type ApiErrorResponse,
+  createMockRequest,
+  parseResponse,
+} from "@/lib/test-utils/api-test-helpers";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  mockStandardProfile,
+  mockUserId,
+} from "../../../profiles/__tests__/fixtures";
+import { POST } from "../route";
+
+vi.mock("@/lib/auth", () => ({
+  getSession: vi.fn(),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    error: vi.fn(),
+    log: vi.fn(),
+    event: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    userSettings: {
+      findUnique: vi.fn(),
+    },
+    profile: {
+      findFirst: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/services/reward-points", () => ({
+  recordPointAward: vi.fn(),
+}));
+
+const mockPrisma = prisma as unknown as {
+  userSettings: { findUnique: ReturnType<typeof vi.fn> };
+  profile: { findFirst: ReturnType<typeof vi.fn> };
+};
+
+const mockRecordPointAward = vi.mocked(recordPointAward);
+
+interface AwardResponse {
+  success: boolean;
+  newTotal: number;
+  alreadyAwarded: boolean;
+}
+
+describe("POST /api/points/award", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when no session", async () => {
+    vi.mocked(getSession).mockResolvedValue(null);
+
+    const request = createMockRequest("/api/points/award", {
+      method: "POST",
+      body: {
+        profileId: mockStandardProfile.id,
+        points: 10,
+        reason: "task_completed",
+      },
+    });
+    const response = await POST(request);
+    const { status, data } = await parseResponse<ApiErrorResponse>(response);
+
+    expect(status).toBe(401);
+    expect(data.error).toBe("Unauthorized");
+  });
+
+  it("returns 400 when profileId is missing", async () => {
+    vi.mocked(getSession).mockResolvedValue(mockSession);
+
+    const request = createMockRequest("/api/points/award", {
+      method: "POST",
+      body: { points: 10, reason: "task_completed" },
+    });
+    const response = await POST(request);
+    const { status, data } = await parseResponse<ApiErrorResponse>(response);
+
+    expect(status).toBe(400);
+    expect(data.error).toBe("profileId is required");
+  });
+
+  it("returns 400 when points is missing or non-positive", async () => {
+    vi.mocked(getSession).mockResolvedValue(mockSession);
+
+    const request = createMockRequest("/api/points/award", {
+      method: "POST",
+      body: {
+        profileId: mockStandardProfile.id,
+        points: 0,
+        reason: "task_completed",
+      },
+    });
+    const response = await POST(request);
+    const { status, data } = await parseResponse<ApiErrorResponse>(response);
+
+    expect(status).toBe(400);
+    expect(data.error).toBe("Invalid points value");
+  });
+
+  it("returns 400 when points is not an integer", async () => {
+    vi.mocked(getSession).mockResolvedValue(mockSession);
+
+    const request = createMockRequest("/api/points/award", {
+      method: "POST",
+      body: {
+        profileId: mockStandardProfile.id,
+        points: 5.5,
+        reason: "task_completed",
+      },
+    });
+    const response = await POST(request);
+    const { status, data } = await parseResponse<ApiErrorResponse>(response);
+
+    expect(status).toBe(400);
+    expect(data.error).toBe("Invalid points value");
+  });
+
+  it("returns 400 when reason is unrecognised", async () => {
+    vi.mocked(getSession).mockResolvedValue(mockSession);
+
+    const request = createMockRequest("/api/points/award", {
+      method: "POST",
+      body: {
+        profileId: mockStandardProfile.id,
+        points: 10,
+        reason: "hacking_the_planet",
+      },
+    });
+    const response = await POST(request);
+    const { status, data } = await parseResponse<ApiErrorResponse>(response);
+
+    expect(status).toBe(400);
+    expect(data.error).toBe("Invalid reason");
+  });
+
+  it("returns 404 when the profile does not belong to the user", async () => {
+    vi.mocked(getSession).mockResolvedValue(mockSession);
+    mockPrisma.profile.findFirst.mockResolvedValue(null);
+
+    const request = createMockRequest("/api/points/award", {
+      method: "POST",
+      body: {
+        profileId: "someone-elses-profile",
+        points: 10,
+        reason: "task_completed",
+      },
+    });
+    const response = await POST(request);
+    const { status, data } = await parseResponse<ApiErrorResponse>(response);
+
+    expect(status).toBe(404);
+    expect(data.error).toBe("Profile not found");
+    expect(mockPrisma.profile.findFirst).toHaveBeenCalledWith({
+      where: {
+        id: "someone-elses-profile",
+        userId: mockUserId,
+        isActive: true,
+      },
+      select: { id: true },
+    });
+  });
+
+  it("returns 403 when rewards are disabled at the account level", async () => {
+    vi.mocked(getSession).mockResolvedValue(mockSession);
+    mockPrisma.profile.findFirst.mockResolvedValue({
+      id: mockStandardProfile.id,
+    });
+    mockPrisma.userSettings.findUnique.mockResolvedValue({
+      rewardSystemEnabled: false,
+    });
+
+    const request = createMockRequest("/api/points/award", {
+      method: "POST",
+      body: {
+        profileId: mockStandardProfile.id,
+        points: 10,
+        reason: "task_completed",
+      },
+    });
+    const response = await POST(request);
+    const { status, data } = await parseResponse<ApiErrorResponse>(response);
+
+    expect(status).toBe(403);
+    expect(data.error).toBe("Reward system not enabled");
+    expect(mockRecordPointAward).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when no UserSettings row exists", async () => {
+    vi.mocked(getSession).mockResolvedValue(mockSession);
+    mockPrisma.profile.findFirst.mockResolvedValue({
+      id: mockStandardProfile.id,
+    });
+    mockPrisma.userSettings.findUnique.mockResolvedValue(null);
+
+    const request = createMockRequest("/api/points/award", {
+      method: "POST",
+      body: {
+        profileId: mockStandardProfile.id,
+        points: 10,
+        reason: "task_completed",
+      },
+    });
+    const response = await POST(request);
+    const { status } = await parseResponse<ApiErrorResponse>(response);
+
+    expect(status).toBe(403);
+  });
+
+  it("delegates to recordPointAward and returns the new total", async () => {
+    vi.mocked(getSession).mockResolvedValue(mockSession);
+    mockPrisma.profile.findFirst.mockResolvedValue({
+      id: mockStandardProfile.id,
+    });
+    mockPrisma.userSettings.findUnique.mockResolvedValue({
+      rewardSystemEnabled: true,
+    });
+    mockRecordPointAward.mockResolvedValue({
+      totalPoints: 60,
+      alreadyAwarded: false,
+    });
+
+    const request = createMockRequest("/api/points/award", {
+      method: "POST",
+      body: {
+        profileId: mockStandardProfile.id,
+        points: 10,
+        reason: "task_completed",
+        taskId: "task-abc",
+        taskTitle: "Buy milk",
+      },
+    });
+    const response = await POST(request);
+    const { status, data } = await parseResponse<AwardResponse>(response);
+
+    expect(status).toBe(200);
+    expect(data).toEqual({
+      success: true,
+      newTotal: 60,
+      alreadyAwarded: false,
+    });
+    expect(mockRecordPointAward).toHaveBeenCalledWith({
+      profileId: mockStandardProfile.id,
+      points: 10,
+      reason: "task_completed",
+      taskId: "task-abc",
+      taskTitle: "Buy milk",
+    });
+  });
+
+  it("surfaces alreadyAwarded duplicates without erroring", async () => {
+    vi.mocked(getSession).mockResolvedValue(mockSession);
+    mockPrisma.profile.findFirst.mockResolvedValue({
+      id: mockStandardProfile.id,
+    });
+    mockPrisma.userSettings.findUnique.mockResolvedValue({
+      rewardSystemEnabled: true,
+    });
+    mockRecordPointAward.mockResolvedValue({
+      totalPoints: 75,
+      alreadyAwarded: true,
+    });
+
+    const request = createMockRequest("/api/points/award", {
+      method: "POST",
+      body: {
+        profileId: mockStandardProfile.id,
+        points: 10,
+        reason: "task_completed",
+        taskId: "task-abc",
+      },
+    });
+    const response = await POST(request);
+    const { status, data } = await parseResponse<AwardResponse>(response);
+
+    expect(status).toBe(200);
+    expect(data).toEqual({
+      success: true,
+      newTotal: 75,
+      alreadyAwarded: true,
+    });
+  });
+
+  it("returns 500 when the service throws an unexpected error", async () => {
+    vi.mocked(getSession).mockResolvedValue(mockSession);
+    mockPrisma.profile.findFirst.mockResolvedValue({
+      id: mockStandardProfile.id,
+    });
+    mockPrisma.userSettings.findUnique.mockResolvedValue({
+      rewardSystemEnabled: true,
+    });
+    mockRecordPointAward.mockRejectedValue(new Error("connection lost"));
+
+    const request = createMockRequest("/api/points/award", {
+      method: "POST",
+      body: {
+        profileId: mockStandardProfile.id,
+        points: 10,
+        reason: "task_completed",
+      },
+    });
+    const response = await POST(request);
+    const { status, data } = await parseResponse<ApiErrorResponse>(response);
+
+    expect(status).toBe(500);
+    expect(data.error).toBe("Failed to award points");
+  });
+});

--- a/src/app/api/points/award/route.ts
+++ b/src/app/api/points/award/route.ts
@@ -1,0 +1,143 @@
+/**
+ * POST /api/points/award - awards points to a profile.
+ *
+ * Body:
+ *   {
+ *     profileId: string;
+ *     points: number;            // positive integer
+ *     reason: PointAwardReason;  // e.g. "task_completed"
+ *     taskId?: string;
+ *     taskTitle?: string;
+ *   }
+ *
+ * Response:
+ *   { success: true, newTotal: number, alreadyAwarded: boolean }
+ *
+ * Reward enablement is checked at the account level
+ * (`UserSettings.rewardSystemEnabled`). Points themselves are stored
+ * per profile. The `alreadyAwarded` flag surfaces idempotency hits
+ * driven by the `(profileId, taskId, reason)` unique index — a
+ * task can only credit a profile once.
+ */
+import { getSession } from "@/lib/auth";
+import { prisma } from "@/lib/db";
+import { logger } from "@/lib/logger";
+import {
+  type PointAwardReason,
+  recordPointAward,
+} from "@/lib/services/reward-points";
+import { NextRequest, NextResponse } from "next/server";
+
+const VALID_REASONS: ReadonlySet<PointAwardReason> = new Set([
+  "task_completed",
+  "manual",
+  "bonus",
+  "streak",
+  "goal",
+]);
+
+interface AwardRequestBody {
+  profileId?: string;
+  points?: number;
+  reason?: string;
+  taskId?: string;
+  taskTitle?: string;
+}
+
+function isValidReason(value: string): value is PointAwardReason {
+  return VALID_REASONS.has(value as PointAwardReason);
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const session = await getSession();
+
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = (await request.json()) as AwardRequestBody;
+    const { profileId, points, reason, taskId, taskTitle } = body;
+
+    if (!profileId) {
+      return NextResponse.json(
+        { error: "profileId is required" },
+        { status: 400 }
+      );
+    }
+
+    if (
+      typeof points !== "number" ||
+      !Number.isInteger(points) ||
+      points <= 0
+    ) {
+      return NextResponse.json(
+        { error: "Invalid points value" },
+        { status: 400 }
+      );
+    }
+
+    if (typeof reason !== "string" || !isValidReason(reason)) {
+      return NextResponse.json({ error: "Invalid reason" }, { status: 400 });
+    }
+
+    const profile = await prisma.profile.findFirst({
+      where: {
+        id: profileId,
+        userId: session.user.id,
+        isActive: true,
+      },
+      select: { id: true },
+    });
+
+    if (!profile) {
+      return NextResponse.json({ error: "Profile not found" }, { status: 404 });
+    }
+
+    const settings = await prisma.userSettings.findUnique({
+      where: { userId: session.user.id },
+      select: { rewardSystemEnabled: true },
+    });
+
+    if (!settings?.rewardSystemEnabled) {
+      return NextResponse.json(
+        { error: "Reward system not enabled" },
+        { status: 403 }
+      );
+    }
+
+    const result = await recordPointAward({
+      profileId,
+      points,
+      reason,
+      taskId,
+      taskTitle,
+    });
+
+    logger.event("PointsAwarded", {
+      userId: session.user.id,
+      profileId,
+      points,
+      reason,
+      newTotal: result.totalPoints,
+      alreadyAwarded: result.alreadyAwarded,
+      ...(taskId ? { taskId } : {}),
+    });
+
+    return NextResponse.json({
+      success: true,
+      newTotal: result.totalPoints,
+      alreadyAwarded: result.alreadyAwarded,
+    });
+  } catch (error) {
+    logger.error(error as Error, {
+      endpoint: "/api/points/award",
+      method: "POST",
+    });
+
+    return NextResponse.json(
+      { error: "Failed to award points" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/points/award/route.ts
+++ b/src/app/api/points/award/route.ts
@@ -4,9 +4,9 @@
  * Body:
  *   {
  *     profileId: string;
- *     points: number;            // positive integer
+ *     points: number;            // positive integer, max MAX_POINTS_PER_AWARD
  *     reason: PointAwardReason;  // e.g. "task_completed"
- *     taskId?: string;
+ *     taskId?: string;           // required when reason === "task_completed"
  *     taskTitle?: string;
  *   }
  *
@@ -17,7 +17,10 @@
  * (`UserSettings.rewardSystemEnabled`). Points themselves are stored
  * per profile. The `alreadyAwarded` flag surfaces idempotency hits
  * driven by the `(profileId, taskId, reason)` unique index — a
- * task can only credit a profile once.
+ * task can only credit a profile once. The index is partial in
+ * effect (Postgres treats NULL as distinct), so the route requires
+ * `taskId` for `task_completed` awards to keep the idempotency
+ * guarantee meaningful.
  */
 import { getSession } from "@/lib/auth";
 import { prisma } from "@/lib/db";
@@ -35,6 +38,12 @@ const VALID_REASONS: ReadonlySet<PointAwardReason> = new Set([
   "streak",
   "goal",
 ]);
+
+// Cap a single award well below 32-bit Int range so an accumulated
+// totalPoints can't reasonably overflow Postgres INTEGER. Anything
+// realistic for task / bonus / streak awards stays comfortably under
+// this; admin manual awards above this should hit a different path.
+const MAX_POINTS_PER_AWARD = 10_000;
 
 interface AwardRequestBody {
   profileId?: string;
@@ -69,7 +78,8 @@ export async function POST(request: NextRequest) {
     if (
       typeof points !== "number" ||
       !Number.isInteger(points) ||
-      points <= 0
+      points <= 0 ||
+      points > MAX_POINTS_PER_AWARD
     ) {
       return NextResponse.json(
         { error: "Invalid points value" },
@@ -79,6 +89,17 @@ export async function POST(request: NextRequest) {
 
     if (typeof reason !== "string" || !isValidReason(reason)) {
       return NextResponse.json({ error: "Invalid reason" }, { status: 400 });
+    }
+
+    // Without taskId the unique (profileId, taskId, reason) index can't
+    // dedupe — Postgres treats NULL as distinct, so a caller could
+    // re-award the same "task" indefinitely. Force taskId on the
+    // automated task path to keep the idempotency guarantee.
+    if (reason === "task_completed" && !taskId) {
+      return NextResponse.json(
+        { error: "taskId is required for task_completed awards" },
+        { status: 400 }
+      );
     }
 
     const profile = await prisma.profile.findFirst({

--- a/src/app/api/points/route.ts
+++ b/src/app/api/points/route.ts
@@ -1,0 +1,78 @@
+/**
+ * GET /api/points - returns the current point total for a profile.
+ *
+ * Query params:
+ *   profileId (required) — the profile to fetch points for.
+ *
+ * Response:
+ *   { totalPoints: number, enabled: boolean }
+ *
+ * `enabled` reflects the account-level `UserSettings.rewardSystemEnabled`
+ * flag. When rewards are disabled the response always reports
+ * `totalPoints: 0` so disabled users do not see stale point totals.
+ */
+import { getSession } from "@/lib/auth";
+import { prisma } from "@/lib/db";
+import { logger } from "@/lib/logger";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(request: NextRequest) {
+  try {
+    const session = await getSession();
+
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const profileId = request.nextUrl.searchParams.get("profileId");
+
+    if (!profileId) {
+      return NextResponse.json(
+        { error: "profileId is required" },
+        { status: 400 }
+      );
+    }
+
+    const profile = await prisma.profile.findFirst({
+      where: {
+        id: profileId,
+        userId: session.user.id,
+        isActive: true,
+      },
+      select: { id: true },
+    });
+
+    if (!profile) {
+      return NextResponse.json({ error: "Profile not found" }, { status: 404 });
+    }
+
+    const settings = await prisma.userSettings.findUnique({
+      where: { userId: session.user.id },
+      select: { rewardSystemEnabled: true },
+    });
+
+    if (!settings?.rewardSystemEnabled) {
+      return NextResponse.json({ totalPoints: 0, enabled: false });
+    }
+
+    const rewardPoints = await prisma.profileRewardPoints.findUnique({
+      where: { profileId },
+      select: { totalPoints: true },
+    });
+
+    return NextResponse.json({
+      totalPoints: rewardPoints?.totalPoints ?? 0,
+      enabled: true,
+    });
+  } catch (error) {
+    logger.error(error as Error, {
+      endpoint: "/api/points",
+      method: "GET",
+    });
+
+    return NextResponse.json(
+      { error: "Failed to fetch points" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/rewards/__tests__/points-context.test.tsx
+++ b/src/components/rewards/__tests__/points-context.test.tsx
@@ -68,7 +68,10 @@ describe("usePoints", () => {
     });
 
     await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalledWith("/api/points?profileId=profile-1");
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/points?profileId=profile-1",
+        expect.objectContaining({ signal: expect.any(AbortSignal) })
+      );
     });
 
     await waitFor(() => {
@@ -271,7 +274,10 @@ describe("usePoints", () => {
     await waitFor(() => {
       expect(getByTestId("total").textContent).toBe("50");
     });
-    expect(mockFetch).toHaveBeenCalledWith("/api/points?profileId=profile-1");
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/points?profileId=profile-1",
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
 
     rerender(
       <PointsProvider profileId="profile-2">
@@ -280,8 +286,84 @@ describe("usePoints", () => {
     );
 
     await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalledWith("/api/points?profileId=profile-2");
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/points?profileId=profile-2",
+        expect.objectContaining({ signal: expect.any(AbortSignal) })
+      );
       expect(getByTestId("total").textContent).toBe("200");
     });
+  });
+
+  it("does not write a stale awardPoints result into the new profile's state", async () => {
+    let resolveAward: ((value: Response) => void) | null = null;
+    const awardPromise = new Promise<Response>((resolve) => {
+      resolveAward = resolve;
+    });
+
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ totalPoints: 50, enabled: true }),
+      })
+      .mockReturnValueOnce(awardPromise)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ totalPoints: 200, enabled: true }),
+      });
+
+    function Probe() {
+      const { totalPoints, awardPoints } = usePoints();
+      return (
+        <div>
+          <div data-testid="total">{totalPoints}</div>
+          <button
+            data-testid="award"
+            onClick={() => {
+              awardPoints(10, "task_completed", { taskId: "t1" }).catch(
+                () => {}
+              );
+            }}
+          />
+        </div>
+      );
+    }
+
+    const { rerender, getByTestId } = render(
+      <PointsProvider profileId="profile-1">
+        <Probe />
+      </PointsProvider>
+    );
+
+    await waitFor(() => expect(getByTestId("total").textContent).toBe("50"));
+
+    // Fire an award under profile-1; do NOT resolve it yet.
+    await act(async () => {
+      getByTestId("award").click();
+    });
+
+    // Switch to profile-2 mid-flight; the GET resolves to 200.
+    rerender(
+      <PointsProvider profileId="profile-2">
+        <Probe />
+      </PointsProvider>
+    );
+    await waitFor(() => expect(getByTestId("total").textContent).toBe("200"));
+
+    // Now resolve the in-flight profile-1 award. Its newTotal of 999
+    // must NOT overwrite profile-2's displayed 200.
+    await act(async () => {
+      resolveAward!({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            success: true,
+            newTotal: 999,
+            alreadyAwarded: false,
+          }),
+      } as Response);
+      await awardPromise;
+    });
+
+    expect(getByTestId("total").textContent).toBe("200");
   });
 });

--- a/src/components/rewards/__tests__/points-context.test.tsx
+++ b/src/components/rewards/__tests__/points-context.test.tsx
@@ -1,0 +1,287 @@
+/**
+ * Tests for PointsContext / PointsProvider / usePoints.
+ *
+ * The provider takes `profileId` as a prop (no internal coupling to
+ * ProfileProvider) so tests don't need to set up a profile context.
+ * Whoever mounts the provider is responsible for forwarding the
+ * active profile id.
+ */
+import { type ReactNode } from "react";
+import { act, render, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PointsProvider, usePoints } from "../points-context";
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    error: vi.fn(),
+    log: vi.fn(),
+    event: vi.fn(),
+  },
+}));
+
+function makeWrapper(profileId: string | null) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <PointsProvider profileId={profileId}>{children}</PointsProvider>;
+  };
+}
+
+describe("usePoints", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+  });
+
+  it("throws when used outside the provider", () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(() => renderHook(() => usePoints())).toThrow(
+      "usePoints must be used within PointsProvider"
+    );
+
+    consoleSpy.mockRestore();
+  });
+
+  it("starts disabled with zero points and never fetches when profileId is null", async () => {
+    const { result } = renderHook(() => usePoints(), {
+      wrapper: makeWrapper(null),
+    });
+
+    expect(result.current.totalPoints).toBe(0);
+    expect(result.current.isEnabled).toBe(false);
+    expect(result.current.profileId).toBeNull();
+
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("fetches points on mount when profileId is provided", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ totalPoints: 1250, enabled: true }),
+    });
+
+    const { result } = renderHook(() => usePoints(), {
+      wrapper: makeWrapper("profile-1"),
+    });
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith("/api/points?profileId=profile-1");
+    });
+
+    await waitFor(() => {
+      expect(result.current.totalPoints).toBe(1250);
+      expect(result.current.isEnabled).toBe(true);
+    });
+  });
+
+  it("reports enabled=false and zero points when the API says rewards are disabled", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ totalPoints: 0, enabled: false }),
+    });
+
+    const { result } = renderHook(() => usePoints(), {
+      wrapper: makeWrapper("profile-1"),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isEnabled).toBe(false);
+      expect(result.current.totalPoints).toBe(0);
+    });
+  });
+
+  it("falls back to disabled when the GET fails", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
+
+    const { result } = renderHook(() => usePoints(), {
+      wrapper: makeWrapper("profile-1"),
+    });
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalled();
+    });
+
+    expect(result.current.isEnabled).toBe(false);
+    expect(result.current.totalPoints).toBe(0);
+  });
+
+  it("awardPoints POSTs the payload and updates totalPoints from the response", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ totalPoints: 50, enabled: true }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            success: true,
+            newTotal: 60,
+            alreadyAwarded: false,
+          }),
+      });
+
+    const { result } = renderHook(() => usePoints(), {
+      wrapper: makeWrapper("profile-1"),
+    });
+
+    await waitFor(() => expect(result.current.totalPoints).toBe(50));
+
+    let awardResult: { newTotal: number; alreadyAwarded: boolean } | undefined;
+    await act(async () => {
+      awardResult = await result.current.awardPoints(10, "task_completed", {
+        taskId: "task-abc",
+        taskTitle: "Buy milk",
+      });
+    });
+
+    expect(mockFetch).toHaveBeenLastCalledWith("/api/points/award", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        profileId: "profile-1",
+        points: 10,
+        reason: "task_completed",
+        taskId: "task-abc",
+        taskTitle: "Buy milk",
+      }),
+    });
+    expect(awardResult).toEqual({ newTotal: 60, alreadyAwarded: false });
+    expect(result.current.totalPoints).toBe(60);
+  });
+
+  it("does not increment totalPoints when alreadyAwarded is true (idempotent)", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ totalPoints: 75, enabled: true }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            success: true,
+            newTotal: 75,
+            alreadyAwarded: true,
+          }),
+      });
+
+    const { result } = renderHook(() => usePoints(), {
+      wrapper: makeWrapper("profile-1"),
+    });
+
+    await waitFor(() => expect(result.current.totalPoints).toBe(75));
+
+    let awardResult: { newTotal: number; alreadyAwarded: boolean } | undefined;
+    await act(async () => {
+      awardResult = await result.current.awardPoints(10, "task_completed", {
+        taskId: "task-abc",
+      });
+    });
+
+    expect(awardResult?.alreadyAwarded).toBe(true);
+    expect(result.current.totalPoints).toBe(75);
+  });
+
+  it("throws and leaves totalPoints unchanged when the award POST fails", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ totalPoints: 50, enabled: true }),
+      })
+      .mockResolvedValueOnce({ ok: false, status: 403 });
+
+    const { result } = renderHook(() => usePoints(), {
+      wrapper: makeWrapper("profile-1"),
+    });
+
+    await waitFor(() => expect(result.current.totalPoints).toBe(50));
+
+    await act(async () => {
+      await expect(
+        result.current.awardPoints(10, "task_completed", { taskId: "task-x" })
+      ).rejects.toThrow("Failed to award points");
+    });
+
+    expect(result.current.totalPoints).toBe(50);
+  });
+
+  it("rejects awardPoints when no active profile is set", async () => {
+    const { result } = renderHook(() => usePoints(), {
+      wrapper: makeWrapper(null),
+    });
+
+    await act(async () => {
+      await expect(
+        result.current.awardPoints(10, "task_completed", { taskId: "task-x" })
+      ).rejects.toThrow("No active profile");
+    });
+  });
+
+  it("refreshPoints re-fetches and updates state", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ totalPoints: 50, enabled: true }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ totalPoints: 80, enabled: true }),
+      });
+
+    const { result } = renderHook(() => usePoints(), {
+      wrapper: makeWrapper("profile-1"),
+    });
+
+    await waitFor(() => expect(result.current.totalPoints).toBe(50));
+
+    await act(async () => {
+      await result.current.refreshPoints();
+    });
+
+    expect(result.current.totalPoints).toBe(80);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-fetches when profileId changes", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ totalPoints: 50, enabled: true }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ totalPoints: 200, enabled: true }),
+      });
+
+    function Probe() {
+      const { totalPoints } = usePoints();
+      return <div data-testid="total">{totalPoints}</div>;
+    }
+
+    const { rerender, getByTestId } = render(
+      <PointsProvider profileId="profile-1">
+        <Probe />
+      </PointsProvider>
+    );
+
+    await waitFor(() => {
+      expect(getByTestId("total").textContent).toBe("50");
+    });
+    expect(mockFetch).toHaveBeenCalledWith("/api/points?profileId=profile-1");
+
+    rerender(
+      <PointsProvider profileId="profile-2">
+        <Probe />
+      </PointsProvider>
+    );
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith("/api/points?profileId=profile-2");
+      expect(getByTestId("total").textContent).toBe("200");
+    });
+  });
+});

--- a/src/components/rewards/points-context.tsx
+++ b/src/components/rewards/points-context.tsx
@@ -16,21 +16,18 @@
  * state (zero points, isEnabled=false) and never hits the network.
  */
 import { logger } from "@/lib/logger";
+import type { PointAwardReason } from "@/lib/services/reward-points";
 import {
   type ReactNode,
   createContext,
   useCallback,
   useContext,
   useEffect,
+  useRef,
   useState,
 } from "react";
 
-export type PointAwardReason =
-  | "task_completed"
-  | "manual"
-  | "bonus"
-  | "streak"
-  | "goal";
+export type { PointAwardReason };
 
 export interface AwardPointsMetadata {
   taskId?: string;
@@ -70,9 +67,61 @@ export function PointsProvider({ profileId, children }: PointsProviderProps) {
   const [fetchedTotal, setFetchedTotal] = useState(0);
   const [fetchedEnabled, setFetchedEnabled] = useState(false);
 
-  const fetchPoints = useCallback(async (id: string) => {
+  // Track the currently-mounted profile id so in-flight requests
+  // started under a different profile don't write their result into
+  // the new profile's displayed state when they resolve.
+  const activeProfileIdRef = useRef<string | null>(profileId);
+  useEffect(() => {
+    activeProfileIdRef.current = profileId;
+  }, [profileId]);
+
+  useEffect(() => {
+    if (!profileId) {
+      return;
+    }
+    const controller = new AbortController();
+    const run = async () => {
+      try {
+        const response = await fetch(
+          `/api/points?profileId=${encodeURIComponent(profileId)}`,
+          { signal: controller.signal }
+        );
+        if (controller.signal.aborted) return;
+        if (!response.ok) {
+          setFetchedTotal(0);
+          setFetchedEnabled(false);
+          return;
+        }
+        const data = (await response.json()) as {
+          totalPoints: number;
+          enabled: boolean;
+        };
+        if (controller.signal.aborted) return;
+        setFetchedTotal(data.totalPoints);
+        setFetchedEnabled(data.enabled);
+      } catch (error) {
+        if ((error as Error).name === "AbortError") return;
+        logger.error(error as Error, { context: "FetchPointsFailed" });
+        setFetchedTotal(0);
+        setFetchedEnabled(false);
+      }
+    };
+    run();
+    return () => controller.abort();
+  }, [profileId]);
+
+  const totalPoints = profileId ? fetchedTotal : 0;
+  const isEnabled = profileId ? fetchedEnabled : false;
+
+  const refreshPoints = useCallback(async () => {
+    if (!profileId) {
+      return;
+    }
     try {
-      const response = await fetch(`/api/points?profileId=${id}`);
+      const response = await fetch(
+        `/api/points?profileId=${encodeURIComponent(profileId)}`
+      );
+      if (activeProfileIdRef.current !== profileId) return;
       if (!response.ok) {
         setFetchedTotal(0);
         setFetchedEnabled(false);
@@ -82,34 +131,16 @@ export function PointsProvider({ profileId, children }: PointsProviderProps) {
         totalPoints: number;
         enabled: boolean;
       };
+      if (activeProfileIdRef.current !== profileId) return;
       setFetchedTotal(data.totalPoints);
       setFetchedEnabled(data.enabled);
     } catch (error) {
       logger.error(error as Error, { context: "FetchPointsFailed" });
+      if (activeProfileIdRef.current !== profileId) return;
       setFetchedTotal(0);
       setFetchedEnabled(false);
     }
-  }, []);
-
-  useEffect(() => {
-    if (!profileId) {
-      return;
-    }
-    const run = async () => {
-      await fetchPoints(profileId);
-    };
-    run();
-  }, [profileId, fetchPoints]);
-
-  const totalPoints = profileId ? fetchedTotal : 0;
-  const isEnabled = profileId ? fetchedEnabled : false;
-
-  const refreshPoints = useCallback(async () => {
-    if (!profileId) {
-      return;
-    }
-    await fetchPoints(profileId);
-  }, [profileId, fetchPoints]);
+  }, [profileId]);
 
   const awardPoints = useCallback(
     async (
@@ -143,7 +174,11 @@ export function PointsProvider({ profileId, children }: PointsProviderProps) {
         alreadyAwarded: boolean;
       };
 
-      setFetchedTotal(data.newTotal);
+      // Only sync local state if this closure's profile is still the
+      // active one — guards against a profile switch during the POST.
+      if (activeProfileIdRef.current === profileId) {
+        setFetchedTotal(data.newTotal);
+      }
 
       logger.event("PointsAwarded", {
         profileId,

--- a/src/components/rewards/points-context.tsx
+++ b/src/components/rewards/points-context.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+/**
+ * PointsContext - client-side state surface for the reward-points
+ * system.
+ *
+ * Reads `/api/points?profileId=…` on mount and whenever the active
+ * profile changes, exposes `awardPoints()` for callers to record a
+ * point award (POST `/api/points/award`), and surfaces the
+ * `alreadyAwarded` idempotency flag returned by the API so callers
+ * can suppress duplicate animations.
+ *
+ * The provider is intentionally decoupled from `ProfileProvider`:
+ * whoever mounts it forwards the active profile id as a prop. When
+ * `profileId` is null the context stays in its initial disabled
+ * state (zero points, isEnabled=false) and never hits the network.
+ */
+import { logger } from "@/lib/logger";
+import {
+  type ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+
+export type PointAwardReason =
+  | "task_completed"
+  | "manual"
+  | "bonus"
+  | "streak"
+  | "goal";
+
+export interface AwardPointsMetadata {
+  taskId?: string;
+  taskTitle?: string;
+}
+
+export interface AwardPointsResult {
+  newTotal: number;
+  alreadyAwarded: boolean;
+}
+
+interface PointsContextValue {
+  totalPoints: number;
+  isEnabled: boolean;
+  profileId: string | null;
+  awardPoints: (
+    points: number,
+    reason: PointAwardReason,
+    metadata?: AwardPointsMetadata
+  ) => Promise<AwardPointsResult>;
+  refreshPoints: () => Promise<void>;
+}
+
+const PointsContext = createContext<PointsContextValue | null>(null);
+
+interface PointsProviderProps {
+  profileId: string | null;
+  children: ReactNode;
+}
+
+export function PointsProvider({ profileId, children }: PointsProviderProps) {
+  // Stored state reflects the most recent fetch. The exposed
+  // `totalPoints` / `isEnabled` are derived from it so that swapping
+  // to a null profile zeros the public values without needing a
+  // synchronous setState in the effect (which would trigger
+  // cascading renders).
+  const [fetchedTotal, setFetchedTotal] = useState(0);
+  const [fetchedEnabled, setFetchedEnabled] = useState(false);
+
+  const fetchPoints = useCallback(async (id: string) => {
+    try {
+      const response = await fetch(`/api/points?profileId=${id}`);
+      if (!response.ok) {
+        setFetchedTotal(0);
+        setFetchedEnabled(false);
+        return;
+      }
+      const data = (await response.json()) as {
+        totalPoints: number;
+        enabled: boolean;
+      };
+      setFetchedTotal(data.totalPoints);
+      setFetchedEnabled(data.enabled);
+    } catch (error) {
+      logger.error(error as Error, { context: "FetchPointsFailed" });
+      setFetchedTotal(0);
+      setFetchedEnabled(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!profileId) {
+      return;
+    }
+    const run = async () => {
+      await fetchPoints(profileId);
+    };
+    run();
+  }, [profileId, fetchPoints]);
+
+  const totalPoints = profileId ? fetchedTotal : 0;
+  const isEnabled = profileId ? fetchedEnabled : false;
+
+  const refreshPoints = useCallback(async () => {
+    if (!profileId) {
+      return;
+    }
+    await fetchPoints(profileId);
+  }, [profileId, fetchPoints]);
+
+  const awardPoints = useCallback(
+    async (
+      points: number,
+      reason: PointAwardReason,
+      metadata?: AwardPointsMetadata
+    ): Promise<AwardPointsResult> => {
+      if (!profileId) {
+        throw new Error("No active profile");
+      }
+
+      const response = await fetch("/api/points/award", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          profileId,
+          points,
+          reason,
+          ...(metadata?.taskId ? { taskId: metadata.taskId } : {}),
+          ...(metadata?.taskTitle ? { taskTitle: metadata.taskTitle } : {}),
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error("Failed to award points");
+      }
+
+      const data = (await response.json()) as {
+        success: boolean;
+        newTotal: number;
+        alreadyAwarded: boolean;
+      };
+
+      setFetchedTotal(data.newTotal);
+
+      logger.event("PointsAwarded", {
+        profileId,
+        points,
+        reason,
+        newTotal: data.newTotal,
+        alreadyAwarded: data.alreadyAwarded,
+      });
+
+      return {
+        newTotal: data.newTotal,
+        alreadyAwarded: data.alreadyAwarded,
+      };
+    },
+    [profileId]
+  );
+
+  const value: PointsContextValue = {
+    totalPoints,
+    isEnabled,
+    profileId,
+    awardPoints,
+    refreshPoints,
+  };
+
+  return (
+    <PointsContext.Provider value={value}>{children}</PointsContext.Provider>
+  );
+}
+
+export function usePoints(): PointsContextValue {
+  const context = useContext(PointsContext);
+  if (!context) {
+    throw new Error("usePoints must be used within PointsProvider");
+  }
+  return context;
+}

--- a/src/lib/services/__tests__/reward-points.test.ts
+++ b/src/lib/services/__tests__/reward-points.test.ts
@@ -7,17 +7,31 @@
 import { prisma } from "@/lib/db";
 import { mockTransaction } from "@/lib/test-utils/prisma-test-helpers";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { awardPoints } from "../reward-points";
+import { awardPoints, recordPointAward } from "../reward-points";
 
 vi.mock("@/lib/db", () => ({
   prisma: {
     $transaction: vi.fn(),
+    profileRewardPoints: {
+      findUnique: vi.fn(),
+    },
   },
 }));
 
 const mockPrisma = prisma as unknown as {
   $transaction: ReturnType<typeof vi.fn>;
+  profileRewardPoints: {
+    findUnique: ReturnType<typeof vi.fn>;
+  };
 };
+
+function makeUniqueConstraintError() {
+  const error = new Error(
+    "Unique constraint failed on the fields: (`profileId`,`taskId`,`reason`)"
+  ) as Error & { code: string };
+  error.code = "P2002";
+  return error;
+}
 
 describe("awardPoints", () => {
   beforeEach(() => {
@@ -125,5 +139,124 @@ describe("awardPoints", () => {
     await expect(awardPoints("profile-1", 10, "admin-1")).rejects.toThrow(
       "db down"
     );
+  });
+});
+
+describe("recordPointAward", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("records a task_completed award with taskId and taskTitle", async () => {
+    const upsert = vi.fn().mockResolvedValue({ totalPoints: 60 });
+    const create = vi.fn().mockResolvedValue({});
+    mockTransaction(mockPrisma, {
+      profileRewardPoints: { upsert },
+      pointTransaction: { create },
+    });
+
+    const result = await recordPointAward({
+      profileId: "profile-1",
+      points: 10,
+      reason: "task_completed",
+      taskId: "task-abc",
+      taskTitle: "Buy milk",
+    });
+
+    expect(result).toEqual({ totalPoints: 60, alreadyAwarded: false });
+    expect(upsert).toHaveBeenCalledWith({
+      where: { profileId: "profile-1" },
+      update: { totalPoints: { increment: 10 } },
+      create: { profileId: "profile-1", totalPoints: 10 },
+    });
+    expect(create).toHaveBeenCalledWith({
+      data: {
+        profileId: "profile-1",
+        points: 10,
+        reason: "task_completed",
+        taskId: "task-abc",
+        taskTitle: "Buy milk",
+        awardedBy: undefined,
+        note: undefined,
+      },
+    });
+  });
+
+  it("records a manual award with awardedBy and note", async () => {
+    const upsert = vi.fn().mockResolvedValue({ totalPoints: 20 });
+    const create = vi.fn().mockResolvedValue({});
+    mockTransaction(mockPrisma, {
+      profileRewardPoints: { upsert },
+      pointTransaction: { create },
+    });
+
+    const result = await recordPointAward({
+      profileId: "profile-1",
+      points: 20,
+      reason: "manual",
+      awardedBy: "admin-1",
+      note: "Great job!",
+    });
+
+    expect(result).toEqual({ totalPoints: 20, alreadyAwarded: false });
+    expect(create).toHaveBeenCalledWith({
+      data: {
+        profileId: "profile-1",
+        points: 20,
+        reason: "manual",
+        taskId: undefined,
+        taskTitle: undefined,
+        awardedBy: "admin-1",
+        note: "Great job!",
+      },
+    });
+  });
+
+  it("returns alreadyAwarded with current total when the unique index rejects a duplicate task award", async () => {
+    mockPrisma.$transaction.mockRejectedValue(makeUniqueConstraintError());
+    mockPrisma.profileRewardPoints.findUnique.mockResolvedValue({
+      totalPoints: 75,
+    });
+
+    const result = await recordPointAward({
+      profileId: "profile-1",
+      points: 10,
+      reason: "task_completed",
+      taskId: "task-abc",
+      taskTitle: "Buy milk",
+    });
+
+    expect(result).toEqual({ totalPoints: 75, alreadyAwarded: true });
+    expect(mockPrisma.profileRewardPoints.findUnique).toHaveBeenCalledWith({
+      where: { profileId: "profile-1" },
+      select: { totalPoints: true },
+    });
+  });
+
+  it("returns zero total when duplicate is caught and no reward-points row exists", async () => {
+    mockPrisma.$transaction.mockRejectedValue(makeUniqueConstraintError());
+    mockPrisma.profileRewardPoints.findUnique.mockResolvedValue(null);
+
+    const result = await recordPointAward({
+      profileId: "profile-1",
+      points: 10,
+      reason: "task_completed",
+      taskId: "task-abc",
+    });
+
+    expect(result).toEqual({ totalPoints: 0, alreadyAwarded: true });
+  });
+
+  it("propagates non-P2002 errors", async () => {
+    mockPrisma.$transaction.mockRejectedValue(new Error("connection lost"));
+
+    await expect(
+      recordPointAward({
+        profileId: "profile-1",
+        points: 10,
+        reason: "task_completed",
+        taskId: "task-abc",
+      })
+    ).rejects.toThrow("connection lost");
   });
 });

--- a/src/lib/services/reward-points.ts
+++ b/src/lib/services/reward-points.ts
@@ -12,18 +12,37 @@ export interface AwardPointsResult {
 }
 
 /**
- * Award points to a profile.
+ * Reasons we recognise for a point award. Mirrors the free-text values
+ * stored on `PointTransaction.reason`.
+ */
+export type PointAwardReason =
+  | "task_completed"
+  | "manual"
+  | "bonus"
+  | "streak"
+  | "goal";
+
+export interface PointAwardInput {
+  profileId: string;
+  points: number;
+  reason: PointAwardReason;
+  taskId?: string;
+  taskTitle?: string;
+  awardedBy?: string;
+  note?: string;
+}
+
+export interface PointAwardResult {
+  totalPoints: number;
+  alreadyAwarded: boolean;
+}
+
+/**
+ * Award points to a profile (manual admin path).
  *
- * Upserts the profile's `ProfileRewardPoints` row (creating it if it
- * doesn't yet exist) and records a matching `PointTransaction`. Both
- * writes run inside a single Prisma `$transaction` so the totals and
- * audit trail stay consistent.
- *
- * @param profileId         Recipient profile.
- * @param points            Positive integer to add.
- * @param awardedBy         Awarding admin profile id.
- * @param note              Optional free-text note on the transaction.
- * @returns                 The recipient's new `totalPoints`.
+ * Thin wrapper around {@link recordPointAward} kept for the existing
+ * admin "give points" route signature. New callers should prefer
+ * `recordPointAward` directly.
  */
 export async function awardPoints(
   profileId: string,
@@ -31,30 +50,84 @@ export async function awardPoints(
   awardedBy: string,
   note?: string
 ): Promise<AwardPointsResult> {
-  return prisma.$transaction(async (tx) => {
-    const rewardPoints = await tx.profileRewardPoints.upsert({
-      where: { profileId },
-      update: {
-        totalPoints: {
-          increment: points,
-        },
-      },
-      create: {
-        profileId,
-        totalPoints: points,
-      },
-    });
-
-    await tx.pointTransaction.create({
-      data: {
-        profileId,
-        points,
-        reason: "manual",
-        awardedBy,
-        note,
-      },
-    });
-
-    return { totalPoints: rewardPoints.totalPoints };
+  const result = await recordPointAward({
+    profileId,
+    points,
+    reason: "manual",
+    awardedBy,
+    note,
   });
+  return { totalPoints: result.totalPoints };
+}
+
+/**
+ * Generalised point-award entry-point that handles both manual admin
+ * awards and automated rewards (task completion, streaks, etc).
+ *
+ * Upserts `ProfileRewardPoints` and inserts a matching
+ * `PointTransaction` inside a single Prisma `$transaction`.
+ *
+ * For `task_completed` awards a unique `(profileId, taskId, reason)`
+ * index in the database makes the operation idempotent: completing the
+ * same task twice will not double-credit the profile. When that index
+ * fires we surface the no-op via `alreadyAwarded: true` and return the
+ * profile's current total so callers can stay in sync without an extra
+ * round trip.
+ */
+export async function recordPointAward(
+  input: PointAwardInput
+): Promise<PointAwardResult> {
+  try {
+    const rewardPoints = await prisma.$transaction(async (tx) => {
+      const updated = await tx.profileRewardPoints.upsert({
+        where: { profileId: input.profileId },
+        update: {
+          totalPoints: {
+            increment: input.points,
+          },
+        },
+        create: {
+          profileId: input.profileId,
+          totalPoints: input.points,
+        },
+      });
+
+      await tx.pointTransaction.create({
+        data: {
+          profileId: input.profileId,
+          points: input.points,
+          reason: input.reason,
+          taskId: input.taskId,
+          taskTitle: input.taskTitle,
+          awardedBy: input.awardedBy,
+          note: input.note,
+        },
+      });
+
+      return updated;
+    });
+
+    return { totalPoints: rewardPoints.totalPoints, alreadyAwarded: false };
+  } catch (error) {
+    if (isUniqueConstraintError(error)) {
+      const existing = await prisma.profileRewardPoints.findUnique({
+        where: { profileId: input.profileId },
+        select: { totalPoints: true },
+      });
+      return {
+        totalPoints: existing?.totalPoints ?? 0,
+        alreadyAwarded: true,
+      };
+    }
+    throw error;
+  }
+}
+
+function isUniqueConstraintError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code: unknown }).code === "P2002"
+  );
 }

--- a/src/lib/services/reward-points.ts
+++ b/src/lib/services/reward-points.ts
@@ -123,6 +123,11 @@ export async function recordPointAward(
   }
 }
 
+// We duck-type the Prisma P2002 code rather than `instanceof
+// PrismaClientKnownRequestError` to avoid pulling the Prisma
+// namespace into this module just for a type guard. P2002 from a
+// non-Prisma source is vanishingly unlikely on this call path
+// (the only awaited write is a Prisma transaction).
 function isUniqueConstraintError(error: unknown): boolean {
   return (
     typeof error === "object" &&


### PR DESCRIPTION
Closes #172

Adds the API + client-state surface for the reward-points system. The Prisma schema and the atomic upsert/insert pattern from #171 were already in place; this PR builds the thin extensions and the surfaces that hang off them.

## Phase 1 — Service + idempotency

- Extends `src/lib/services/reward-points.ts` with `recordPointAward({ profileId, points, reason, taskId?, taskTitle?, awardedBy?, note? })`. The existing `awardPoints` admin path now calls through it for backward compatibility.
- New migration `0005_pointtransaction_unique_task_award` adds a unique index on `PointTransaction(profileId, taskId, reason)`. Postgres treats unique-index NULLs as distinct, so manual / bonus / streak awards (which leave `taskId` NULL) are unaffected; the constraint only fires when the same task tries to credit the same profile a second time.
- `recordPointAward` catches the resulting `P2002` and returns `alreadyAwarded: true` together with the profile's current total — so callers stay in sync without an extra round trip.
- Six new unit tests cover the task-completion path, manual path, both no-record and existing-record duplicates, and non-P2002 propagation.

## Phase 2 — `GET /api/points` and `POST /api/points/award`

- `GET /api/points?profileId=…` returns `{ totalPoints, enabled }`. `enabled` is the account-level `UserSettings.rewardSystemEnabled` flag; when false the route always reports `totalPoints: 0` so disabled accounts never see stale totals leak through.
- `POST /api/points/award` validates positive integer points, a recognised reason, profile ownership, and that rewards are enabled, then delegates to `recordPointAward`. Idempotent task-completion duplicates surface as `{ alreadyAwarded: true, newTotal }` rather than 5xx errors.
- 19 route tests cover unauthenticated / missing-param / invalid-input / cross-account / disabled / happy / duplicate / failure paths.

## Phase 3 — `PointsContext` / `usePoints`

- Provider takes `profileId` as a prop (decoupled from `ProfileProvider`) so whoever mounts it forwards the active profile id and tests don't need a profile context. Public values are derived from stored fetch state so swapping to a null profile zeros the surface without a synchronous `setState` in the effect.
- Exposes `totalPoints`, `isEnabled`, `profileId`, `awardPoints(points, reason, metadata?)`, and `refreshPoints()`. `awardPoints` does NOT locally increment when the API reports a duplicate.
- 11 component tests cover the hook contract end-to-end (error-outside-provider, null-profile no-fetch, success/disabled/failure GET, POST happy path, idempotent duplicate, POST failure, no-profile reject, refreshPoints, re-fetch on profileId change).

## Out of scope (handled by other issues)

- Mounting `PointsProvider` in the root layout and wiring it to the active profile from `ProfileContext` — #173.
- `PointsBadge`, `PointsAnimation`, settings UI, and the `TaskItem` integration — #173.

## Notes for reviewers

- #171 is effectively done in code already (schema, migration, atomic upsert + transaction insert, six existing unit tests). Left a comment on it recommending closure.
- The reward enablement check still lives on `UserSettings` (per-account), while the points themselves are per-profile via `ProfileRewardPoints`. This is the design that the rest of the codebase has already moved to since the multi-profile work landed.
- All checks green locally: `pnpm lint:fix && pnpm format:fix && pnpm check-types && pnpm test:run` — 1470 tests, no errors, no warnings I introduced.