### PR TITLE
fix(scheduler): stability and correctness bugs from PR #50 self-review

### DIFF
--- a/.claude/plans/scheduler-stability-221.md
+++ b/.claude/plans/scheduler-stability-221.md
@@ -1,0 +1,71 @@
+# Plan — Issue #221: Scheduler stability and correctness bugs
+
+Source: https://github.com/BenSeymourODB/next-digital-wall-calendar/issues/221
+
+## Triage of the seven listed bugs
+
+Audited against current `main`:
+
+- **Bug 3** (midnight wraparound in `isTimeMatch`) — already fixed at `src/lib/scheduler/time-utils.ts:23` (`Math.min(diff, 1440 - diff)`); test coverage at `time-utils.test.ts:50-62`.
+- **Bug 4** (time-specific check skips initial run) — already fixed at `use-screen-scheduler.ts:242` (`setTimeout(checkTimeSpecific, 0)`).
+- **Bug 5** (module-level mutable `idCounter`) — already fixed; `crypto.randomUUID()` is used at `schedule-config.ts:43,62`. No `idCounter` references in tree.
+- **Bug 6** (countdown drift via separate `setInterval`) — already fixed; a single 1-second tick at `use-screen-scheduler.ts:186-200` drives both countdown and navigation, eliminating drift.
+- **Bug 1** (unstable `controls` object) — **remains**. `controls` is recreated each render at `use-screen-scheduler.ts:279-286` and is used as a `useEffect` dep at `screen-scheduler.tsx:81` and `:142`.
+- **Bug 2** (pause/resume oscillation + manual-unpause lockout) — **remains**. `useInteractionDetector` owns its own `isPaused` state. `useScreenScheduler.resume()` clears `state.isPaused` but does not propagate into the interaction detector, so `effectivelyPaused = state.isPaused || isInteractionPaused` keeps the scheduler paused. The toggle button is functionally inert during the interaction-pause window.
+- **Bug 7** (`ScreenTransition` geometry/timer race) — **remains**. Two-phase (`exiting` → `entering`) model with separate timers means the total animation runs `2 × durationMs`. During `exiting`, incoming children render at `translateX(0)` opacity 1 (so the user briefly sees the new content at final position before it snaps back to start in `entering`). `direction` is read every render with no snapshot, so a mid-flight prop change can flip the keyframe.
+
+## Phases
+
+### Phase 1 — Backfill regression tests for already-fixed bugs
+
+Lock in correctness so a future refactor cannot silently regress these.
+
+- `time-utils.test.ts` — confirm midnight tests exist (they do). Add a comment describing the regression they cover. Add a test asserting that `isTimeMatch(00:00, 23:59)` and `isTimeMatch(23:59, 00:00)` both return `true` while `isTimeMatch(00:00, 23:58)` returns `false` (already covered, double-check).
+- `schedule-config.test.ts` — add a test asserting that two newly-built sequences receive distinct ids (regression for the old shared `idCounter`).
+- `use-screen-scheduler.test.ts` — add a test asserting that the time-specific check runs on the next microtask after `start()`, not after a 60-second delay (regression for the deferred initial check).
+- `use-screen-scheduler.test.ts` — add a test asserting that the countdown remains in lock-step with auto-rotation across N intervals (regression for the dual-interval drift).
+
+Acceptance: all four regression tests pass without touching production code.
+
+### Phase 2 — Bugs #1 + #2 (controls stability + manual-unpause lockout)
+
+Tests first:
+
+- New test in `use-screen-scheduler.test.ts`: `controls` reference is identical across renders triggered by unrelated state changes (e.g. countdown ticks).
+- New test in `use-interaction-detector.test.ts`: returned `release()` clears the pause timer and resets `isPaused` to `false` immediately.
+- New test in `screen-scheduler.test.tsx`: clicking the resume button while the interaction detector is paused unpauses the scheduler.
+
+Implementation:
+
+- `use-screen-scheduler.ts`: hold each control implementation in a ref refreshed every render via a single combined-update effect; build a `controls` object once via `useState` (init function) whose methods forward to the refs. This produces a stable identity without `useMemo`/`useCallback` (forbidden under React Compiler).
+- `use-interaction-detector.ts`: extend the result with a `release()` function that clears the timeout ref and sets `isPaused` to `false`. Wrap with the same ref-trick for stable identity.
+- `screen-scheduler.tsx`: when the user calls `resume` (or toggles via Space), invoke `interactionDetector.release()` immediately so the manual action terminates the interaction-pause window.
+
+### Phase 3 — Bug #7 (ScreenTransition rewrite)
+
+Port AnimatedSwap's single-phase model to `ScreenTransition`.
+
+Tests first (extend `screen-transition.test.tsx`):
+
+- Total animation duration is `durationMs` (not `2 × durationMs`). Asserted by checking that after `durationMs` the snapshot is gone and the testid `transition-idle` is rendered.
+- Direction snapshot: trigger a swap with `direction="forward"`, then change `direction="backward"` mid-animation, and assert the in-flight outgoing keyframe still uses the forward exit transform.
+- Rapid swaps: two pathname changes within `durationMs / 2` correctly restart the timer and animation; the final idle state arrives at start + 1.5 × durationMs (or whatever the math says), not earlier.
+- Reduced-motion flipped on mid-animation collapses to idle.
+
+Implementation:
+
+- Replace `phase: "exiting" | "entering"` with `phase: "animating" | "idle"`.
+- Snapshot geometry at swap start (`useState`).
+- Use a single `useEffect` keyed on `[phase, durationMs, animationId]` driving one timer.
+- Use `animationId` to suffix `@keyframes` names and re-mount keyed nodes for clean restart.
+- Update incoming/outgoing markup to mirror AnimatedSwap.
+
+## Test commands
+
+After every phase: `pnpm lint:fix && pnpm format:fix && pnpm check-types && pnpm test`.
+
+## Out of scope
+
+- New scheduler features.
+- Public API changes to the scheduler (signatures stay compatible).
+- Visual redesign of the navigation controls.

--- a/src/components/scheduler/__tests__/use-screen-scheduler.test.ts
+++ b/src/components/scheduler/__tests__/use-screen-scheduler.test.ts
@@ -446,4 +446,113 @@ describe("useScreenScheduler", () => {
       expect(result.current.state.isPaused).toBe(false);
     });
   });
+
+  // Regression: issue #221 bug 4 — previously the time-specific check was
+  // gated behind the first 60-second tick of `setInterval`, so a scheduler
+  // started inside an active window stayed in sequence-rotation mode for up
+  // to a minute. The hook now schedules an immediate `setTimeout(..., 0)`
+  // alongside the 60s interval; this test pins that contract.
+  describe("regression: time-specific check runs immediately (issue #221, bug 4)", () => {
+    it("activates the matching time-specific entry on the next microtask, not after 60s", () => {
+      const configWithTimeSpecific: ScheduleConfig = {
+        sequences: [
+          {
+            id: "seq-1",
+            name: "Main",
+            enabled: true,
+            screens: ["/calendar", "/tasks"],
+            intervalSeconds: 60,
+            pauseOnInteractionSeconds: 120,
+          },
+        ],
+        timeSpecific: [
+          {
+            id: "ts-1",
+            enabled: true,
+            screen: "/recipe",
+            time: "08:00",
+            durationMinutes: 30,
+          },
+        ],
+      };
+
+      // Boot the scheduler INSIDE the active window for ts-1.
+      vi.setSystemTime(new Date(2024, 2, 15, 8, 0, 0));
+
+      const { result } = renderHook(() =>
+        useScreenScheduler(configWithTimeSpecific)
+      );
+
+      act(() => {
+        result.current.controls.start();
+      });
+
+      // Just one tick of fake time — well below the 60s interval — must be
+      // enough for the immediate check to fire.
+      act(() => {
+        vi.advanceTimersByTime(0);
+      });
+
+      expect(result.current.state.activeTimeSpecific?.id).toBe("ts-1");
+    });
+  });
+
+  // Regression: issue #221 bug 6 — earlier the countdown ran on its own
+  // 1-second interval while auto-rotation ran on its own N-second interval,
+  // so the two clocks drifted (and the displayed "time until next" was
+  // incorrect after long uptimes). Both are now driven by a single 1-second
+  // tick; this test pins the lock-step behaviour across multiple intervals.
+  describe("regression: countdown stays in lock-step with rotation (issue #221, bug 6)", () => {
+    it("decrements every second and resets cleanly on each rotation", () => {
+      mockPathname.mockReturnValue("/calendar");
+      const shortConfig: ScheduleConfig = {
+        sequences: [
+          {
+            id: "seq-1",
+            name: "Main",
+            enabled: true,
+            screens: ["/calendar", "/recipe", "/tasks"],
+            intervalSeconds: 5,
+            pauseOnInteractionSeconds: 120,
+          },
+        ],
+        timeSpecific: [],
+      };
+
+      const { result } = renderHook(() => useScreenScheduler(shortConfig));
+
+      act(() => {
+        result.current.controls.start();
+      });
+      expect(result.current.state.timeUntilNextNav).toBe(5);
+
+      // After one tick the countdown is strictly less than 5 — i.e. it is
+      // actually decrementing rather than being reset by a separate timer.
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+      expect(result.current.state.timeUntilNextNav).toBeLessThan(5);
+      expect(result.current.state.timeUntilNextNav).toBeGreaterThanOrEqual(3);
+
+      // Cross the first interval boundary. Rotation must fire AND the
+      // countdown must reset to the configured `intervalSeconds` (5),
+      // proving both clocks share the same source of truth.
+      act(() => {
+        vi.advanceTimersByTime(5000);
+      });
+      expect(mockPush).toHaveBeenLastCalledWith("/recipe");
+      expect(result.current.state.timeUntilNextNav).toBe(5);
+
+      // Two more full intervals must rotate exactly two more times, with
+      // the countdown landing back on 5 at the end. A drifting countdown
+      // would diverge from the rotation by tens of seconds across many
+      // cycles; this assertion catches even single-tick drift early.
+      const pushesAfterFirst = mockPush.mock.calls.length;
+      act(() => {
+        vi.advanceTimersByTime(10000);
+      });
+      expect(mockPush.mock.calls.length).toBe(pushesAfterFirst + 2);
+      expect(result.current.state.timeUntilNextNav).toBe(5);
+    });
+  });
 });

--- a/src/lib/scheduler/__tests__/schedule-config.test.ts
+++ b/src/lib/scheduler/__tests__/schedule-config.test.ts
@@ -65,6 +65,18 @@ describe("createDefaultSequence", () => {
     expect(seq1.id).not.toBe(seq2.id);
   });
 
+  // Regression: issue #221 bug 5 — earlier implementations relied on a
+  // module-level mutable `idCounter` that risked collisions across SSR
+  // hydration boundaries and test runs. `crypto.randomUUID()` is now used,
+  // and any future regression to a counter would surface here.
+  it("regression (issue #221, bug 5): produces distinct ids across many calls", () => {
+    const ids = new Set<string>();
+    for (let i = 0; i < 64; i += 1) {
+      ids.add(createDefaultSequence().id);
+    }
+    expect(ids.size).toBe(64);
+  });
+
   it("uses SCHEDULER_DEFAULTS when no overrides provided", () => {
     const seq = createDefaultSequence();
     expect(seq.intervalSeconds).toBe(SCHEDULER_DEFAULTS.intervalSeconds);
@@ -129,6 +141,16 @@ describe("createDefaultTimeSpecific", () => {
     const nav1 = createDefaultTimeSpecific();
     const nav2 = createDefaultTimeSpecific();
     expect(nav1.id).not.toBe(nav2.id);
+  });
+
+  // Regression: issue #221 bug 5 — see `createDefaultSequence`'s matching
+  // regression above. Same root cause, different factory.
+  it("regression (issue #221, bug 5): produces distinct ids across many calls", () => {
+    const ids = new Set<string>();
+    for (let i = 0; i < 64; i += 1) {
+      ids.add(createDefaultTimeSpecific().id);
+    }
+    expect(ids.size).toBe(64);
   });
 
   it("is enabled by default", () => {

--- a/src/lib/scheduler/__tests__/time-utils.test.ts
+++ b/src/lib/scheduler/__tests__/time-utils.test.ts
@@ -61,6 +61,28 @@ describe("isTimeMatch", () => {
     const current = new Date(2024, 2, 15, 0, 0, 0);
     expect(isTimeMatch(current, "23:58")).toBe(false);
   });
+
+  // Regression: issue #221 bug 3 — naive `Math.abs(curr - sched)` produced a
+  // diff of 1439 minutes between 23:59 and 00:00 instead of 1, so a scheduled
+  // 23:59 entry would silently miss its 60s firing window once the clock
+  // ticked past midnight. The wraparound is now handled by
+  // `Math.min(diff, 1440 - diff)` and these cases lock that in.
+  describe("regression: midnight wraparound (issue #221, bug 3)", () => {
+    it("scheduled 23:59 still matches at 00:00 the next day", () => {
+      expect(isTimeMatch(new Date(2024, 2, 16, 0, 0, 0), "23:59")).toBe(true);
+    });
+
+    it("scheduled 00:00 still matches at 23:59 the previous day", () => {
+      expect(isTimeMatch(new Date(2024, 2, 15, 23, 59, 0), "00:00")).toBe(true);
+    });
+
+    it("rejects a 2-minute gap across the midnight boundary", () => {
+      expect(isTimeMatch(new Date(2024, 2, 16, 0, 0, 0), "23:58")).toBe(false);
+      expect(isTimeMatch(new Date(2024, 2, 15, 23, 58, 0), "00:00")).toBe(
+        false
+      );
+    });
+  });
 });
 
 describe("isActiveDay", () => {


### PR DESCRIPTION
## Summary

Closes part of #221.

The seven bugs listed in #221 break down as follows:

| # | Bug | Status before this PR |
|---|-----|----|
| 3 | Midnight wraparound in `isTimeMatch()` | Already fixed on `main` (`Math.min(diff, 1440 - diff)` at `src/lib/scheduler/time-utils.ts:23`); no regression test labeled as such. |
| 4 | Time-specific check skips initial run | Already fixed — `setTimeout(checkTimeSpecific, 0)` at `use-screen-scheduler.ts:242`; no regression test. |
| 5 | Module-level mutable `idCounter` | Already fixed — `crypto.randomUUID()` at `schedule-config.ts:43,62`; one weak test (`!== other`). |
| 6 | Countdown drift | Already fixed — single 1-second tick drives both countdown and rotation at `use-screen-scheduler.ts:186-200`; no regression test. |
| 1 | Unstable `controls` object | Still present. |
| 2 | Pause/resume oscillation + manual-unpause lockout | Still present. |
| 7 | `ScreenTransition` geometry/timer-race | Still present. |

This PR (Phase 1 of three planned phases) **lands regression tests for the four already-fixed bugs** so a future refactor cannot silently regress them. Phases 2 and 3 will follow on the same branch.

## Phases

- [x] **Phase 1 — backfill regression tests** for bugs 3, 4, 5, 6 _(this commit)_
- [ ] Phase 2 — bugs 1 (stable `controls`) and 2 (manual-unpause lockout)
- [ ] Phase 3 — bug 7 (`ScreenTransition` rewrite to AnimatedSwap-style single-phase)

Plan saved to `.claude/plans/scheduler-stability-221.md`.

## Test plan

- [x] `pnpm test:run src/components/scheduler src/lib/scheduler` — 144 / 144 passing (was 137).
- [x] `pnpm format:fix` — clean.
- [x] `pnpm lint:fix` — only pre-existing warnings outside this PR's scope.
- [ ] `pnpm check-types` — pre-existing failure in `src/components/calendar/__tests__/AgendaList.test.tsx` (`deleteEvent` typing issue from a prior PR, unrelated). Will not fix in this PR.

https://claude.ai/code/session_015itGnHvivyWyUdzarGVKA5

---
_Generated by [Claude Code](https://claude.ai/code/session_015itGnHvivyWyUdzarGVKA5)_