### PR TITLE
chore(calendar): UX polish — scroll-to-7am, search match count, sidebar visibility (#214)

### DIFF
--- a/.claude/plans/calendar-ux-polish-214.md
+++ b/.claude/plans/calendar-ux-polish-214.md
@@ -1,0 +1,81 @@
+# Calendar UX polish — issue #214
+
+Three small UX items deferred across recent calendar PRs. Each is independent and ships as its own phase / commit.
+
+## Phase 1 — Scroll Day/Week time grid to ~7am on mount
+
+**Goal.** When the user first lands on the Day or Week view, the time grid is positioned so working hours (~7am onwards) are immediately visible, without a manual scroll.
+
+**Approach.**
+
+- Add a shared `WORKING_HOURS_START_HOUR` constant (default `7`) — the hour to surface on mount.
+- `DayCalendar` (`HOUR_HEIGHT_PX = 48`): scroll target is `7 * 48 = 336px`.
+- `WeekCalendar` (`HOUR_HEIGHT_PX = 40`): scroll target is `7 * 40 = 280px`.
+- Use `useLayoutEffect` on a `useRef` attached to the scroll container. `useLayoutEffect` runs synchronously after DOM mutations but before paint, so the grid never visibly flashes at 0:00.
+- The effect runs only on mount — subsequent user scrolls are not overridden.
+- Each grid's existing `overflow-y-auto` div is the scroll container; capture it via `ref`.
+
+**Tests.**
+
+- Unit test: `getInitialScrollTop(7, 48) === 336` and `(7, 40) === 280`. Pure helper.
+- Component test (DayCalendar / WeekCalendar):
+  - Mount the component with mocked `scrollTop` setter.
+  - Assert the scroll container's `scrollTop` is set to the expected pixel value once.
+- E2E (Playwright): mount Day view, assert the 7am hour label is in the visible viewport.
+
+**Acceptance.** Day and Week views auto-scroll to 7am on mount; user scroll behaviour unaffected.
+
+## Phase 2 — Visible match count next to AgendaCalendar search input
+
+**Goal.** Sighted users see a live match count while filtering. The existing `aria-live` `sr-only` announcement stays for screen readers.
+
+**Approach.**
+
+- Render a small badge inline with the search input, only when `searchActive` (i.e. trimmed query length > 0).
+- Text: `${resultCount} matches` / `1 match` / `0 matches`. Reuse the existing `resultCount` constant.
+- Place it inside the input's right padding band (left of the clear button) or as a sibling beneath, depending on what looks cleanest. Defer to inline-on-the-right since the input already has right padding for the clear icon.
+- Use `text-muted-foreground text-xs` to match other secondary copy in the file.
+- Keep the existing `sr-only` `aria-live` region untouched.
+
+**Tests.**
+
+- Component test:
+  - With no query: badge is not rendered (assert `queryByTestId("agenda-search-match-count")` returns `null`).
+  - With query "Standup" against a fixture with 1 matching event: badge text reads `1 match`.
+  - With query "no-such-event": badge text reads `0 matches`.
+
+**Acceptance.** Visible "N matches" badge renders next to the search input while a query is active. `sr-only` aria-live region preserved.
+
+## Phase 3 — Restrict MiniCalendarSidebar visibility to day/week
+
+**Goal.** Sidebar visible only when the user is in Day or Week view _and_ not in agenda mode. Hidden in Month, Year, Clock, and any agenda-mode display.
+
+**Approach.**
+
+- `src/app/calendar/page.tsx` line 54 currently uses an exclusion list:
+  ```ts
+  const showSidebar = view !== "month" && view !== "clock" && view !== "year";
+  ```
+- Replace with an explicit allow-list and an agenda gate:
+  ```ts
+  const showSidebar = (view === "day" || view === "week") && !agendaMode;
+  ```
+- Pull `agendaMode` from `useCalendar()`.
+- The `test/calendar` page is left unchanged because it explicitly renders an `AgendaCalendar` view that no longer corresponds to the production agenda-mode model. (#195 deferred reconciling this.)
+
+**Tests.**
+
+- Component test on `CalendarContent` (or page-level wrapper):
+  - View=day, agendaMode=false → sidebar present.
+  - View=week, agendaMode=false → sidebar present.
+  - View=day, agendaMode=true → sidebar hidden.
+  - View=month → sidebar hidden.
+  - View=year → sidebar hidden.
+  - View=clock → sidebar hidden.
+
+**Acceptance.** Sidebar appears only in day/week non-agenda displays.
+
+## Out of scope
+
+- Reconciling `test/calendar`'s standalone agenda view with the production agenda-mode model (#195 follow-up; not part of this issue).
+- Changing the `WORKING_HOURS_START_HOUR` from a constant to a user-configurable preference. Issue spec says "configurable working-hours start, defaulting to 7"; the constant is the simplest configurable surface and tests document the contract. Wiring it through `CalendarSettingsPanel` is a separate ticket if the user wants per-user configuration.

--- a/src/app/calendar/__tests__/page.test.tsx
+++ b/src/app/calendar/__tests__/page.test.tsx
@@ -65,8 +65,8 @@ vi.mock("@/components/ui/sonner", () => ({
   Toaster: () => <div data-testid="mock-toaster" />,
 }));
 
-function setView(view: TCalendarView): void {
-  mockUseCalendar.mockReturnValue({ view });
+function setView(view: TCalendarView, agendaMode = false): void {
+  mockUseCalendar.mockReturnValue({ view, agendaMode });
 }
 
 describe("CalendarPage — mini-calendar sidebar visibility", () => {
@@ -110,5 +110,21 @@ describe("CalendarPage — mini-calendar sidebar visibility", () => {
       screen.queryByTestId("mini-calendar-sidebar")
     ).not.toBeInTheDocument();
     expect(screen.getByTestId("mock-analog-clock-view")).toBeInTheDocument();
+  });
+
+  it("hides the mini-calendar sidebar when day view has agendaMode on (#214)", () => {
+    setView("day", true);
+    render(<CalendarPage />);
+    expect(
+      screen.queryByTestId("mini-calendar-sidebar")
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides the mini-calendar sidebar when week view has agendaMode on (#214)", () => {
+    setView("week", true);
+    render(<CalendarPage />);
+    expect(
+      screen.queryByTestId("mini-calendar-sidebar")
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -45,13 +45,14 @@ function CalendarView({ view }: { view: TCalendarView }) {
  * Extracted to access useCalendar hook
  */
 function CalendarContent() {
-  const { view } = useCalendar();
+  const { view, agendaMode } = useCalendar();
   const [showSettings, setShowSettings] = useState(false);
 
-  // Views that surface the mini-calendar sidebar. Month duplicates the main
-  // grid (issue #146) and the Clock view ships its own all-day events aside,
-  // so neither needs the shared sidebar.
-  const showSidebar = view !== "month" && view !== "clock" && view !== "year";
+  // Sidebar belongs to the day/week time-grid views only. Month, Year,
+  // and Clock have their own primary surface (issue #146 / #152), and
+  // when the user is in agenda mode (#150) the sidebar would compete
+  // with the chronological list. (#214)
+  const showSidebar = (view === "day" || view === "week") && !agendaMode;
 
   return (
     <div className="bg-background min-h-screen p-4 sm:p-8">

--- a/src/components/calendar/AgendaCalendar.tsx
+++ b/src/components/calendar/AgendaCalendar.tsx
@@ -307,32 +307,43 @@ export function AgendaCalendar() {
         </div>
       </div>
 
-      <div className="relative">
-        <Search
-          className="text-muted-foreground pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2"
-          aria-hidden="true"
-        />
-        <Input
-          type="search"
-          value={searchQuery}
-          onChange={(e) => setSearchQuery(e.target.value)}
-          placeholder="Search events by title, description, or attendee…"
-          aria-label="Search events"
-          data-testid="agenda-search-input"
-          className="pr-9 pl-9"
-        />
+      <div className="flex items-center gap-3">
+        <div className="relative flex-1">
+          <Search
+            className="text-muted-foreground pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2"
+            aria-hidden="true"
+          />
+          <Input
+            type="search"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="Search events by title, description, or attendee…"
+            aria-label="Search events"
+            data-testid="agenda-search-input"
+            className="pr-9 pl-9"
+          />
+          {searchActive && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              onClick={() => setSearchQuery("")}
+              aria-label="Clear search"
+              data-testid="agenda-search-clear"
+              className="text-muted-foreground hover:text-foreground absolute top-1/2 right-1 h-7 w-7 -translate-y-1/2"
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          )}
+        </div>
         {searchActive && (
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            onClick={() => setSearchQuery("")}
-            aria-label="Clear search"
-            data-testid="agenda-search-clear"
-            className="text-muted-foreground hover:text-foreground absolute top-1/2 right-1 h-7 w-7 -translate-y-1/2"
+          <span
+            className="text-muted-foreground shrink-0 text-xs tabular-nums"
+            data-testid="agenda-search-match-count"
+            aria-hidden="true"
           >
-            <X className="h-4 w-4" />
-          </Button>
+            {resultCount} {resultCount === 1 ? "match" : "matches"}
+          </span>
         )}
       </div>
 

--- a/src/components/calendar/DayCalendar.tsx
+++ b/src/components/calendar/DayCalendar.tsx
@@ -3,10 +3,12 @@
 import { useCalendar } from "@/components/providers/CalendarProvider";
 import { Button } from "@/components/ui/button";
 import {
+  WORKING_HOURS_START_HOUR,
   computeEventColumns,
   formatTime,
   getCurrentTimePosition,
   getEventTimePosition,
+  getInitialScrollTop,
 } from "@/lib/calendar-helpers";
 import { useTodayStartOfDay } from "@/lib/hooks/use-date-now";
 import type { IEvent, TEventColor } from "@/types/calendar";
@@ -26,10 +28,10 @@ import { AgendaList } from "./AgendaList";
 const HOURS = Array.from({ length: 24 }, (_, i) => i);
 const HOUR_HEIGHT_PX = 48;
 const TIME_GRID_HEIGHT_PX = HOUR_HEIGHT_PX * 24;
-// Hour the time grid scrolls to on mount so working-hours events are
-// immediately visible without a manual scroll. (#214)
-const WORKING_HOURS_START_HOUR = 7;
-const INITIAL_SCROLL_TOP_PX = WORKING_HOURS_START_HOUR * HOUR_HEIGHT_PX;
+const INITIAL_SCROLL_TOP_PX = getInitialScrollTop(
+  WORKING_HOURS_START_HOUR,
+  HOUR_HEIGHT_PX
+);
 
 function getEventBlockClasses(color: TEventColor): string {
   const classes: Record<TEventColor, string> = {

--- a/src/components/calendar/DayCalendar.tsx
+++ b/src/components/calendar/DayCalendar.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/lib/calendar-helpers";
 import { useTodayStartOfDay } from "@/lib/hooks/use-date-now";
 import type { IEvent, TEventColor } from "@/types/calendar";
-import { useEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import {
   addDays,
   endOfDay,
@@ -26,6 +26,10 @@ import { AgendaList } from "./AgendaList";
 const HOURS = Array.from({ length: 24 }, (_, i) => i);
 const HOUR_HEIGHT_PX = 48;
 const TIME_GRID_HEIGHT_PX = HOUR_HEIGHT_PX * 24;
+// Hour the time grid scrolls to on mount so working-hours events are
+// immediately visible without a manual scroll. (#214)
+const WORKING_HOURS_START_HOUR = 7;
+const INITIAL_SCROLL_TOP_PX = WORKING_HOURS_START_HOUR * HOUR_HEIGHT_PX;
 
 function getEventBlockClasses(color: TEventColor): string {
   const classes: Record<TEventColor, string> = {
@@ -253,6 +257,17 @@ function DayGridView({
   use24HourFormat,
   isLoading,
 }: DayGridViewProps) {
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+
+  // Scroll the time grid to the start of working hours on mount so
+  // morning events are immediately visible. useLayoutEffect runs
+  // synchronously before paint, avoiding a visible flash from 00:00.
+  useLayoutEffect(() => {
+    if (scrollContainerRef.current) {
+      scrollContainerRef.current.scrollTop = INITIAL_SCROLL_TOP_PX;
+    }
+  }, []);
+
   return (
     <>
       {allDayEvents.length > 0 && (
@@ -300,6 +315,7 @@ function DayGridView({
       )}
 
       <div
+        ref={scrollContainerRef}
         className="border-border bg-card relative max-h-[calc(100vh-280px)] overflow-y-auto rounded-lg border"
         data-testid="day-calendar-grid"
         role="grid"

--- a/src/components/calendar/WeekCalendar.tsx
+++ b/src/components/calendar/WeekCalendar.tsx
@@ -15,7 +15,7 @@ import {
 } from "@/lib/calendar-helpers";
 import { useTodayStartOfDay } from "@/lib/hooks/use-date-now";
 import type { IEvent, TEventColor } from "@/types/calendar";
-import { useEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import {
   addWeeks,
   differenceInCalendarDays,
@@ -36,6 +36,10 @@ const HOURS = Array.from({ length: 24 }, (_, i) => i);
 const HOUR_HEIGHT_PX = 40;
 const TIME_GRID_HEIGHT_PX = HOUR_HEIGHT_PX * 24;
 const BAR_ROW_HEIGHT_PX = 22;
+// Hour the time grid scrolls to on mount so working-hours events are
+// immediately visible without a manual scroll. (#214)
+const WORKING_HOURS_START_HOUR = 7;
+const INITIAL_SCROLL_TOP_PX = WORKING_HOURS_START_HOUR * HOUR_HEIGHT_PX;
 
 function getEventBlockClasses(color: TEventColor): string {
   const classes: Record<TEventColor, string> = {
@@ -134,6 +138,17 @@ export function WeekCalendar() {
   const previousWeek = () => setSelectedDate(subWeeks(selectedDate, 1));
   const nextWeek = () => setSelectedDate(addWeeks(selectedDate, 1));
   const goToToday = () => setSelectedDate(new Date());
+
+  // Scroll the time grid to the start of working hours when the grid
+  // mounts so morning events are immediately visible. Re-runs when
+  // agendaMode toggles back to false so re-entering the grid view also
+  // lands on working hours.
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  useLayoutEffect(() => {
+    if (!agendaMode && scrollContainerRef.current) {
+      scrollContainerRef.current.scrollTop = INITIAL_SCROLL_TOP_PX;
+    }
+  }, [agendaMode]);
 
   // Split into multi-day vs single-day timed events.
   const multiDayEvents = weekEvents.filter(isMultiDayEvent);
@@ -302,7 +317,11 @@ export function WeekCalendar() {
             </div>
           )}
 
-          <div className="relative flex max-h-[calc(100vh-320px)] overflow-y-auto">
+          <div
+            ref={scrollContainerRef}
+            data-testid="week-calendar-grid-scroll"
+            className="relative flex max-h-[calc(100vh-320px)] overflow-y-auto"
+          >
             <div
               className="w-12 shrink-0"
               style={{ height: `${TIME_GRID_HEIGHT_PX}px` }}

--- a/src/components/calendar/WeekCalendar.tsx
+++ b/src/components/calendar/WeekCalendar.tsx
@@ -4,12 +4,14 @@ import { useCalendar } from "@/components/providers/CalendarProvider";
 import { Button } from "@/components/ui/button";
 import {
   WEEK_STARTS_ON,
+  WORKING_HOURS_START_HOUR,
   assignBarRows,
   computeEventColumns,
   formatTime,
   getCurrentTimePosition,
   getEventTimePosition,
   getEventsForWeek,
+  getInitialScrollTop,
   getShortWeekdayLabels,
   getWeekDates,
 } from "@/lib/calendar-helpers";
@@ -36,10 +38,10 @@ const HOURS = Array.from({ length: 24 }, (_, i) => i);
 const HOUR_HEIGHT_PX = 40;
 const TIME_GRID_HEIGHT_PX = HOUR_HEIGHT_PX * 24;
 const BAR_ROW_HEIGHT_PX = 22;
-// Hour the time grid scrolls to on mount so working-hours events are
-// immediately visible without a manual scroll. (#214)
-const WORKING_HOURS_START_HOUR = 7;
-const INITIAL_SCROLL_TOP_PX = WORKING_HOURS_START_HOUR * HOUR_HEIGHT_PX;
+const INITIAL_SCROLL_TOP_PX = getInitialScrollTop(
+  WORKING_HOURS_START_HOUR,
+  HOUR_HEIGHT_PX
+);
 
 function getEventBlockClasses(color: TEventColor): string {
   const classes: Record<TEventColor, string> = {
@@ -139,26 +141,6 @@ export function WeekCalendar() {
   const nextWeek = () => setSelectedDate(addWeeks(selectedDate, 1));
   const goToToday = () => setSelectedDate(new Date());
 
-  // Scroll the time grid to the start of working hours when the grid
-  // mounts so morning events are immediately visible. Re-runs when
-  // agendaMode toggles back to false so re-entering the grid view also
-  // lands on working hours.
-  const scrollContainerRef = useRef<HTMLDivElement>(null);
-  useLayoutEffect(() => {
-    if (!agendaMode && scrollContainerRef.current) {
-      scrollContainerRef.current.scrollTop = INITIAL_SCROLL_TOP_PX;
-    }
-  }, [agendaMode]);
-
-  // Split into multi-day vs single-day timed events.
-  const multiDayEvents = weekEvents.filter(isMultiDayEvent);
-  const timedEvents = weekEvents.filter((e) => !isMultiDayEvent(e));
-  const barRows = assignBarRows(multiDayEvents, weekStart, weekEnd);
-  const barRowCount =
-    Object.values(barRows).length === 0
-      ? 0
-      : Math.max(...Object.values(barRows)) + 1;
-
   return (
     <div className="w-full space-y-4">
       <div className="flex items-center justify-between">
@@ -226,211 +208,264 @@ export function WeekCalendar() {
           emptyLabel={`No events from ${format(weekStart, "MMM d")} to ${format(weekEnd, "MMM d")}`}
         />
       ) : (
-        <div
-          className="border-border bg-card overflow-hidden rounded-lg border"
-          role="grid"
-          aria-label={`Week of ${format(weekStart, "MMMM d, yyyy")}`}
-        >
-          <div className="border-border bg-muted flex border-b" role="row">
-            <div className="w-12 shrink-0" aria-hidden="true" />
-            <div className="grid flex-1 grid-cols-7">
-              {weekDates.map((day, index) => {
-                const isTodayCell = isSameDay(day, today);
-                return (
-                  <div
-                    key={day.toISOString()}
-                    role="columnheader"
-                    data-testid={
-                      isTodayCell ? "week-calendar-today-cell" : undefined
-                    }
-                    className={`flex flex-col items-center p-2 ${isTodayCell ? "bg-blue-50 dark:bg-blue-950" : ""}`}
-                  >
-                    <span className="text-muted-foreground text-xs font-semibold">
-                      {weekdayHeaders[index]}
-                    </span>
-                    <span
-                      className={
-                        isTodayCell
-                          ? "mt-0.5 inline-flex h-7 w-7 items-center justify-center rounded-full bg-blue-600 text-sm text-white"
-                          : "text-foreground mt-0.5 text-sm font-semibold"
-                      }
-                    >
-                      {format(day, "d")}
-                    </span>
-                  </div>
-                );
-              })}
-            </div>
-          </div>
+        <WeekGridView
+          weekStart={weekStart}
+          weekEnd={weekEnd}
+          weekDates={weekDates}
+          weekdayHeaders={weekdayHeaders}
+          weekEvents={weekEvents}
+          today={today}
+          use24HourFormat={use24HourFormat}
+        />
+      )}
+    </div>
+  );
+}
 
-          {(barRowCount > 0 || multiDayEvents.length > 0) && (
-            <div
-              className="border-border flex border-b"
-              data-testid="week-calendar-multi-day-row"
-              role="row"
-              aria-label="All-day and multi-day events"
-            >
-              <div className="w-12 shrink-0" aria-hidden="true" />
+interface WeekGridViewProps {
+  weekStart: Date;
+  weekEnd: Date;
+  weekDates: Date[];
+  weekdayHeaders: readonly string[];
+  weekEvents: IEvent[];
+  today: Date;
+  use24HourFormat: boolean;
+}
+
+function WeekGridView({
+  weekStart,
+  weekEnd,
+  weekDates,
+  weekdayHeaders,
+  weekEvents,
+  today,
+  use24HourFormat,
+}: WeekGridViewProps) {
+  // Split into multi-day vs single-day timed events.
+  const multiDayEvents = weekEvents.filter(isMultiDayEvent);
+  const timedEvents = weekEvents.filter((e) => !isMultiDayEvent(e));
+  const barRows = assignBarRows(multiDayEvents, weekStart, weekEnd);
+  const barRowCount =
+    Object.values(barRows).length === 0
+      ? 0
+      : Math.max(...Object.values(barRows)) + 1;
+
+  // Scroll the time grid to the start of working hours when the grid
+  // mounts so morning events are immediately visible. Lives inside the
+  // sub-component so it re-fires every time the grid (re-)mounts —
+  // i.e. when the user toggles agenda mode off — without disturbing
+  // manual scroll between renders.
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  useLayoutEffect(() => {
+    if (scrollContainerRef.current) {
+      scrollContainerRef.current.scrollTop = INITIAL_SCROLL_TOP_PX;
+    }
+  }, []);
+
+  return (
+    <div
+      className="border-border bg-card overflow-hidden rounded-lg border"
+      role="grid"
+      aria-label={`Week of ${format(weekStart, "MMMM d, yyyy")}`}
+    >
+      <div className="border-border bg-muted flex border-b" role="row">
+        <div className="w-12 shrink-0" aria-hidden="true" />
+        <div className="grid flex-1 grid-cols-7">
+          {weekDates.map((day, index) => {
+            const isTodayCell = isSameDay(day, today);
+            return (
               <div
-                className="relative flex-1"
-                style={{
-                  height: `${Math.max(barRowCount, 1) * BAR_ROW_HEIGHT_PX + 8}px`,
-                }}
+                key={day.toISOString()}
+                role="columnheader"
+                data-testid={
+                  isTodayCell ? "week-calendar-today-cell" : undefined
+                }
+                className={`flex flex-col items-center p-2 ${isTodayCell ? "bg-blue-50 dark:bg-blue-950" : ""}`}
               >
-                {multiDayEvents.map((event) => {
-                  const row = barRows[event.id];
-                  if (row === undefined) return null;
-                  const eventStart = parseISO(event.startDate);
-                  const eventEnd = parseISO(event.endDate);
-                  const visibleStart =
-                    eventStart < weekStart ? weekStart : eventStart;
-                  const visibleEnd = eventEnd > weekEnd ? weekEnd : eventEnd;
-                  const startCol = differenceInCalendarDays(
-                    visibleStart,
-                    weekStart
-                  );
-                  const span =
-                    differenceInCalendarDays(visibleEnd, visibleStart) + 1;
-                  const widthPct = (span * 100) / 7;
-                  const leftPct = (startCol * 100) / 7;
+                <span className="text-muted-foreground text-xs font-semibold">
+                  {weekdayHeaders[index]}
+                </span>
+                <span
+                  className={
+                    isTodayCell
+                      ? "mt-0.5 inline-flex h-7 w-7 items-center justify-center rounded-full bg-blue-600 text-sm text-white"
+                      : "text-foreground mt-0.5 text-sm font-semibold"
+                  }
+                >
+                  {format(day, "d")}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {(barRowCount > 0 || multiDayEvents.length > 0) && (
+        <div
+          className="border-border flex border-b"
+          data-testid="week-calendar-multi-day-row"
+          role="row"
+          aria-label="All-day and multi-day events"
+        >
+          <div className="w-12 shrink-0" aria-hidden="true" />
+          <div
+            className="relative flex-1"
+            style={{
+              height: `${Math.max(barRowCount, 1) * BAR_ROW_HEIGHT_PX + 8}px`,
+            }}
+          >
+            {multiDayEvents.map((event) => {
+              const row = barRows[event.id];
+              if (row === undefined) return null;
+              const eventStart = parseISO(event.startDate);
+              const eventEnd = parseISO(event.endDate);
+              const visibleStart =
+                eventStart < weekStart ? weekStart : eventStart;
+              const visibleEnd = eventEnd > weekEnd ? weekEnd : eventEnd;
+              const startCol = differenceInCalendarDays(
+                visibleStart,
+                weekStart
+              );
+              const span =
+                differenceInCalendarDays(visibleEnd, visibleStart) + 1;
+              const widthPct = (span * 100) / 7;
+              const leftPct = (startCol * 100) / 7;
+
+              return (
+                <div
+                  key={event.id}
+                  data-testid="week-calendar-multi-day-bar"
+                  className={`absolute mx-0.5 truncate rounded px-2 py-0.5 text-xs ${getBarPillClasses(event.color)}`}
+                  style={{
+                    top: `${row * BAR_ROW_HEIGHT_PX + 4}px`,
+                    left: `${leftPct}%`,
+                    width: `calc(${widthPct}% - 0.25rem)`,
+                    height: `${BAR_ROW_HEIGHT_PX - 4}px`,
+                  }}
+                  title={event.title}
+                >
+                  <span data-testid="week-calendar-event-title">
+                    {event.title}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      <div
+        ref={scrollContainerRef}
+        data-testid="week-calendar-grid-scroll"
+        className="relative flex max-h-[calc(100vh-320px)] overflow-y-auto"
+      >
+        <div
+          className="w-12 shrink-0"
+          style={{ height: `${TIME_GRID_HEIGHT_PX}px` }}
+          aria-hidden="true"
+        >
+          {HOURS.map((hour) => (
+            <div
+              key={hour}
+              className="border-border relative border-b"
+              style={{ height: `${HOUR_HEIGHT_PX}px` }}
+            >
+              <span className="text-muted-foreground absolute -top-2 right-1 text-[10px]">
+                {use24HourFormat
+                  ? `${String(hour).padStart(2, "0")}:00`
+                  : hour === 0
+                    ? "12 AM"
+                    : hour < 12
+                      ? `${hour} AM`
+                      : hour === 12
+                        ? "12 PM"
+                        : `${hour - 12} PM`}
+              </span>
+            </div>
+          ))}
+        </div>
+
+        <div
+          className="relative grid flex-1 grid-cols-7"
+          style={{ height: `${TIME_GRID_HEIGHT_PX}px` }}
+        >
+          {weekDates.map((day) => {
+            const isTodayCol = isSameDay(day, today);
+            const dayTimedEvents = timedEvents
+              .filter((e) => isSameDay(parseISO(e.startDate), day))
+              .sort(
+                (a, b) =>
+                  parseISO(a.startDate).getTime() -
+                  parseISO(b.startDate).getTime()
+              );
+            const eventColumn = computeEventColumns(dayTimedEvents);
+
+            return (
+              <div
+                key={day.toISOString()}
+                role="gridcell"
+                data-testid={`week-calendar-day-col-${format(day, "yyyy-MM-dd")}`}
+                className={`border-border relative border-r last:border-r-0 ${
+                  isTodayCol ? "bg-blue-50/40 dark:bg-blue-950/40" : ""
+                }`}
+              >
+                {HOURS.map((hour) => (
+                  <div
+                    key={hour}
+                    className="border-border absolute right-0 left-0 border-b"
+                    style={{
+                      top: `${hour * HOUR_HEIGHT_PX}px`,
+                      height: `${HOUR_HEIGHT_PX}px`,
+                    }}
+                    aria-hidden="true"
+                  />
+                ))}
+
+                {dayTimedEvents.map((event) => {
+                  const { top, height } = getEventTimePosition(event, day);
+                  const slot = eventColumn[event.id] ?? {
+                    column: 0,
+                    columns: 1,
+                  };
+                  const widthPct = 100 / slot.columns;
+                  const leftPct = slot.column * widthPct;
 
                   return (
                     <div
                       key={event.id}
-                      data-testid="week-calendar-multi-day-bar"
-                      className={`absolute mx-0.5 truncate rounded px-2 py-0.5 text-xs ${getBarPillClasses(event.color)}`}
+                      data-testid="week-calendar-event"
+                      role="button"
+                      aria-label={`${event.title}, ${formatTime(event.startDate, use24HourFormat)} to ${formatTime(event.endDate, use24HourFormat)}`}
+                      className={`absolute overflow-hidden rounded border-l-4 px-1 py-0.5 text-[10px] leading-tight ${getEventBlockClasses(event.color)}`}
                       style={{
-                        top: `${row * BAR_ROW_HEIGHT_PX + 4}px`,
+                        top: `${top}%`,
+                        height: `${height}%`,
                         left: `${leftPct}%`,
-                        width: `calc(${widthPct}% - 0.25rem)`,
-                        height: `${BAR_ROW_HEIGHT_PX - 4}px`,
+                        width: `calc(${widthPct}% - 0.125rem)`,
                       }}
-                      title={event.title}
                     >
-                      <span data-testid="week-calendar-event-title">
+                      <div
+                        className="truncate font-semibold"
+                        data-testid="week-calendar-event-title"
+                        title={event.title}
+                      >
                         {event.title}
-                      </span>
+                      </div>
+                      {!event.isAllDay && (
+                        <div className="truncate opacity-80">
+                          {formatTime(event.startDate, use24HourFormat)}
+                        </div>
+                      )}
                     </div>
                   );
                 })}
               </div>
-            </div>
-          )}
+            );
+          })}
 
-          <div
-            ref={scrollContainerRef}
-            data-testid="week-calendar-grid-scroll"
-            className="relative flex max-h-[calc(100vh-320px)] overflow-y-auto"
-          >
-            <div
-              className="w-12 shrink-0"
-              style={{ height: `${TIME_GRID_HEIGHT_PX}px` }}
-              aria-hidden="true"
-            >
-              {HOURS.map((hour) => (
-                <div
-                  key={hour}
-                  className="border-border relative border-b"
-                  style={{ height: `${HOUR_HEIGHT_PX}px` }}
-                >
-                  <span className="text-muted-foreground absolute -top-2 right-1 text-[10px]">
-                    {use24HourFormat
-                      ? `${String(hour).padStart(2, "0")}:00`
-                      : hour === 0
-                        ? "12 AM"
-                        : hour < 12
-                          ? `${hour} AM`
-                          : hour === 12
-                            ? "12 PM"
-                            : `${hour - 12} PM`}
-                  </span>
-                </div>
-              ))}
-            </div>
-
-            <div
-              className="relative grid flex-1 grid-cols-7"
-              style={{ height: `${TIME_GRID_HEIGHT_PX}px` }}
-            >
-              {weekDates.map((day) => {
-                const isTodayCol = isSameDay(day, today);
-                const dayTimedEvents = timedEvents
-                  .filter((e) => isSameDay(parseISO(e.startDate), day))
-                  .sort(
-                    (a, b) =>
-                      parseISO(a.startDate).getTime() -
-                      parseISO(b.startDate).getTime()
-                  );
-                const eventColumn = computeEventColumns(dayTimedEvents);
-
-                return (
-                  <div
-                    key={day.toISOString()}
-                    role="gridcell"
-                    data-testid={`week-calendar-day-col-${format(day, "yyyy-MM-dd")}`}
-                    className={`border-border relative border-r last:border-r-0 ${
-                      isTodayCol ? "bg-blue-50/40 dark:bg-blue-950/40" : ""
-                    }`}
-                  >
-                    {HOURS.map((hour) => (
-                      <div
-                        key={hour}
-                        className="border-border absolute right-0 left-0 border-b"
-                        style={{
-                          top: `${hour * HOUR_HEIGHT_PX}px`,
-                          height: `${HOUR_HEIGHT_PX}px`,
-                        }}
-                        aria-hidden="true"
-                      />
-                    ))}
-
-                    {dayTimedEvents.map((event) => {
-                      const { top, height } = getEventTimePosition(event, day);
-                      const slot = eventColumn[event.id] ?? {
-                        column: 0,
-                        columns: 1,
-                      };
-                      const widthPct = 100 / slot.columns;
-                      const leftPct = slot.column * widthPct;
-
-                      return (
-                        <div
-                          key={event.id}
-                          data-testid="week-calendar-event"
-                          role="button"
-                          aria-label={`${event.title}, ${formatTime(event.startDate, use24HourFormat)} to ${formatTime(event.endDate, use24HourFormat)}`}
-                          className={`absolute overflow-hidden rounded border-l-4 px-1 py-0.5 text-[10px] leading-tight ${getEventBlockClasses(event.color)}`}
-                          style={{
-                            top: `${top}%`,
-                            height: `${height}%`,
-                            left: `${leftPct}%`,
-                            width: `calc(${widthPct}% - 0.125rem)`,
-                          }}
-                        >
-                          <div
-                            className="truncate font-semibold"
-                            data-testid="week-calendar-event-title"
-                            title={event.title}
-                          >
-                            {event.title}
-                          </div>
-                          {!event.isAllDay && (
-                            <div className="truncate opacity-80">
-                              {formatTime(event.startDate, use24HourFormat)}
-                            </div>
-                          )}
-                        </div>
-                      );
-                    })}
-                  </div>
-                );
-              })}
-
-              <NowLine weekStart={weekStart} weekEnd={weekEnd} />
-            </div>
-          </div>
+          <NowLine weekStart={weekStart} weekEnd={weekEnd} />
         </div>
-      )}
+      </div>
     </div>
   );
 }

--- a/src/components/calendar/__tests__/AgendaCalendar.test.tsx
+++ b/src/components/calendar/__tests__/AgendaCalendar.test.tsx
@@ -418,6 +418,66 @@ describe("AgendaCalendar", () => {
       expect(screen.getByText("Soccer Practice")).toBeInTheDocument();
       expect(screen.getByText("Birthday Party")).toBeInTheDocument();
     });
+
+    describe("Visible match count badge (#214)", () => {
+      it("does not render the badge when the query is empty", () => {
+        renderWithContext(buildEvents());
+        expect(
+          screen.queryByTestId("agenda-search-match-count")
+        ).not.toBeInTheDocument();
+      });
+
+      it("does not render the badge for a whitespace-only query", async () => {
+        const user = userEvent.setup();
+        renderWithContext(buildEvents());
+
+        await user.type(screen.getByPlaceholderText(/search events/i), "   ");
+
+        expect(
+          screen.queryByTestId("agenda-search-match-count")
+        ).not.toBeInTheDocument();
+      });
+
+      it("shows '1 match' (singular) when exactly one event matches", async () => {
+        const user = userEvent.setup();
+        renderWithContext(buildEvents());
+
+        await user.type(
+          screen.getByPlaceholderText(/search events/i),
+          "soccer"
+        );
+
+        expect(
+          screen.getByTestId("agenda-search-match-count")
+        ).toHaveTextContent("1 match");
+      });
+
+      it("shows 'N matches' (plural) when multiple events match", async () => {
+        const user = userEvent.setup();
+        renderWithContext(buildEvents());
+
+        // All three fixture titles include the letter "e".
+        await user.type(screen.getByPlaceholderText(/search events/i), "e");
+
+        expect(
+          screen.getByTestId("agenda-search-match-count")
+        ).toHaveTextContent("3 matches");
+      });
+
+      it("shows '0 matches' when no events match", async () => {
+        const user = userEvent.setup();
+        renderWithContext(buildEvents());
+
+        await user.type(
+          screen.getByPlaceholderText(/search events/i),
+          "nothing-matches-this"
+        );
+
+        expect(
+          screen.getByTestId("agenda-search-match-count")
+        ).toHaveTextContent("0 matches");
+      });
+    });
   });
 
   describe("Group by", () => {

--- a/src/components/calendar/__tests__/DayCalendar.test.tsx
+++ b/src/components/calendar/__tests__/DayCalendar.test.tsx
@@ -396,6 +396,21 @@ describe("DayCalendar", () => {
     });
   });
 
+  describe("Initial scroll position (#214)", () => {
+    // HOUR_HEIGHT_PX = 48; working hours start at 07:00
+    // Expected scrollTop: 7 * 48 = 336
+    it("auto-scrolls the time grid to ~7am on mount", () => {
+      renderWithContext({ selectedDate: new Date() });
+      const grid = screen.getByTestId("day-calendar-grid");
+      expect(grid.scrollTop).toBe(336);
+    });
+
+    it("does not render the grid (and thus does not scroll) in agenda mode", () => {
+      renderWithContext({ selectedDate: new Date(), agendaMode: true });
+      expect(screen.queryByTestId("day-calendar-grid")).not.toBeInTheDocument();
+    });
+  });
+
   describe("Multi-day events", () => {
     it("shows a multi-day all-day event in the all-day section even when the user is mid-span", () => {
       const selectedDate = startOfDay(new Date(2026, 3, 15)); // Wed

--- a/src/components/calendar/__tests__/WeekCalendar.test.tsx
+++ b/src/components/calendar/__tests__/WeekCalendar.test.tsx
@@ -437,6 +437,53 @@ describe("WeekCalendar", () => {
         screen.queryByTestId("week-calendar-grid-scroll")
       ).not.toBeInTheDocument();
     });
+
+    // The grid lives in a sub-component (WeekGridView) so it unmounts/
+    // remounts when agendaMode toggles. The scroll-on-mount effect uses
+    // an empty dep array, which preserves user scroll between regular
+    // re-renders while still resetting to 7am on each fresh re-entry
+    // from agenda mode.
+    it("re-scrolls to 7am after toggling agenda off and back to grid", () => {
+      const selectedDate = new Date();
+      const contextValue = {
+        selectedDate,
+        agendaMode: false,
+      } satisfies Partial<ICalendarContext>;
+      const { rerender } = render(
+        <CalendarContext.Provider value={createMockContext(contextValue)}>
+          <WeekCalendar />
+        </CalendarContext.Provider>
+      );
+
+      const initialGrid = screen.getByTestId("week-calendar-grid-scroll");
+      expect(initialGrid.scrollTop).toBe(280);
+      // Simulate the user scrolling somewhere else.
+      initialGrid.scrollTop = 0;
+      expect(initialGrid.scrollTop).toBe(0);
+
+      // Toggle agenda on — grid unmounts.
+      rerender(
+        <CalendarContext.Provider
+          value={createMockContext({ ...contextValue, agendaMode: true })}
+        >
+          <WeekCalendar />
+        </CalendarContext.Provider>
+      );
+      expect(
+        screen.queryByTestId("week-calendar-grid-scroll")
+      ).not.toBeInTheDocument();
+
+      // Toggle agenda off — grid remounts; effect re-fires; back to 280.
+      rerender(
+        <CalendarContext.Provider
+          value={createMockContext({ ...contextValue, agendaMode: false })}
+        >
+          <WeekCalendar />
+        </CalendarContext.Provider>
+      );
+      const remountedGrid = screen.getByTestId("week-calendar-grid-scroll");
+      expect(remountedGrid.scrollTop).toBe(280);
+    });
   });
 
   describe("Multi-day spanning bars", () => {

--- a/src/components/calendar/__tests__/WeekCalendar.test.tsx
+++ b/src/components/calendar/__tests__/WeekCalendar.test.tsx
@@ -422,6 +422,23 @@ describe("WeekCalendar", () => {
     });
   });
 
+  describe("Initial scroll position (#214)", () => {
+    // HOUR_HEIGHT_PX = 40; working hours start at 07:00
+    // Expected scrollTop: 7 * 40 = 280
+    it("auto-scrolls the time grid to ~7am on mount", () => {
+      renderWithContext({ selectedDate: new Date() });
+      const grid = screen.getByTestId("week-calendar-grid-scroll");
+      expect(grid.scrollTop).toBe(280);
+    });
+
+    it("does not render the grid (and thus does not scroll) in agenda mode", () => {
+      renderWithContext({ selectedDate: new Date(), agendaMode: true });
+      expect(
+        screen.queryByTestId("week-calendar-grid-scroll")
+      ).not.toBeInTheDocument();
+    });
+  });
+
   describe("Multi-day spanning bars", () => {
     it("renders a single bar for an event spanning multiple days", () => {
       const selectedDate = midday(new Date(2026, 3, 15));

--- a/src/components/calendar/__tests__/midnight-rollover.test.tsx
+++ b/src/components/calendar/__tests__/midnight-rollover.test.tsx
@@ -59,6 +59,7 @@ function makeContext(
     deleteEvent: vi.fn(),
     clearFilter: vi.fn(),
     refreshEvents: vi.fn(),
+    loadEventsForYear: vi.fn(),
     isLoading: false,
     isAuthenticated: true,
     maxEventsPerDay: 3,

--- a/src/lib/__tests__/calendar-helpers.test.ts
+++ b/src/lib/__tests__/calendar-helpers.test.ts
@@ -3,6 +3,7 @@ import { parseISO } from "date-fns";
 import { describe, expect, it } from "vitest";
 import {
   WEEK_STARTS_ON,
+  WORKING_HOURS_START_HOUR,
   assignBarRows,
   computeEventColumns,
   formatTime,
@@ -18,6 +19,7 @@ import {
   getEventsForWeek,
   getEventsForYear,
   getFirstLetters,
+  getInitialScrollTop,
   getShortWeekdayLabels,
   getWeekDates,
   groupEvents,
@@ -437,7 +439,7 @@ describe("getEventsForWeek", () => {
     const result = getEventsForWeek([spanningOut], new Date(2024, 2, 13));
     expect(result.map((e) => e.id)).toEqual(["span-out"]);
   });
-  
+
   // Regression: #234 — events that start on the last day of the week (Saturday
   // when WEEK_STARTS_ON = 0) at any time after 00:00 were being filtered out
   // because the upper bound was `weekDates[6]`, i.e. Saturday at midnight.
@@ -732,6 +734,18 @@ describe("getCurrentTimePosition", () => {
       (23 * 60 + 59) / 14.4,
       5
     );
+  });
+});
+
+describe("getInitialScrollTop (#214)", () => {
+  it("multiplies the hour by the row height", () => {
+    expect(getInitialScrollTop(7, 48)).toBe(336);
+    expect(getInitialScrollTop(7, 40)).toBe(280);
+    expect(getInitialScrollTop(0, 48)).toBe(0);
+  });
+
+  it("WORKING_HOURS_START_HOUR defaults to 7 (start of working day)", () => {
+    expect(WORKING_HOURS_START_HOUR).toBe(7);
   });
 });
 

--- a/src/lib/calendar-helpers.ts
+++ b/src/lib/calendar-helpers.ts
@@ -46,6 +46,27 @@ const FORMAT_STRING = "MMM d, yyyy";
  */
 export const WEEK_STARTS_ON: Day = 0;
 
+/**
+ * Hour of day the Day/Week time grids scroll to on mount so working-hours
+ * events are immediately visible. (#214)
+ *
+ * 0 = midnight, 7 = 7am, etc. Plumbed through `getInitialScrollTop` so
+ * each calendar can derive its scrollTop from its own row height.
+ */
+export const WORKING_HOURS_START_HOUR = 7;
+
+/**
+ * Compute the scrollTop in pixels needed to position the time grid at a
+ * specific hour of day. Used by Day/Week views to land on the start of
+ * working hours when the grid mounts.
+ */
+export function getInitialScrollTop(
+  hour: number,
+  hourHeightPx: number
+): number {
+  return hour * hourHeightPx;
+}
+
 const SHORT_WEEKDAY_LABELS = [
   "Sun",
   "Mon",


### PR DESCRIPTION
Closes #214.

## Summary

Three small UX polish items deferred across recent calendar PRs, grouped to keep the issue queue manageable.

- **Phase 1 — Auto-scroll Day/Week time grid to 7am on mount** (`bc69661`/`70a5aba`)
  Working-hours events are immediately visible without a manual scroll. Uses `useLayoutEffect` to avoid a visible 00:00 → 07:00 flash. Re-runs when `agendaMode` toggles back to false (re-entering the grid view).
- **Phase 2 — Visible "N matches" badge in `AgendaCalendar`** (`e020e04`)
  Sighted users see a live match count while filtering. The existing `aria-live` `sr-only` announcement stays for screen readers. Singular form is "1 match", plural "N matches" / "0 matches".
- **Phase 3 — Restrict `MiniCalendarSidebar` visibility to day/week, non-agenda** (`b2ca72b`)
  Sidebar visibility uses an explicit allow-list: visible only when view is `day` or `week` AND `agendaMode` is off. Previously remained visible in agenda mode.
- **Bonus — `loadEventsForYear` test mock fix** (`1d1af61`)
  CI's strict tsc surfaced a pre-existing missing field on `midnight-rollover.test.tsx` after rebase onto main. One-line fix.

Plan: [`.claude/plans/calendar-ux-polish-214.md`](./.claude/plans/calendar-ux-polish-214.md).

## Test plan

- [x] `pnpm test:run` — 1750/1750 passing
- [x] `pnpm lint && pnpm check-types` — clean (warnings only, all pre-existing on main)
- [x] `npx prisma migrate diff --from-migrations prisma/migrations --to-schema prisma/schema.prisma --exit-code` — in sync
- [ ] Manual / Playwright (deferred to local QA): open `/calendar` on Day or Week view → grid shows 7am region first
- [ ] Manual: type in agenda search input → "N matches" badge appears next to the input
- [ ] Manual: cycle Day/Week/Month/Year/Clock + agenda toggle → sidebar visible only in day/week with agenda off

## Out of scope

- Reconciling `test/calendar`'s standalone agenda view with the production agenda-mode model (#195 follow-up).
- Wiring `WORKING_HOURS_START_HOUR` to a user-configurable preference; currently a constant.

https://claude.ai/code/session_01JcD8BYdas9esYxiu1tVG4b