### PR TITLE
chore(infra): enforce Prisma migration naming convention (#219)

### DIFF
--- a/.github/workflows/main_nextjs-template-build.yml
+++ b/.github/workflows/main_nextjs-template-build.yml
@@ -41,5 +41,8 @@ jobs:
             exit 1
           }
 
+      - name: Validate Prisma migration naming convention
+        run: pnpm db:migrate:check-names
+
       - name: Build
         run: pnpm build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,10 +22,11 @@ pnpm lint:fix && pnpm format:fix && pnpm check-types
 pnpm test                # Run all tests
 
 # Database
-pnpm db:migrate          # Create migration (dev)
-pnpm db:migrate:deploy   # Apply migrations (prod)
-pnpm db:migrate:reset    # Reset + reapply all
-pnpm db:migrate:status   # Check status
+pnpm db:migrate              # Create migration (dev)
+pnpm db:migrate:deploy       # Apply migrations (prod)
+pnpm db:migrate:reset        # Reset + reapply all
+pnpm db:migrate:status       # Check status
+pnpm db:migrate:check-names  # Validate NNNN_snake_case naming
 
 # Dependencies
 pnpm bump-deps           # Update to @latest
@@ -171,4 +172,4 @@ A task is **not complete** until:
 2. All code quality checks pass (`pnpm lint:fix && pnpm format:fix && pnpm check-types`)
 3. Feature matches the plan spec (if implementing from `.claude/plans/`)
 4. Never commit test output artifacts (`test-results/`, `playwright-report/`, `blob-report/`)
-5. Use `pnpm db:migrate` for schema changes (never `prisma db push`). See [docs/database.md](./docs/database.md)
+5. Use `pnpm db:migrate` for schema changes (never `prisma db push`). Migrations follow the `NNNN_snake_case` naming convention (e.g. `0005_add_meal_planning`); CI runs `pnpm db:migrate:check-names` to enforce it. See [docs/database.md](./docs/database.md)

--- a/docs/database.md
+++ b/docs/database.md
@@ -5,11 +5,50 @@ This project uses **PostgreSQL** with **Prisma ORM** for database management.
 ## Quick Reference
 
 ```bash
-pnpm db:migrate          # Create a new migration (development)
-pnpm db:migrate:deploy   # Apply pending migrations (production)
-pnpm db:migrate:reset    # Reset database and reapply all migrations
-pnpm db:migrate:status   # Check migration status
+pnpm db:migrate              # Create a new migration (development)
+pnpm db:migrate:deploy       # Apply pending migrations (production)
+pnpm db:migrate:reset        # Reset database and reapply all migrations
+pnpm db:migrate:status       # Check migration status
+pnpm db:migrate:check-names  # Validate the NNNN_snake_case naming convention
 ```
+
+## Migration Naming Convention
+
+This project uses **sequential numeric prefixes** for migration directory names:
+
+```
+NNNN_snake_case_description
+```
+
+- `NNNN` — strictly increasing 4-digit prefix starting at `0001` (no gaps, no duplicates).
+- `snake_case_description` — lowercase letters, digits, and underscores only.
+
+Examples:
+
+```
+0001_initial
+0002_add_scheduler_settings
+0003_unique_account_user_provider
+0004_add_calendar_settings
+0005_add_meal_planning
+```
+
+### Why sequential, not Prisma's default timestamp prefix?
+
+|                                         | Sequential `NNNN_`                             | Timestamp `YYYYMMDDHHMMSS_`              |
+| --------------------------------------- | ---------------------------------------------- | ---------------------------------------- |
+| Tidy ordering in code review            | ✓ aligned columns                              | ✗ wide column                            |
+| Collision-free with concurrent PRs      | ✓ obvious next number; conflicts surface in CI | ✗ two PRs at the same minute can collide |
+| Communicates ordering at a glance       | ✓ `0007` clearly follows `0006`                | ✗ requires reading the timestamp         |
+| Matches Prisma's out-of-the-box default | ✗ requires explicit naming                     | ✓                                        |
+
+Decision: trade the small friction of explicitly naming each new migration `NNNN_…` for the larger gains in review legibility and conflict avoidance.
+
+### Enforcement
+
+`pnpm db:migrate:check-names` (also wired into CI) validates that every entry under `prisma/migrations/` matches the convention and that prefixes are strictly sequential. Run it locally before pushing if you've added a migration.
+
+When `pnpm db:migrate` prompts for a name, answer with the snake-case description only — `add_scheduler_settings`, not `0005_add_scheduler_settings`. Prisma normally prepends a timestamp, so after the migration is created, **rename the directory** from `<timestamp>_add_scheduler_settings/` to the next sequential prefix (`0005_add_scheduler_settings/`) before committing. The check script will reject the timestamp form so a forgotten rename fails CI.
 
 ## Development Workflow
 
@@ -24,7 +63,9 @@ pnpm db:migrate:status   # Check migration status
    - Generates a SQL migration file in `prisma/migrations/`
    - Applies it to your local database
    - Regenerates the Prisma client
-3. **Commit** the migration file along with the schema change
+3. **Rename the migration directory** to the next sequential prefix (e.g. `0005_add_scheduler_settings/`) — see [Migration Naming Convention](#migration-naming-convention).
+4. **Verify** the name with `pnpm db:migrate:check-names`.
+5. **Commit** the migration file along with the schema change.
 
 ### Example: Adding a New Field
 
@@ -40,9 +81,13 @@ model UserSettings {
 pnpm db:migrate
 # Enter migration name: add_scheduler_interval
 # Migration created and applied!
-```
 
-This creates `prisma/migrations/<timestamp>_add_scheduler_interval/migration.sql`.
+# Rename to the next sequential prefix (see Migration Naming Convention):
+mv prisma/migrations/<timestamp>_add_scheduler_interval \
+   prisma/migrations/0005_add_scheduler_interval
+
+pnpm db:migrate:check-names  # Verify
+```
 
 ## Production Deployment
 
@@ -67,11 +112,13 @@ This tells Prisma that the `0001_initial` migration has already been applied (si
 
 ## CI Validation
 
-The CI pipeline validates that migrations are in sync with the schema. If you modify `prisma/schema.prisma` without creating a migration, CI will fail with:
+The CI pipeline validates two things on every push:
 
-```
-Prisma migrations are out of date. Run 'pnpm db:migrate' to create a new migration.
-```
+1. **Schema-vs-migrations drift** — if you modify `prisma/schema.prisma` without creating a migration, CI fails with:
+   ```
+   Prisma migrations are out of date. Run 'pnpm db:migrate' to create a new migration.
+   ```
+2. **Naming convention** — `pnpm db:migrate:check-names` runs in CI and fails if any migration directory does not match `^[0-9]{4}_[a-z0-9_]+$` or if prefixes are not strictly sequential. See [Migration Naming Convention](#migration-naming-convention).
 
 ## Migration Directory Structure
 
@@ -82,8 +129,8 @@ prisma/
 │   ├── migration_lock.toml          # Provider lock file (do not edit)
 │   ├── 0001_initial/
 │   │   └── migration.sql            # Baseline migration
-│   └── <timestamp>_<name>/
-│       └── migration.sql            # Subsequent migrations
+│   └── NNNN_snake_case_description/
+│       └── migration.sql            # Subsequent migrations (sequential prefix)
 ```
 
 ## Important Rules

--- a/docs/database.md
+++ b/docs/database.md
@@ -48,7 +48,35 @@ Decision: trade the small friction of explicitly naming each new migration `NNNN
 
 `pnpm db:migrate:check-names` (also wired into CI) validates that every entry under `prisma/migrations/` matches the convention and that prefixes are strictly sequential. Run it locally before pushing if you've added a migration.
 
-When `pnpm db:migrate` prompts for a name, answer with the snake-case description only — `add_scheduler_settings`, not `0005_add_scheduler_settings`. Prisma normally prepends a timestamp, so after the migration is created, **rename the directory** from `<timestamp>_add_scheduler_settings/` to the next sequential prefix (`0005_add_scheduler_settings/`) before committing. The check script will reject the timestamp form so a forgotten rename fails CI.
+### Renaming a freshly-created migration
+
+When `pnpm db:migrate` prompts for a name, answer with the snake-case description only — `add_scheduler_settings`, not `0005_add_scheduler_settings`. Prisma still prepends a timestamp to the directory it creates on disk, and **also writes a row into the local `_prisma_migrations` table under the same timestamp name**. Renaming the directory only — without touching the DB row — leaves the two out of sync, and the next `pnpm db:migrate` run will fail with a "migration not found" / drift error.
+
+The full rename ritual is:
+
+```bash
+# 1. Find the timestamp directory Prisma just created.
+TIMESTAMP_DIR=$(ls -1d prisma/migrations/[0-9]*_add_scheduler_settings | head -1)
+NEXT_PREFIX=$(printf "%04d" $(($(ls -1d prisma/migrations/[0-9]*/ | wc -l))))
+NEW_NAME="${NEXT_PREFIX}_add_scheduler_settings"
+
+# 2. Rename the directory.
+mv "$TIMESTAMP_DIR" "prisma/migrations/$NEW_NAME"
+
+# 3. Update the local _prisma_migrations row so Prisma still recognises it.
+#    Either (a) rewrite the row in place:
+psql "$DATABASE_URL" -c "UPDATE _prisma_migrations SET migration_name = '$NEW_NAME' \
+  WHERE migration_name = '$(basename "$TIMESTAMP_DIR")';"
+
+#    or (b) reset the local DB and re-apply from scratch — simplest in dev:
+pnpm db:migrate:reset
+
+# 4. Verify.
+pnpm db:migrate:check-names
+pnpm db:migrate:status
+```
+
+The check script rejects the timestamp form, so a forgotten rename fails CI. Production databases are not affected — `prisma migrate deploy` reads the renamed directory directly, and the `_prisma_migrations` row is created on first apply with the correct (renamed) value.
 
 ## Development Workflow
 
@@ -82,9 +110,12 @@ pnpm db:migrate
 # Enter migration name: add_scheduler_interval
 # Migration created and applied!
 
-# Rename to the next sequential prefix (see Migration Naming Convention):
+# Rename to the next sequential prefix (replace <NNNN> with the actual next
+# number — check prisma/migrations/ or run pnpm db:migrate:check-names).
+# Remember to also update the local _prisma_migrations row, or reset the
+# dev DB. See "Renaming a freshly-created migration" above.
 mv prisma/migrations/<timestamp>_add_scheduler_interval \
-   prisma/migrations/0005_add_scheduler_interval
+   prisma/migrations/<NNNN>_add_scheduler_interval
 
 pnpm db:migrate:check-names  # Verify
 ```

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "db:migrate:deploy": "prisma migrate deploy",
     "db:migrate:reset": "prisma migrate reset",
     "db:migrate:status": "prisma migrate status",
+    "db:migrate:check-names": "node scripts/check-migration-naming.mjs",
     "bump-deps-minor": "ncu --target minor -u && pnpm install",
     "bump-deps": "ncu -x recharts -u && pnpm install",
     "bump-ui": "npx shadcn@latest add --all --overwrite",

--- a/scripts/__tests__/check-migration-naming.test.ts
+++ b/scripts/__tests__/check-migration-naming.test.ts
@@ -27,6 +27,13 @@ describe("MIGRATION_NAME_PATTERN", () => {
     expect(MIGRATION_NAME_PATTERN.test("0001")).toBe(false);
     expect(MIGRATION_NAME_PATTERN.test("0001_")).toBe(false);
   });
+
+  it("rejects trailing or doubled underscores in the description", () => {
+    expect(MIGRATION_NAME_PATTERN.test("0001_add_")).toBe(false);
+    expect(MIGRATION_NAME_PATTERN.test("0001___")).toBe(false);
+    expect(MIGRATION_NAME_PATTERN.test("0001_add__settings")).toBe(false);
+    expect(MIGRATION_NAME_PATTERN.test("0001__initial")).toBe(false);
+  });
 });
 
 describe("validateMigrationNames", () => {
@@ -90,18 +97,26 @@ describe("validateMigrationNames", () => {
     ];
 
     const errors = validateMigrationNames(entries);
-    // Both 0002s sort after 0001; the second one in sort order is at index 2,
-    // expects prefix 0003. Either way, at least one ordering error is reported.
-    expect(errors.length).toBeGreaterThan(0);
-    expect(errors.some((e) => e.includes("0002"))).toBe(true);
+    // After sort: ["0001_initial", "0002_first", "0002_second"]. The second
+    // 0002 sits at index 2 where prefix 0003 is expected, so exactly one
+    // sequential-error is emitted (for "0002_second"). Tighter than
+    // toBeGreaterThan(0) so a future regression that double-reports or
+    // suppresses errors fails the test.
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('"0002_second"');
+    expect(errors[0]).toContain("expected 0003");
   });
 
   it("flags a sequence that does not start at 0001", () => {
     const entries = [dir("0002_skipped_one"), dir("0003_second")];
 
     const errors = validateMigrationNames(entries);
+    // Both entries are wrong: "0002_skipped_one" is at index 0 (expected 0001)
+    // and "0003_second" is at index 1 (expected 0002), so the validator emits
+    // one error per entry.
     expect(errors).toHaveLength(2);
     expect(errors[0]).toContain("expected 0001");
+    expect(errors[1]).toContain("expected 0002");
   });
 
   it("returns multiple errors when several names break the rules", () => {
@@ -112,7 +127,13 @@ describe("validateMigrationNames", () => {
     ];
 
     const errors = validateMigrationNames(entries);
+    // Expected: one regex error for "not-a-migration", one sequential error
+    // for "0003_skipped_two" (expected 0002 at index 1 of the sorted valid
+    // list). Asserting on both messages — not just the count — guards against
+    // a refactor that merges or drops one of them.
     expect(errors).toHaveLength(2);
+    expect(errors.some((e) => e.includes('"not-a-migration"'))).toBe(true);
+    expect(errors.some((e) => e.includes('"0003_skipped_two"'))).toBe(true);
   });
 
   it("treats an empty migrations directory as valid", () => {

--- a/scripts/__tests__/check-migration-naming.test.ts
+++ b/scripts/__tests__/check-migration-naming.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import {
+  MIGRATION_NAME_PATTERN,
+  validateMigrationNames,
+} from "../check-migration-naming.mjs";
+
+type Entry = { name: string; isDirectory: boolean };
+
+const dir = (name: string): Entry => ({ name, isDirectory: true });
+const file = (name: string): Entry => ({ name, isDirectory: false });
+
+describe("MIGRATION_NAME_PATTERN", () => {
+  it("matches the canonical 4-digit snake-case form", () => {
+    expect(MIGRATION_NAME_PATTERN.test("0001_initial")).toBe(true);
+    expect(MIGRATION_NAME_PATTERN.test("0042_add_calendar_settings")).toBe(
+      true
+    );
+    expect(MIGRATION_NAME_PATTERN.test("9999_x")).toBe(true);
+  });
+
+  it("rejects short prefixes, uppercase, hyphens, and timestamps", () => {
+    expect(MIGRATION_NAME_PATTERN.test("001_initial")).toBe(false);
+    expect(MIGRATION_NAME_PATTERN.test("00001_initial")).toBe(false);
+    expect(MIGRATION_NAME_PATTERN.test("0001_AddSettings")).toBe(false);
+    expect(MIGRATION_NAME_PATTERN.test("0001_add-settings")).toBe(false);
+    expect(MIGRATION_NAME_PATTERN.test("20260427120000_initial")).toBe(false);
+    expect(MIGRATION_NAME_PATTERN.test("0001")).toBe(false);
+    expect(MIGRATION_NAME_PATTERN.test("0001_")).toBe(false);
+  });
+});
+
+describe("validateMigrationNames", () => {
+  it("returns no errors for the canonical sequential set", () => {
+    const entries = [
+      dir("0001_initial"),
+      dir("0002_add_scheduler_settings"),
+      dir("0003_unique_account_user_provider"),
+      dir("0004_add_calendar_settings"),
+      file("migration_lock.toml"),
+    ];
+
+    expect(validateMigrationNames(entries)).toEqual([]);
+  });
+
+  it("ignores non-directory entries (lock files, README)", () => {
+    const entries = [
+      file("migration_lock.toml"),
+      file("README.md"),
+      dir("0001_initial"),
+    ];
+
+    expect(validateMigrationNames(entries)).toEqual([]);
+  });
+
+  it("flags a name that doesn't match the regex", () => {
+    const entries = [dir("0001_initial"), dir("not-a-migration")];
+
+    const errors = validateMigrationNames(entries);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('Invalid migration name: "not-a-migration"');
+  });
+
+  it("flags a Prisma-default timestamp-prefixed name", () => {
+    const entries = [dir("0001_initial"), dir("20260427120000_add_settings")];
+
+    const errors = validateMigrationNames(entries);
+    expect(errors.some((e) => e.includes("20260427120000_add_settings"))).toBe(
+      true
+    );
+  });
+
+  it("flags a gap in the sequence", () => {
+    const entries = [
+      dir("0001_initial"),
+      dir("0002_second"),
+      dir("0004_skipped_three"),
+    ];
+
+    const errors = validateMigrationNames(entries);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('"0004_skipped_three"');
+    expect(errors[0]).toContain("expected 0003");
+  });
+
+  it("flags a duplicate prefix", () => {
+    const entries = [
+      dir("0001_initial"),
+      dir("0002_first"),
+      dir("0002_second"),
+    ];
+
+    const errors = validateMigrationNames(entries);
+    // Both 0002s sort after 0001; the second one in sort order is at index 2,
+    // expects prefix 0003. Either way, at least one ordering error is reported.
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors.some((e) => e.includes("0002"))).toBe(true);
+  });
+
+  it("flags a sequence that does not start at 0001", () => {
+    const entries = [dir("0002_skipped_one"), dir("0003_second")];
+
+    const errors = validateMigrationNames(entries);
+    expect(errors).toHaveLength(2);
+    expect(errors[0]).toContain("expected 0001");
+  });
+
+  it("returns multiple errors when several names break the rules", () => {
+    const entries = [
+      dir("not-a-migration"),
+      dir("0001_initial"),
+      dir("0003_skipped_two"),
+    ];
+
+    const errors = validateMigrationNames(entries);
+    expect(errors).toHaveLength(2);
+  });
+
+  it("treats an empty migrations directory as valid", () => {
+    expect(validateMigrationNames([])).toEqual([]);
+    expect(validateMigrationNames([file("migration_lock.toml")])).toEqual([]);
+  });
+
+  it("processes names in numeric order even when input is shuffled", () => {
+    const entries = [dir("0003_third"), dir("0001_first"), dir("0002_second")];
+
+    expect(validateMigrationNames(entries)).toEqual([]);
+  });
+});

--- a/scripts/check-migration-naming.mjs
+++ b/scripts/check-migration-naming.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+// Validates Prisma migration directory names match the project convention:
+// NNNN_snake_case_description, with NNNN a strictly increasing 4-digit prefix
+// starting at 0001. See docs/database.md for the rationale.
+import { readdirSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const MIGRATION_NAME_PATTERN = /^[0-9]{4}_[a-z0-9_]+$/;
+
+/**
+ * @typedef {{ name: string; isDirectory: boolean }} MigrationEntry
+ */
+
+/**
+ * Validate a list of migration directory entries.
+ *
+ * @param {MigrationEntry[]} entries
+ * @returns {string[]} list of error messages (empty when everything is valid)
+ */
+export function validateMigrationNames(entries) {
+  const errors = [];
+
+  const dirNames = entries
+    .filter((e) => e.isDirectory)
+    .map((e) => e.name)
+    .sort();
+
+  for (const name of dirNames) {
+    if (!MIGRATION_NAME_PATTERN.test(name)) {
+      errors.push(
+        `Invalid migration name: "${name}". Expected NNNN_snake_case_description (e.g. "0005_add_meal_planning"). See docs/database.md.`
+      );
+    }
+  }
+
+  const valid = dirNames.filter((n) => MIGRATION_NAME_PATTERN.test(n));
+  for (let i = 0; i < valid.length; i++) {
+    const prefix = Number.parseInt(valid[i].slice(0, 4), 10);
+    const expected = i + 1;
+    if (prefix !== expected) {
+      const expectedPrefix = String(expected).padStart(4, "0");
+      errors.push(
+        `Migration "${valid[i]}" has prefix ${String(prefix).padStart(4, "0")}, ` +
+          `expected ${expectedPrefix}. Prefixes must be strictly sequential ` +
+          `starting at 0001 (no gaps, no duplicates).`
+      );
+    }
+  }
+
+  return errors;
+}
+
+/**
+ * Read entries (files + directories) from a real filesystem path.
+ *
+ * @param {string} dir
+ * @returns {MigrationEntry[]}
+ */
+export function readMigrationEntries(dir) {
+  return readdirSync(dir).map((name) => {
+    const fullPath = join(dir, name);
+    return { name, isDirectory: statSync(fullPath).isDirectory() };
+  });
+}
+
+function main() {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const migrationsDir = resolve(here, "..", "prisma", "migrations");
+
+  const entries = readMigrationEntries(migrationsDir);
+  const errors = validateMigrationNames(entries);
+
+  if (errors.length > 0) {
+    for (const err of errors) {
+      console.error(`::error::${err}`);
+    }
+    console.error(
+      `\nFound ${errors.length} migration-naming problem(s). Fix the above and re-run.`
+    );
+    process.exit(1);
+  }
+
+  const count = entries.filter((e) => e.isDirectory).length;
+  console.log(
+    `✓ ${count} migration${count === 1 ? "" : "s"} follow the NNNN_snake_case convention`
+  );
+}
+
+const invokedDirectly =
+  import.meta.url === `file://${process.argv[1]}` ||
+  import.meta.url === `file://${resolve(process.argv[1] ?? "")}`;
+
+if (invokedDirectly) {
+  main();
+}

--- a/scripts/check-migration-naming.mjs
+++ b/scripts/check-migration-naming.mjs
@@ -2,11 +2,13 @@
 // Validates Prisma migration directory names match the project convention:
 // NNNN_snake_case_description, with NNNN a strictly increasing 4-digit prefix
 // starting at 0001. See docs/database.md for the rationale.
-import { readdirSync, statSync } from "node:fs";
+import { lstatSync, readdirSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-export const MIGRATION_NAME_PATTERN = /^[0-9]{4}_[a-z0-9_]+$/;
+// Forbids a trailing underscore and double-underscores (e.g. "0001_add_",
+// "0001___") while still accepting "0001_initial" and "0004_add_calendar_settings".
+export const MIGRATION_NAME_PATTERN = /^[0-9]{4}_[a-z0-9]+(?:_[a-z0-9]+)*$/;
 
 /**
  * @typedef {{ name: string; isDirectory: boolean }} MigrationEntry
@@ -21,6 +23,9 @@ export const MIGRATION_NAME_PATTERN = /^[0-9]{4}_[a-z0-9_]+$/;
 export function validateMigrationNames(entries) {
   const errors = [];
 
+  // Lexicographic sort equals numeric order because prefixes are always
+  // zero-padded to exactly 4 digits (0001–9999). Do not switch to a numeric
+  // comparator without revisiting the ordering invariant below.
   const dirNames = entries
     .filter((e) => e.isDirectory)
     .map((e) => e.name)
@@ -58,9 +63,13 @@ export function validateMigrationNames(entries) {
  * @returns {MigrationEntry[]}
  */
 export function readMigrationEntries(dir) {
+  // lstatSync (not statSync) so a directory-typed symlink is reported as a
+  // symlink, not as a directory. Migration directories should never be
+  // symlinks — surfacing them as non-directory entries means they are
+  // skipped from validation rather than silently treated as real migrations.
   return readdirSync(dir).map((name) => {
     const fullPath = join(dir, name);
-    return { name, isDirectory: statSync(fullPath).isDirectory() };
+    return { name, isDirectory: lstatSync(fullPath).isDirectory() };
   });
 }
 
@@ -87,10 +96,6 @@ function main() {
   );
 }
 
-const invokedDirectly =
-  import.meta.url === `file://${process.argv[1]}` ||
-  import.meta.url === `file://${resolve(process.argv[1] ?? "")}`;
-
-if (invokedDirectly) {
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
   main();
 }

--- a/src/components/calendar/__tests__/AgendaList.test.tsx
+++ b/src/components/calendar/__tests__/AgendaList.test.tsx
@@ -62,6 +62,7 @@ function makeContext(
     addEvent: vi.fn(),
     updateEvent: vi.fn(),
     removeEvent: vi.fn(),
+    deleteEvent: vi.fn(),
     clearFilter: vi.fn(),
     refreshEvents: vi.fn(),
     isLoading: false,


### PR DESCRIPTION
Closes #219.

## Decision

Going with **option 2 — sequential `NNNN_descriptive_name`**, formalising what the codebase already does. All four existing migrations (`0001_initial`, `0002_add_scheduler_settings`, `0003_unique_account_user_provider`, `0004_add_calendar_settings`) follow this pattern, so no rename is needed.

Rationale:

- Tidier ordering for code review (4-digit prefixes line up; timestamps don't).
- Existing migrations already form a coherent sequence; switching to timestamps would require renumbering and bumping every dev's local `_prisma_migrations` row for zero functional benefit.
- The "next number" is unambiguous in PRs (timestamps can collide if two PRs are open at the same minute).

## Phase 1 — Enforcement (this commit)

- **`scripts/check-migration-naming.mjs`** scans `prisma/migrations/` and asserts that every subdirectory matches `^[0-9]{4}_[a-z0-9_]+$` *and* that prefixes are strictly sequential starting at 0001 (no gaps, no duplicates).
- **Vitest unit tests** (`scripts/__tests__/check-migration-naming.test.ts`) cover: canonical input, regex failures (uppercase, hyphens, short/long prefixes, timestamp-prefixed Prisma defaults), gaps, duplicates, not-starting-at-0001, mixed files/dirs, shuffled input order, empty directory.
- **`pnpm db:migrate:check-names`** new script.
- **CI integration** — wired into `.github/workflows/main_nextjs-template-build.yml` immediately after the existing migration-drift step so a non-conforming name fails CI on the same job.

### Drive-by

`src/components/calendar/__tests__/AgendaList.test.tsx` was missing the `deleteEvent` mock added to `ICalendarContext` in PR #197. The same one-line patch is carried by PRs #228, #229, and #244 — included here so this PR's typecheck step passes on its own.

## Phase 2 — Documentation (follow-up commit on this same PR)

- ADR-style entry in `docs/database.md` documenting the convention.
- Update `CLAUDE.md` Quick Reference to mention the rule and the new check script.

## Out of scope (deferred)

- Pre-commit hook to suggest the next `NNNN` prefix. CI catch is sufficient and the friction of the hook outweighs its value for an occasional task.
- Renaming any existing migration (none violate the rule).

## Test plan

- [x] `pnpm db:migrate:check-names` → ✓ 4 migrations follow the convention.
- [x] `pnpm test:run scripts/__tests__/check-migration-naming.test.ts` → 12/12 passing.
- [x] `pnpm test:run` → 1584/1584 passing.
- [x] `pnpm lint:fix && pnpm format:fix && pnpm check-types` clean.

---
_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01S3GHWBt1Gby2J1r5fo8kxB)_