### PR TITLE
fix(calendar): split-button ViewSwitcher + dropdown modal=false (#235)

### DIFF
--- a/.claude/plans/viewswitcher-split-button.md
+++ b/.claude/plans/viewswitcher-split-button.md
@@ -1,0 +1,85 @@
+# ViewSwitcher Split Button + Popover Pointer Fix — Implementation Plan
+
+> Addresses GitHub Issue #235.
+
+## Goal
+
+Replace the Day/Week single-button-as-dropdown UI in `ViewSwitcher` with a
+proper split-button UX (primary "switch view" button + caret that opens the
+Grid/Agenda menu). Eliminate the Radix-popover pointer-events leak that was
+blocking subsequent clicks after the popover closed.
+
+## Problem recap
+
+`ViewSwitcher` (post-#150) makes the entire Day/Week button a dropdown trigger.
+That:
+
+1. Hides the primary "switch view" affordance — sighted users have no signal
+   that there is a sub-menu, even though the button has a chevron.
+2. Breaks any test or naïve user interaction that clicks
+   `view-switcher-day` expecting to switch views, since clicking opens a
+   popover with Grid/Agenda options.
+3. After the popover closes, pointer-events on the body remain trapped under
+   the Radix modal overlay, so the next click on (e.g.) Year/Month is
+   intercepted.
+
+## Design — Option (a) from the issue
+
+Split each Day/Week control into two adjacent buttons sharing visual borders:
+
+```
+┌─────────────┬───┐
+│ ☐ Day · …   │ ▾ │
+└─────────────┴───┘
+   primary    caret
+```
+
+- **Primary button** (`data-testid="view-switcher-day"` / `…-week"`) — plain
+  `Button`, switches the view via `setView(view)`. Preserves the user's
+  current `agendaMode` setting (it is global state, set deliberately).
+- **Caret button** (`data-testid="view-switcher-day-mode"` / `…-week-mode"`) —
+  `DropdownMenu` trigger that opens a `Grid`/`Agenda` `RadioGroup`. Picking an
+  option both `setView(view)` and `setAgendaMode(mode === "agenda")`.
+- **`aria-label`** on the caret describes its purpose for screen readers
+  (e.g. `"Choose day display mode"`), since its visible content is just an
+  icon.
+- **`modal={false}`** on the `DropdownMenu` to stop Radix from installing the
+  body-level pointer-blocking overlay. This is the root fix for the
+  "popover doesn't release pointer cleanly" complaint.
+
+The primary button keeps the existing visible label that reflects the current
+mode (`Day` vs `Day · Agenda`) so sighted users still see the sub-mode at a
+glance.
+
+## Phases
+
+1. **Component tests + implementation.** Update
+   `src/components/calendar/__tests__/ViewSwitcher.test.tsx` to assert the
+   new behaviour (primary click switches view, caret click opens menu, primary
+   button has no `aria-haspopup`, caret has `aria-haspopup="menu"` and an
+   accessible label). Implement the split-button structure in
+   `ViewSwitcher.tsx`.
+2. **E2E spec updates.** Update existing Playwright specs that exercised the
+   broken affordance to click the caret instead of the primary button:
+   - `e2e/agenda-toggle.spec.ts`
+   - `e2e/week-day-views.spec.ts`
+   - `e2e/calendar.spec.ts`
+     Add a focused regression spec proving:
+   - Primary `view-switcher-week` click switches to week view (no menu).
+   - Primary click followed by an immediate Year click does not get
+     intercepted (regression for the pointer-events leak).
+3. **Verification + PR.** `pnpm test`, `pnpm lint:fix`, `pnpm format:fix`,
+   `pnpm check-types`. Push, open draft PR, mark ready when green.
+
+## Acceptance criteria (from issue + plan)
+
+- [ ] Day and Week render as split buttons (primary + caret).
+- [ ] Clicking the primary button switches view without opening the menu.
+- [ ] Clicking the caret opens the Grid/Agenda menu.
+- [ ] Caret has `aria-haspopup="menu"` and a screen-reader-friendly label.
+- [ ] `DropdownMenu` opened from the caret uses `modal={false}` to prevent
+      pointer-events leakage onto sibling buttons.
+- [ ] No regression in existing E2E specs (after they are updated to click
+      the caret where they were exercising the menu).
+- [ ] `pnpm test && pnpm lint:fix && pnpm format:fix && pnpm check-types`
+      pass.

--- a/e2e/agenda-toggle.spec.ts
+++ b/e2e/agenda-toggle.spec.ts
@@ -1,27 +1,32 @@
 /**
- * E2E coverage for the agenda toggle inside Day and Week views (issue #150).
+ * E2E coverage for the agenda toggle inside Day and Week views (issues #150 +
+ * #235).
+ *
+ * Day and Week are split buttons after #235:
+ *   - The primary `view-switcher-day` / `view-switcher-week` button switches
+ *     view (preserving the global agenda mode).
+ *   - A separate caret `view-switcher-day-mode` / `view-switcher-week-mode`
+ *     opens the Grid/Agenda menu.
  *
  * Video is captured for the full Day → Day+Agenda → Week+Agenda → Week →
- * Month round-trip so the grid ↔ agenda fade and the dropdown UX can be
- * reviewed as part of the PR. Animation behavior is shared with #87 — the
- * composite swap key (`day:agenda` / `week:agenda`) drives the same
- * AnimatedSwap wrapper as a primary-view change.
+ * Month round-trip so the grid ↔ agenda fade and the new split-button UX
+ * can be reviewed as part of the PR.
  */
 import { expect, test } from "@playwright/test";
 
 test.use({ video: "on", viewport: { width: 1280, height: 720 } });
 
-test.describe("Agenda toggle inside Day and Week views (#150)", () => {
+test.describe("Agenda toggle inside Day and Week views (#150 + #235)", () => {
   test("Day → Day+Agenda → Week+Agenda → Week → Month round-trip", async ({
     page,
   }) => {
-    // Start in Day view (grid). The Day dropdown trigger reflects "Day".
+    // Start in Day view (grid).
     await page.goto("/test/calendar?events=default&view=day");
     await expect(page.getByTestId("day-calendar-grid")).toBeVisible();
     await expect(page.getByTestId("agenda-list")).toHaveCount(0);
 
-    // Day → Day+Agenda via the Day dropdown.
-    await page.getByTestId("view-switcher-day").click();
+    // Day → Day+Agenda via the Day caret.
+    await page.getByTestId("view-switcher-day-mode").click();
     await page.getByRole("menuitemradio", { name: /agenda/i }).click();
 
     // The grid is gone, AgendaList is in. Day header is still visible.
@@ -29,10 +34,9 @@ test.describe("Agenda toggle inside Day and Week views (#150)", () => {
     await expect(page.getByTestId("agenda-list")).toBeVisible();
     await expect(page.getByTestId("day-calendar-heading")).toBeVisible();
 
-    // Switching to Week + Agenda from Day+Agenda should commit both a
-    // view change and keep agenda mode on. The Week trigger is also a
-    // dropdown — Agenda sub-option drives the transition.
-    await page.getByTestId("view-switcher-week").click();
+    // Switching to Week + Agenda from Day+Agenda commits both a view change
+    // and keeps agenda mode on via the Week caret's Agenda sub-option.
+    await page.getByTestId("view-switcher-week-mode").click();
     await page.getByRole("menuitemradio", { name: /agenda/i }).click();
 
     // Week range header replaces Day header; AgendaList stays.
@@ -40,7 +44,7 @@ test.describe("Agenda toggle inside Day and Week views (#150)", () => {
     await expect(page.getByTestId("week-calendar-range")).toBeVisible();
 
     // Week+Agenda → Week (grid) via the Grid sub-option.
-    await page.getByTestId("view-switcher-week").click();
+    await page.getByTestId("view-switcher-week-mode").click();
     await page.getByRole("menuitemradio", { name: /grid/i }).click();
 
     // Week time-grid is back, AgendaList is gone.
@@ -52,6 +56,33 @@ test.describe("Agenda toggle inside Day and Week views (#150)", () => {
     await expect(page.getByTestId("calendar-display")).toBeVisible();
     // Month grid renders the weekday-header row "Sun…Sat".
     await expect(page.getByText("Sun", { exact: true }).first()).toBeVisible();
+  });
+
+  test("primary Day button switches view directly (no menu) — #235", async ({
+    page,
+  }) => {
+    // Start in Month so the primary Day click is a real view change.
+    await page.goto("/test/calendar?events=default&view=month");
+
+    // Click the primary Day button — should land in Day grid view, no menu.
+    await page.getByTestId("view-switcher-day").click();
+
+    await expect(page.getByTestId("day-calendar-grid")).toBeVisible();
+    await expect(page.getByRole("menuitemradio")).toHaveCount(0);
+  });
+
+  test("primary Week button preserves agenda mode — #235", async ({ page }) => {
+    // Pre-toggle Day+Agenda via the Day caret.
+    await page.goto("/test/calendar?events=default&view=day");
+    await page.getByTestId("view-switcher-day-mode").click();
+    await page.getByRole("menuitemradio", { name: /agenda/i }).click();
+    await expect(page.getByTestId("agenda-list")).toBeVisible();
+
+    // Clicking the primary Week button should switch view AND keep agenda
+    // mode on (so AgendaList stays rendered, not the week grid).
+    await page.getByTestId("view-switcher-week").click();
+    await expect(page.getByTestId("agenda-list")).toBeVisible();
+    await expect(page.getByTestId("week-calendar-range")).toBeVisible();
   });
 
   test("agenda mode preserves the selected date when toggled", async ({
@@ -67,33 +98,55 @@ test.describe("Agenda toggle inside Day and Week views (#150)", () => {
     const navigatedHeading = await heading.textContent();
     expect(navigatedHeading).not.toBe(startingHeading);
 
-    // Toggle into agenda mode — the date must not reset.
-    await page.getByTestId("view-switcher-day").click();
+    // Toggle into agenda mode via the caret — the date must not reset.
+    await page.getByTestId("view-switcher-day-mode").click();
     await page.getByRole("menuitemradio", { name: /agenda/i }).click();
     await expect(page.getByTestId("agenda-list")).toBeVisible();
 
     expect(await heading.textContent()).toBe(navigatedHeading);
   });
 
-  test("Day dropdown shows the current sub-mode in its label", async ({
-    page,
-  }) => {
+  test("primary Day label reflects the current sub-mode", async ({ page }) => {
     await page.goto("/test/calendar?events=default&view=day");
     const dayBtn = page.getByTestId("view-switcher-day");
 
-    // Initially in grid mode — the trigger reads just "Day".
+    // Initially in grid mode — the primary reads just "Day".
     await expect(dayBtn).toHaveText(/^Day$/);
 
-    // Switch to agenda — trigger now shows "Day · Agenda".
-    await dayBtn.click();
+    // Switch to agenda via the caret — primary now shows "Day · Agenda".
+    await page.getByTestId("view-switcher-day-mode").click();
     await page.getByRole("menuitemradio", { name: /agenda/i }).click();
     await expect(dayBtn).toHaveText(/Day · Agenda/);
   });
 
+  test("Year click after Week-caret menu dismissal is not intercepted — #235", async ({
+    page,
+  }) => {
+    // Regression: previously the Radix modal overlay blocked subsequent
+    // clicks on sibling buttons after the dropdown closed. With
+    // `modal={false}` the overlay is gone and Year click should land
+    // immediately.
+    await page.goto("/test/calendar?events=default&view=month");
+
+    // Open the Week caret menu, then dismiss without picking anything.
+    await page.getByTestId("view-switcher-week-mode").click();
+    await expect(
+      page.getByRole("menuitemradio", { name: /grid/i })
+    ).toBeVisible();
+    await page.keyboard.press("Escape");
+
+    // Year click must reach the button (no pointer-event interception).
+    await page.getByTestId("view-switcher-year").click();
+    await expect(page.getByTestId("view-switcher-year")).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    );
+  });
+
   test("Month is unaffected by the agenda mode setting", async ({ page }) => {
-    // Pre-toggle agenda mode via the Day dropdown.
+    // Pre-toggle agenda mode via the Day caret.
     await page.goto("/test/calendar?events=default&view=day");
-    await page.getByTestId("view-switcher-day").click();
+    await page.getByTestId("view-switcher-day-mode").click();
     await page.getByRole("menuitemradio", { name: /agenda/i }).click();
     await expect(page.getByTestId("agenda-list")).toBeVisible();
 

--- a/e2e/calendar.spec.ts
+++ b/e2e/calendar.spec.ts
@@ -324,8 +324,8 @@ test.describe("View Switcher", () => {
   }) => {
     await page.goto("/test/calendar?events=default&view=month");
 
-    // Day is a dropdown — open it and pick Agenda.
-    await page.getByTestId("view-switcher-day").click();
+    // Day is a split button — open the caret menu and pick Agenda (#235).
+    await page.getByTestId("view-switcher-day-mode").click();
     await page.getByRole("menuitemradio", { name: /agenda/i }).click();
 
     // Day-view agenda renders the AgendaList.
@@ -350,8 +350,8 @@ test.describe("View Switcher", () => {
     // Verify event in month view
     await expect(page.getByText("Morning Standup")).toBeVisible();
 
-    // Switch to day-agenda mode via the dropdown.
-    await page.getByTestId("view-switcher-day").click();
+    // Switch to day-agenda mode via the caret menu (#235).
+    await page.getByTestId("view-switcher-day-mode").click();
     await page.getByRole("menuitemradio", { name: /agenda/i }).click();
 
     // Event should still be visible in agenda mode for the same date range.

--- a/e2e/week-day-views.spec.ts
+++ b/e2e/week-day-views.spec.ts
@@ -124,18 +124,16 @@ test.describe("View switcher navigation", () => {
     await page.goto("/test/calendar?events=default&view=month");
     await expect(page.getByText("Sun", { exact: true }).first()).toBeVisible();
 
-    // After #150, Day and Week are dropdown triggers — opening the menu
-    // and picking "Grid" lands on the time-grid view.
+    // After #235, Day and Week are split buttons — primary click switches
+    // view directly; the caret opens the Grid/Agenda menu.
     await page.getByTestId("view-switcher-week").click();
-    await page.getByRole("menuitemradio", { name: /grid/i }).click();
     await expect(page.getByTestId("week-calendar-range")).toBeVisible();
 
     await page.getByTestId("view-switcher-day").click();
-    await page.getByRole("menuitemradio", { name: /grid/i }).click();
     await expect(page.getByTestId("day-calendar-heading")).toBeVisible();
 
-    // Day → Day+Agenda via the dropdown's Agenda sub-option (#150).
-    await page.getByTestId("view-switcher-day").click();
+    // Day → Day+Agenda via the caret's Agenda sub-option (#150 + #235).
+    await page.getByTestId("view-switcher-day-mode").click();
     await page.getByRole("menuitemradio", { name: /agenda/i }).click();
     await expect(page.getByTestId("agenda-list")).toBeVisible();
 

--- a/src/components/calendar/ViewSwitcher.tsx
+++ b/src/components/calendar/ViewSwitcher.tsx
@@ -22,14 +22,24 @@ import {
 /**
  * Top-level calendar view switcher.
  *
- * Day and Week are dropdown triggers (Day ▾ / Week ▾) that surface
- * "Grid" and "Agenda" as the two display modes — matches the
- * Windows 11 / Microsoft Teams Calendar widget UX (issue #150).
- * Month, Year, and Clock are plain toggle buttons.
+ * Day and Week are split buttons:
  *
- * The dropdown commits both `setView(view)` and `setAgendaMode(mode)`
- * in a single user action so jumping from e.g. Month → Day+Agenda
- * lands in the right place without an intermediate grid flash.
+ *   ┌─────────────┬───┐
+ *   │ ☐ Day · …   │ ▾ │
+ *   └─────────────┴───┘
+ *      primary    caret
+ *
+ * The primary button switches to that view (preserving the user's global
+ * `agendaMode`). The caret opens a small Grid/Agenda RadioGroup that commits
+ * `setView(view)` AND `setAgendaMode(mode === "agenda")` in a single action,
+ * so jumping from e.g. Month → Week+Agenda lands in the right place without
+ * an intermediate grid flash.
+ *
+ * The DropdownMenu is rendered with `modal={false}` so Radix does not install
+ * the body-level overlay that was leaking pointer events to sibling buttons
+ * after dismissal (see issue #235).
+ *
+ * Month, Year, and Clock are plain primary buttons.
  */
 export function ViewSwitcher() {
   const { view, setView, agendaMode, setAgendaMode } = useCalendar();
@@ -46,21 +56,23 @@ export function ViewSwitcher() {
       aria-label="Calendar view"
       data-testid="view-switcher"
     >
-      <ModeDropdown
+      <SplitViewControl
         view="day"
         label="Day"
         icon={<CalendarDays className="h-4 w-4" />}
         active={view === "day"}
         agendaMode={agendaMode}
-        onSelect={(mode) => selectMode("day", mode)}
+        onSwitchView={() => setView("day")}
+        onSelectMode={(mode) => selectMode("day", mode)}
       />
-      <ModeDropdown
+      <SplitViewControl
         view="week"
         label="Week"
         icon={<CalendarRange className="h-4 w-4" />}
         active={view === "week"}
         agendaMode={agendaMode}
-        onSelect={(mode) => selectMode("week", mode)}
+        onSwitchView={() => setView("week")}
+        onSelectMode={(mode) => selectMode("week", mode)}
       />
       <PrimaryButton
         view="month"
@@ -118,54 +130,76 @@ function PrimaryButton({
   );
 }
 
-interface ModeDropdownProps {
+interface SplitViewControlProps {
   view: "day" | "week";
   label: string;
   icon: React.ReactNode;
   active: boolean;
   agendaMode: boolean;
-  onSelect: (mode: "grid" | "agenda") => void;
+  onSwitchView: () => void;
+  onSelectMode: (mode: "grid" | "agenda") => void;
 }
 
-function ModeDropdown({
+function SplitViewControl({
   view,
   label,
   icon,
   active,
   agendaMode,
-  onSelect,
-}: ModeDropdownProps) {
-  // Reflect the current sub-mode in the trigger label only when this
-  // dropdown's view is active; otherwise the bare label is fine.
+  onSwitchView,
+  onSelectMode,
+}: SplitViewControlProps) {
+  // Reflect the current sub-mode in the primary label only when this
+  // control's view is active; otherwise the bare label is fine.
   const subModeLabel = active && agendaMode ? `${label} · Agenda` : label;
   const currentValue = active && agendaMode ? "agenda" : "grid";
+  const variant = active ? "default" : "ghost";
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button
-          type="button"
-          variant={active ? "default" : "ghost"}
-          size="sm"
-          aria-pressed={active}
-          aria-haspopup="menu"
-          data-testid={`view-switcher-${view}`}
-          className="flex items-center gap-2"
-        >
-          {icon}
-          <span>{subModeLabel}</span>
-          <ChevronDown className="h-3 w-3 opacity-70" aria-hidden="true" />
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="start">
-        <DropdownMenuRadioGroup
-          value={currentValue}
-          onValueChange={(value) => onSelect(value as "grid" | "agenda")}
-        >
-          <DropdownMenuRadioItem value="grid">Grid</DropdownMenuRadioItem>
-          <DropdownMenuRadioItem value="agenda">Agenda</DropdownMenuRadioItem>
-        </DropdownMenuRadioGroup>
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <div
+      role="group"
+      aria-label={`${label} view`}
+      className="inline-flex items-stretch"
+    >
+      <Button
+        type="button"
+        variant={variant}
+        size="sm"
+        aria-pressed={active}
+        onClick={onSwitchView}
+        data-testid={`view-switcher-${view}`}
+        className="flex items-center gap-2 rounded-r-none pr-2"
+      >
+        {icon}
+        <span>{subModeLabel}</span>
+      </Button>
+      {/* `modal={false}` prevents Radix from installing the body-level
+          overlay that previously left sibling buttons unclickable after
+          dismissal (issue #235). */}
+      <DropdownMenu modal={false}>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            variant={variant}
+            size="sm"
+            aria-pressed={active}
+            aria-label={`Choose ${label.toLowerCase()} display mode`}
+            data-testid={`view-switcher-${view}-mode`}
+            className="rounded-l-none border-l border-l-black/10 px-1.5 dark:border-l-white/15"
+          >
+            <ChevronDown className="h-3 w-3 opacity-70" aria-hidden="true" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start">
+          <DropdownMenuRadioGroup
+            value={currentValue}
+            onValueChange={(value) => onSelectMode(value as "grid" | "agenda")}
+          >
+            <DropdownMenuRadioItem value="grid">Grid</DropdownMenuRadioItem>
+            <DropdownMenuRadioItem value="agenda">Agenda</DropdownMenuRadioItem>
+          </DropdownMenuRadioGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
   );
 }

--- a/src/components/calendar/__tests__/ViewSwitcher.test.tsx
+++ b/src/components/calendar/__tests__/ViewSwitcher.test.tsx
@@ -1,10 +1,20 @@
 /**
- * Tests for the post-#150 ViewSwitcher.
+ * Tests for the post-#235 ViewSwitcher.
  *
- * The flat tab row is replaced by a row of buttons. Day and Week are now
- * dropdown triggers (Day ▾ / Week ▾) that surface "Grid" and "Agenda" as
- * sub-options matching the Windows / Teams Calendar widget UX. Month, Year,
- * and Clock stay as plain buttons.
+ * The Day/Week controls are split buttons:
+ *   ┌─────────────┬───┐
+ *   │ ☐ Day · …   │ ▾ │
+ *   └─────────────┴───┘
+ *      primary    caret
+ *
+ * - Primary button (data-testid="view-switcher-day" / "view-switcher-week"):
+ *     plain button that switches the view. Preserves agendaMode (global).
+ * - Caret button (data-testid="view-switcher-day-mode" / "view-switcher-week-mode"):
+ *     DropdownMenu trigger that surfaces "Grid" / "Agenda" radio items.
+ *     Picking one commits both setView(view) and setAgendaMode(mode === "agenda").
+ *
+ * Month / Year / Clock stay as plain primary buttons. Agenda is not a
+ * primary button — it is a sub-mode of Day/Week.
  */
 import {
   CalendarContext,
@@ -71,9 +81,9 @@ function renderWithContext(overrides: Partial<ICalendarContext> = {}) {
   };
 }
 
-describe("ViewSwitcher (#150)", () => {
+describe("ViewSwitcher (#235 split-button affordance)", () => {
   describe("primary buttons", () => {
-    it("renders Day, Week, Month, Year, and Clock controls", () => {
+    it("renders Day, Week, Month, Year, and Clock primary controls", () => {
       renderWithContext();
       expect(screen.getByTestId("view-switcher-day")).toBeInTheDocument();
       expect(screen.getByTestId("view-switcher-week")).toBeInTheDocument();
@@ -82,14 +92,14 @@ describe("ViewSwitcher (#150)", () => {
       expect(screen.getByTestId("view-switcher-clock")).toBeInTheDocument();
     });
 
-    it("does NOT render an Agenda primary button (agenda is now a sub-mode)", () => {
+    it("does NOT render an Agenda primary button (agenda is a sub-mode)", () => {
       renderWithContext();
       expect(
         screen.queryByTestId("view-switcher-agenda")
       ).not.toBeInTheDocument();
     });
 
-    it("marks the active view's button as selected via aria-pressed", () => {
+    it("marks the active view's primary button as selected via aria-pressed", () => {
       renderWithContext({ view: "year" });
       expect(screen.getByTestId("view-switcher-year")).toHaveAttribute(
         "aria-pressed",
@@ -101,7 +111,7 @@ describe("ViewSwitcher (#150)", () => {
       );
     });
 
-    it("calls setView when a primary button is clicked", async () => {
+    it("calls setView when a Month/Year/Clock primary button is clicked", async () => {
       const user = userEvent.setup();
       const { contextValue } = renderWithContext({ view: "month" });
 
@@ -110,12 +120,86 @@ describe("ViewSwitcher (#150)", () => {
     });
   });
 
-  describe("Day ▾ dropdown", () => {
-    it("opens a menu with Grid and Agenda options when clicked", async () => {
+  describe("Day primary button (split-button affordance)", () => {
+    it("clicking the primary Day button switches view without opening a menu", async () => {
+      const user = userEvent.setup();
+      const { contextValue } = renderWithContext({
+        view: "month",
+        agendaMode: false,
+      });
+
+      await user.click(screen.getByTestId("view-switcher-day"));
+
+      expect(contextValue.setView).toHaveBeenCalledWith("day");
+      // No agenda menu opens from the primary button.
+      expect(
+        screen.queryByRole("menuitemradio", { name: /grid/i })
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("menuitemradio", { name: /agenda/i })
+      ).not.toBeInTheDocument();
+    });
+
+    it("primary Day button does not advertise a popup (no aria-haspopup)", () => {
+      renderWithContext();
+      expect(screen.getByTestId("view-switcher-day")).not.toHaveAttribute(
+        "aria-haspopup"
+      );
+    });
+
+    it("primary Day click preserves the current agendaMode (does not reset it)", async () => {
+      const user = userEvent.setup();
+      const { contextValue } = renderWithContext({
+        view: "week",
+        agendaMode: true,
+      });
+
+      await user.click(screen.getByTestId("view-switcher-day"));
+
+      expect(contextValue.setView).toHaveBeenCalledWith("day");
+      // The primary button is intentionally a pure setView — agendaMode is
+      // global and should not be reset by a view switch.
+      expect(contextValue.setAgendaMode).not.toHaveBeenCalled();
+    });
+
+    it("reflects the active sub-mode in the primary label (Day · Agenda)", () => {
+      renderWithContext({ view: "day", agendaMode: true });
+      expect(screen.getByTestId("view-switcher-day")).toHaveTextContent(
+        /Day · Agenda/
+      );
+    });
+
+    it("shows just the bare label when the view is not active", () => {
+      renderWithContext({ view: "month", agendaMode: true });
+      expect(screen.getByTestId("view-switcher-day")).toHaveTextContent(
+        /^Day$/
+      );
+    });
+  });
+
+  describe("Day caret button (mode dropdown)", () => {
+    it("renders a separate caret with view-switcher-day-mode test id", () => {
+      renderWithContext();
+      expect(screen.getByTestId("view-switcher-day-mode")).toBeInTheDocument();
+    });
+
+    it("caret advertises a popup via aria-haspopup=menu", () => {
+      renderWithContext();
+      const caret = screen.getByTestId("view-switcher-day-mode");
+      expect(caret).toHaveAttribute("aria-haspopup", "menu");
+    });
+
+    it("caret has an accessible label describing its purpose", () => {
+      renderWithContext();
+      const caret = screen.getByTestId("view-switcher-day-mode");
+      expect(caret).toHaveAccessibleName(/day display mode/i);
+    });
+
+    it("clicking the caret opens a menu with Grid and Agenda options", async () => {
       const user = userEvent.setup();
       renderWithContext({ view: "day" });
 
-      await user.click(screen.getByTestId("view-switcher-day"));
+      await user.click(screen.getByTestId("view-switcher-day-mode"));
 
       expect(
         screen.getByRole("menuitemradio", { name: /grid/i })
@@ -129,7 +213,7 @@ describe("ViewSwitcher (#150)", () => {
       const user = userEvent.setup();
       renderWithContext({ view: "day", agendaMode: false });
 
-      await user.click(screen.getByTestId("view-switcher-day"));
+      await user.click(screen.getByTestId("view-switcher-day-mode"));
       expect(
         screen.getByRole("menuitemradio", { name: /grid/i })
       ).toHaveAttribute("aria-checked", "true");
@@ -142,34 +226,34 @@ describe("ViewSwitcher (#150)", () => {
       const user = userEvent.setup();
       renderWithContext({ view: "day", agendaMode: true });
 
-      await user.click(screen.getByTestId("view-switcher-day"));
+      await user.click(screen.getByTestId("view-switcher-day-mode"));
       expect(
         screen.getByRole("menuitemradio", { name: /agenda/i })
       ).toHaveAttribute("aria-checked", "true");
     });
 
-    it("clicking Agenda calls setView('day') AND setAgendaMode(true)", async () => {
+    it("clicking Agenda from caret menu calls setView('day') AND setAgendaMode(true)", async () => {
       const user = userEvent.setup();
       const { contextValue } = renderWithContext({
         view: "month",
         agendaMode: false,
       });
 
-      await user.click(screen.getByTestId("view-switcher-day"));
+      await user.click(screen.getByTestId("view-switcher-day-mode"));
       await user.click(screen.getByRole("menuitemradio", { name: /agenda/i }));
 
       expect(contextValue.setView).toHaveBeenCalledWith("day");
       expect(contextValue.setAgendaMode).toHaveBeenCalledWith(true);
     });
 
-    it("clicking Grid calls setView('day') AND setAgendaMode(false)", async () => {
+    it("clicking Grid from caret menu calls setView('day') AND setAgendaMode(false)", async () => {
       const user = userEvent.setup();
       const { contextValue } = renderWithContext({
         view: "day",
         agendaMode: true,
       });
 
-      await user.click(screen.getByTestId("view-switcher-day"));
+      await user.click(screen.getByTestId("view-switcher-day-mode"));
       await user.click(screen.getByRole("menuitemradio", { name: /grid/i }));
 
       expect(contextValue.setView).toHaveBeenCalledWith("day");
@@ -177,19 +261,51 @@ describe("ViewSwitcher (#150)", () => {
     });
   });
 
-  describe("Week ▾ dropdown", () => {
-    it("clicking Agenda calls setView('week') AND setAgendaMode(true)", async () => {
+  describe("Week primary + caret", () => {
+    it("clicking primary Week switches to week view without opening a menu", async () => {
+      const user = userEvent.setup();
+      const { contextValue } = renderWithContext({ view: "month" });
+
+      await user.click(screen.getByTestId("view-switcher-week"));
+
+      expect(contextValue.setView).toHaveBeenCalledWith("week");
+      expect(
+        screen.queryByRole("menuitemradio", { name: /grid/i })
+      ).not.toBeInTheDocument();
+    });
+
+    it("primary Week click preserves agendaMode", async () => {
+      const user = userEvent.setup();
+      const { contextValue } = renderWithContext({
+        view: "day",
+        agendaMode: true,
+      });
+
+      await user.click(screen.getByTestId("view-switcher-week"));
+
+      expect(contextValue.setView).toHaveBeenCalledWith("week");
+      expect(contextValue.setAgendaMode).not.toHaveBeenCalled();
+    });
+
+    it("Week caret opens a menu and Agenda commits both view and mode", async () => {
       const user = userEvent.setup();
       const { contextValue } = renderWithContext({
         view: "month",
         agendaMode: false,
       });
 
-      await user.click(screen.getByTestId("view-switcher-week"));
+      await user.click(screen.getByTestId("view-switcher-week-mode"));
       await user.click(screen.getByRole("menuitemradio", { name: /agenda/i }));
 
       expect(contextValue.setView).toHaveBeenCalledWith("week");
       expect(contextValue.setAgendaMode).toHaveBeenCalledWith(true);
+    });
+
+    it("Week caret has aria-haspopup=menu and an accessible label", () => {
+      renderWithContext();
+      const caret = screen.getByTestId("view-switcher-week-mode");
+      expect(caret).toHaveAttribute("aria-haspopup", "menu");
+      expect(caret).toHaveAccessibleName(/week display mode/i);
     });
   });
 
@@ -215,6 +331,17 @@ describe("ViewSwitcher (#150)", () => {
       expect(
         screen.queryByRole("menuitemradio", { name: /agenda/i })
       ).not.toBeInTheDocument();
+    });
+
+    it("Month/Year/Clock primary buttons do not advertise a popup", () => {
+      renderWithContext();
+      for (const id of [
+        "view-switcher-month",
+        "view-switcher-year",
+        "view-switcher-clock",
+      ]) {
+        expect(screen.getByTestId(id)).not.toHaveAttribute("aria-haspopup");
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

Replaces the Day/Week dropdown-as-button UI in `ViewSwitcher` with a proper split button and stops the Radix popover from leaking pointer events to sibling buttons after dismissal.

Closes #235.

### What changed

- **Split-button affordance.** Day and Week each render as a primary button + a caret:
  - Primary `view-switcher-{day,week}` is a plain `Button` that calls `setView(view)` and preserves the user's global `agendaMode`.
  - Caret `view-switcher-{day,week}-mode` is the `DropdownMenuTrigger` with `aria-haspopup="menu"` and an `aria-label` like *"Choose day display mode"*.
  - The pre-existing sub-mode label (`Day · Agenda`) stays on the primary button for sighted users.
- **Pointer-events leak.** `DropdownMenu modal={false}` on the caret so Radix does not install the body-level overlay that was eating subsequent clicks on Year/Month/Clock after dismissal.
- **E2E specs updated** to follow the new affordance — they were locking in the broken behaviour that the issue calls out:
  - `e2e/agenda-toggle.spec.ts`
  - `e2e/week-day-views.spec.ts`
  - `e2e/calendar.spec.ts`

### Tests

Component (Vitest + RTL):
- 24 specs covering primary-button click switches view without opening menu, primary preserves `agendaMode`, primary has no `aria-haspopup`, caret has `aria-haspopup="menu"`, caret has accessible label, Grid/Agenda radio state and selection, label reflects current sub-mode, Month/Year/Clock unchanged.

E2E (Playwright, `video: "on"` on the agenda spec):
- Updated round-trip Day → Day+Agenda → Week+Agenda → Week → Month.
- New: primary Day click switches view directly with no menu rendered.
- New: primary Week click preserves `agendaMode` (Day+Agenda → Week stays in agenda).
- New: Year click after Week-caret menu dismissal is not intercepted (regression for `modal={false}`).

### Verification

- `pnpm test:run` — 1584/1584 passing.
- `pnpm lint:fix` — clean (only pre-existing warnings unrelated to this PR).
- `pnpm format:fix` — clean.
- `pnpm check-types` — one pre-existing error in `src/components/calendar/__tests__/AgendaList.test.tsx` (verified present on `main` before this branch; out of scope).
- Playwright browser binaries are blocked from downloading in this sandbox; CI will run the E2E suite.

## Test plan

- [ ] CI Vitest suite green
- [ ] CI Playwright suite green (regression + new specs in `agenda-toggle.spec.ts`)
- [ ] Manual: load `/test/calendar?events=default&view=month`, click Week — lands in Week grid, no popover. Click Year — focus moves immediately, no pointer trap.
- [ ] Manual: open the Week caret, pick Agenda — lands in Week+Agenda. Click Day primary — stays in agenda mode (Day+Agenda).

https://claude.ai/code/session_01NqYRLtzdTuUifECHUkRg1R

---
_Generated by [Claude Code](https://claude.ai/code/session_01NqYRLtzdTuUifECHUkRg1R)_