### PR TITLE
feat(cache): per-event TTL, upsert, in-memory fallback (#218)

### DIFF
--- a/.claude/plans/event-cache-rework-218.md
+++ b/.claude/plans/event-cache-rework-218.md
@@ -1,0 +1,94 @@
+# Event cache rework (slice 1) — issue #218
+
+Tracking issue: [#218](https://github.com/BenSeymourODB/next-digital-wall-calendar/issues/218).
+
+## Goal
+
+Replace the existing `EventCache` clear-and-rewrite IndexedDB layer with an
+upsert-based, TTL-aware cache that transparently falls back to an in-memory
+`Map` when IndexedDB is unavailable.
+
+## Scope
+
+| Item                                        | In this PR | Deferred                    |
+| ------------------------------------------- | ---------- | --------------------------- |
+| Per-event `cachedAt` timestamp              | yes        | —                           |
+| Read-time TTL filter (default 24h)          | yes        | wiring TTL to user settings |
+| Upsert (`put`) instead of `clear` + `add`   | yes        | —                           |
+| In-memory fallback when IDB unavailable     | yes        | —                           |
+| LRU eviction on `QuotaExceededError`        | —          | follow-up issue             |
+| Background `visibilitychange` cleanup sweep | —          | follow-up issue             |
+| User-settings UI for cache TTL              | —          | follow-up issue             |
+
+The TTL stays a constant in this slice. Today's read-time filter already
+prevents stale data from surfacing; LRU eviction and background cleanup are
+additive optimisations that don't block the cache being correct.
+
+## Phases
+
+### Phase 1 — Data model: per-event TTL + tests
+
+Introduce `cachedAt` per stored row, default `EVENT_CACHE_TTL_MS = 24 *
+60 * 60 * 1000`, and filter on read.
+
+- New file `src/lib/event-cache.ts` containing the public `EventCache`
+  surface plus an internal `EventStore` interface.
+- Two implementations: `InMemoryEventStore` (test-friendly, also the
+  fallback) and `IndexedDBEventStore` (production path).
+- Move `eventCache` export from `calendar-storage.ts` to the new module
+  and re-export from `calendar-storage.ts` for backward compatibility
+  (so `CalendarProvider.tsx` keeps its existing import path; we sweep
+  it in a later slice).
+- Tests:
+  - `InMemoryEventStore`: put + getAll round-trip, getAll filters
+    expired entries, expired entries are evicted from the store on
+    read, multiple writes upsert by id.
+  - `EventCache` (front facade): selects the in-memory backend in jsdom
+    (no IndexedDB), accepts injected store for tests.
+
+### Phase 2 — Upsert semantics
+
+The current implementation does `objectStore.clear()` then `add()` per
+event. Replace with `put()` (upsert) so partial-range refreshes don't
+blow away rows from other ranges and so there's never a brief
+"cache empty" window between `clear` and the puts completing.
+
+- `EventStore.put(events)` becomes the single write entry point.
+- Drop `clearEvents()` from the public surface; keep `clear()` on the
+  store interface for explicit nukes (`logout` flows might want it
+  later, but no caller needs it today).
+- Tests assert that a second put with a disjoint id set leaves the
+  earlier rows intact, and that overlapping ids are overwritten.
+
+### Phase 3 — In-memory fallback wiring
+
+- `selectEventStore()` chooses `IndexedDBEventStore` when
+  `typeof indexedDB !== "undefined"` and `indexedDB.open` is callable;
+  otherwise returns `InMemoryEventStore`.
+- IDB construction errors (e.g. private mode where `open` rejects)
+  log a warning via `logger` and fall through to the in-memory store
+  for the lifetime of the page.
+- Tests: stub `globalThis.indexedDB` to assert selection, and assert
+  the in-memory fallback is used when `indexedDB` is undefined.
+
+## Acceptance criteria mapping
+
+From the issue:
+
+- [x] Per-event TTL respected on read; expired rows are filtered out
+      and queued for cleanup → expired rows are filtered AND deleted
+      from the store on read (single pass, no separate queue).
+- [x] Wholesale clear-and-rewrite is gone; cache is upsert-only.
+- [ ] QuotaExceededError triggers least-recently-used eviction —
+      **deferred**.
+- [x] In-memory fallback transparently substitutes when IndexedDB is
+      unavailable; no caller code changes.
+- [x] Unit tests for TTL expiry, upsert, and the fallback path.
+
+## Risk / caller impact
+
+The only production caller is `CalendarProvider.tsx`. It uses
+`eventCache.saveEvents(googleEvents)` and `eventCache.getEvents()` —
+the new facade keeps both methods and the same Promise-returning
+shape, so the caller is unchanged. The existing `vi.mock` in
+`CalendarProvider.test.tsx` continues to work.

--- a/src/lib/__tests__/event-cache.test.ts
+++ b/src/lib/__tests__/event-cache.test.ts
@@ -1,0 +1,204 @@
+import {
+  EVENT_CACHE_TTL_MS,
+  EventCache,
+  type EventStore,
+  InMemoryEventStore,
+  IndexedDBEventStore,
+  selectEventStore,
+} from "@/lib/event-cache";
+import type { GoogleCalendarEvent } from "@/lib/google-calendar";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+function makeEvent(
+  id: string,
+  overrides?: Partial<GoogleCalendarEvent>
+): GoogleCalendarEvent {
+  return {
+    id,
+    summary: `Event ${id}`,
+    start: { dateTime: "2026-05-03T10:00:00Z" },
+    end: { dateTime: "2026-05-03T11:00:00Z" },
+    calendarId: "primary",
+    ...overrides,
+  };
+}
+
+describe("InMemoryEventStore", () => {
+  let store: InMemoryEventStore;
+
+  beforeEach(() => {
+    store = new InMemoryEventStore();
+  });
+
+  it("round-trips events that were just put", async () => {
+    await store.put([makeEvent("a"), makeEvent("b")], 1_000);
+
+    const got = await store.getAll(1_000);
+    expect(got.map((e) => e.id).sort()).toEqual(["a", "b"]);
+  });
+
+  it("upserts by id (latest write wins, no duplicates)", async () => {
+    await store.put([makeEvent("a", { summary: "first" })], 1_000);
+    await store.put([makeEvent("a", { summary: "second" })], 2_000);
+
+    const got = await store.getAll(2_000);
+    expect(got).toHaveLength(1);
+    expect(got[0]?.summary).toBe("second");
+  });
+
+  it("preserves untouched ids when a later put covers a disjoint set", async () => {
+    await store.put([makeEvent("a"), makeEvent("b")], 1_000);
+    await store.put([makeEvent("c")], 2_000);
+
+    const got = await store.getAll(2_000);
+    expect(got.map((e) => e.id).sort()).toEqual(["a", "b", "c"]);
+  });
+
+  it("filters out entries older than the TTL on read", async () => {
+    await store.put([makeEvent("fresh")], 1_000);
+    await store.put([makeEvent("stale")], 1_000 - EVENT_CACHE_TTL_MS - 1);
+
+    const got = await store.getAll(1_000);
+    expect(got.map((e) => e.id)).toEqual(["fresh"]);
+  });
+
+  it("evicts expired entries from the store on read", async () => {
+    const expiredCachedAt = 1_000 - EVENT_CACHE_TTL_MS - 1;
+    await store.put([makeEvent("stale")], expiredCachedAt);
+    await store.put([makeEvent("fresh")], 1_000);
+
+    await store.getAll(1_000);
+
+    // After eviction, even when peeking at a "now" near the stale row's
+    // original cachedAt, only the fresh row is present (proves the stale
+    // row was deleted from the underlying map, not just filtered out).
+    const peek = await store.getAll(expiredCachedAt + 10);
+    expect(peek.map((e) => e.id)).toEqual(["fresh"]);
+  });
+
+  it("strips the cachedAt timestamp from returned events", async () => {
+    await store.put([makeEvent("a")], 1_000);
+    const got = await store.getAll(1_000);
+    expect(got[0]).not.toHaveProperty("cachedAt");
+  });
+
+  it("clear() empties the store", async () => {
+    await store.put([makeEvent("a")], 1_000);
+    await store.clear();
+    expect(await store.getAll(1_000)).toEqual([]);
+  });
+
+  it("returns an empty array when nothing has been written", async () => {
+    expect(await store.getAll(1_000)).toEqual([]);
+  });
+});
+
+describe("EventCache facade", () => {
+  let store: InMemoryEventStore;
+  let cache: EventCache;
+
+  beforeEach(() => {
+    store = new InMemoryEventStore();
+    cache = new EventCache(store);
+  });
+
+  it("delegates saveEvents to store.put with the current time", async () => {
+    const putSpy = vi.spyOn(store, "put");
+    const events = [makeEvent("a")];
+    await cache.saveEvents(events);
+
+    expect(putSpy).toHaveBeenCalledOnce();
+    const [passedEvents, cachedAt] = putSpy.mock.calls[0]!;
+    expect(passedEvents).toEqual(events);
+    expect(cachedAt).toBeTypeOf("number");
+    expect(cachedAt).toBeGreaterThan(0);
+  });
+
+  it("delegates getEvents to store.getAll", async () => {
+    const getAllSpy = vi.spyOn(store, "getAll");
+    await cache.saveEvents([makeEvent("a")]);
+    const got = await cache.getEvents();
+
+    expect(getAllSpy).toHaveBeenCalledOnce();
+    expect(got.map((e) => e.id)).toEqual(["a"]);
+  });
+
+  it("does not surface entries older than the TTL", async () => {
+    const realDateNow = Date.now;
+    try {
+      Date.now = () => 1_000_000_000_000;
+      await cache.saveEvents([makeEvent("old")]);
+      Date.now = () => 1_000_000_000_000 + EVENT_CACHE_TTL_MS + 1;
+      await cache.saveEvents([makeEvent("new")]);
+      const got = await cache.getEvents();
+      expect(got.map((e) => e.id)).toEqual(["new"]);
+    } finally {
+      Date.now = realDateNow;
+    }
+  });
+
+  it("falls back to the in-memory store when the underlying store rejects", async () => {
+    let calls = 0;
+    const flaky: EventStore = {
+      put: vi.fn(async () => {
+        calls += 1;
+        if (calls === 1) throw new Error("idb dead");
+      }),
+      getAll: vi.fn(async () => []),
+      clear: vi.fn(async () => {}),
+    };
+    const flakyCache = new EventCache(flaky);
+
+    // First write fails on the flaky store, transparently retried in-memory.
+    await flakyCache.saveEvents([makeEvent("a")]);
+    expect(flaky.put).toHaveBeenCalledOnce();
+
+    // Subsequent reads now go through the in-memory store, not the flaky one.
+    const got = await flakyCache.getEvents();
+    expect(got.map((e) => e.id)).toEqual(["a"]);
+    expect(flaky.getAll).not.toHaveBeenCalled();
+  });
+
+  it("re-throws when even the in-memory fallback rejects", async () => {
+    const dead: EventStore = {
+      put: vi.fn(async () => {
+        throw new Error("dead");
+      }),
+      getAll: vi.fn(),
+      clear: vi.fn(),
+    };
+    const deadCache = new EventCache(new InMemoryEventStore());
+    // Force the cache into a state where the active store is the failing one.
+    (deadCache as unknown as { store: EventStore }).store = dead;
+    (deadCache as unknown as { hasFallenBack: boolean }).hasFallenBack = true;
+
+    await expect(deadCache.saveEvents([makeEvent("a")])).rejects.toThrow(
+      "dead"
+    );
+  });
+});
+
+describe("selectEventStore", () => {
+  const originalIndexedDb = (globalThis as { indexedDB?: IDBFactory })
+    .indexedDB;
+
+  afterEach(() => {
+    if (originalIndexedDb === undefined) {
+      delete (globalThis as { indexedDB?: IDBFactory }).indexedDB;
+    } else {
+      (globalThis as { indexedDB?: IDBFactory }).indexedDB = originalIndexedDb;
+    }
+  });
+
+  it("returns the in-memory store when indexedDB is undefined", () => {
+    delete (globalThis as { indexedDB?: IDBFactory }).indexedDB;
+    expect(selectEventStore()).toBeInstanceOf(InMemoryEventStore);
+  });
+
+  it("returns an IndexedDBEventStore when indexedDB is defined", () => {
+    (globalThis as { indexedDB?: IDBFactory }).indexedDB = {
+      open: vi.fn(),
+    } as unknown as IDBFactory;
+    expect(selectEventStore()).toBeInstanceOf(IndexedDBEventStore);
+  });
+});

--- a/src/lib/calendar-storage.ts
+++ b/src/lib/calendar-storage.ts
@@ -1,13 +1,14 @@
 /**
  * Browser storage utilities for calendar data
- * Handles localStorage for accounts and IndexedDB for event caching
+ * Handles localStorage for accounts; the IndexedDB event cache lives in
+ * `./event-cache` and is re-exported here for callers that import via this
+ * module.
  */
 import { logger } from "@/lib/logger";
 import type { TEventColor } from "@/types/calendar";
-import type {
-  GoogleCalendarAccount,
-  GoogleCalendarEvent,
-} from "./google-calendar";
+import type { GoogleCalendarAccount } from "./google-calendar";
+
+export { eventCache } from "./event-cache";
 
 const STORAGE_KEYS = {
   ACCOUNTS: "calendar_accounts",
@@ -273,137 +274,3 @@ export function clearAllData(): void {
     throw error;
   }
 }
-
-/**
- * IndexedDB storage for cached events
- */
-class EventCache {
-  private dbName = "CalendarEventsDB";
-  private storeName = "events";
-  private db: IDBDatabase | null = null;
-
-  async init(): Promise<void> {
-    if (this.db) {
-      return;
-    }
-
-    return new Promise((resolve, reject) => {
-      const request = indexedDB.open(this.dbName, 1);
-
-      request.onerror = () => {
-        logger.error(new Error("Failed to open IndexedDB"), {
-          context: "EventCache.init",
-        });
-        reject(request.error);
-      };
-
-      request.onsuccess = () => {
-        this.db = request.result;
-        resolve();
-      };
-
-      request.onupgradeneeded = (event) => {
-        const db = (event.target as IDBOpenDBRequest).result;
-        if (!db.objectStoreNames.contains(this.storeName)) {
-          const objectStore = db.createObjectStore(this.storeName, {
-            keyPath: "id",
-          });
-          objectStore.createIndex("calendarId", "calendarId", {
-            unique: false,
-          });
-          objectStore.createIndex("start", "start", { unique: false });
-        }
-      };
-    });
-  }
-
-  async saveEvents(events: GoogleCalendarEvent[]): Promise<void> {
-    await this.init();
-    if (!this.db) {
-      throw new Error("Database not initialized");
-    }
-
-    return new Promise((resolve, reject) => {
-      const transaction = this.db!.transaction([this.storeName], "readwrite");
-      const objectStore = transaction.objectStore(this.storeName);
-
-      // Clear existing events first
-      objectStore.clear();
-
-      // Add new events
-      events.forEach((event) => {
-        objectStore.add({
-          ...event,
-          // Store start date as timestamp for indexing
-          start: event.start.dateTime || event.start.date,
-        });
-      });
-
-      transaction.oncomplete = () => {
-        logger.log("Cached events in IndexedDB", { count: events.length });
-        resolve();
-      };
-
-      transaction.onerror = () => {
-        logger.error(new Error("Failed to cache events"), {
-          context: "EventCache.saveEvents",
-        });
-        reject(transaction.error);
-      };
-    });
-  }
-
-  async getEvents(): Promise<GoogleCalendarEvent[]> {
-    await this.init();
-    if (!this.db) {
-      throw new Error("Database not initialized");
-    }
-
-    return new Promise((resolve, reject) => {
-      const transaction = this.db!.transaction([this.storeName], "readonly");
-      const objectStore = transaction.objectStore(this.storeName);
-      const request = objectStore.getAll();
-
-      request.onsuccess = () => {
-        logger.log("Retrieved cached events", {
-          count: request.result.length,
-        });
-        resolve(request.result);
-      };
-
-      request.onerror = () => {
-        logger.error(new Error("Failed to retrieve cached events"), {
-          context: "EventCache.getEvents",
-        });
-        reject(request.error);
-      };
-    });
-  }
-
-  async clearEvents(): Promise<void> {
-    await this.init();
-    if (!this.db) {
-      throw new Error("Database not initialized");
-    }
-
-    return new Promise((resolve, reject) => {
-      const transaction = this.db!.transaction([this.storeName], "readwrite");
-      const objectStore = transaction.objectStore(this.storeName);
-      const request = objectStore.clear();
-
-      request.onsuccess = () => {
-        logger.log("Cleared cached events");
-        resolve();
-      };
-
-      request.onerror = () => {
-        logger.error(new Error("Failed to clear cached events"), {
-          context: "EventCache.clearEvents",
-        });
-        reject(request.error);
-      };
-    });
-  }
-}
-
-export const eventCache = new EventCache();

--- a/src/lib/event-cache.ts
+++ b/src/lib/event-cache.ts
@@ -1,0 +1,237 @@
+/**
+ * Cached calendar events.
+ *
+ * `EventCache` is the single public surface used by `CalendarProvider`.
+ * Internally it delegates to an `EventStore` implementation; the in-memory
+ * store is used when IndexedDB is unavailable (private mode, certain
+ * WebViews, SSR / test envs) or when the IndexedDB-backed store rejects a
+ * call at runtime.
+ *
+ * Per-event `cachedAt` timestamps are filtered against `EVENT_CACHE_TTL_MS`
+ * on read so callers never see stale rows. Expired rows are also evicted
+ * from the store as a side effect of the read so the cache does not grow
+ * unbounded.
+ *
+ * Writes use upsert semantics (`put` keyed by event id) — there is no
+ * `clear+rewrite` window during which the cache is empty.
+ */
+import type { GoogleCalendarEvent } from "@/lib/google-calendar";
+import { logger } from "@/lib/logger";
+
+export const EVENT_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+
+const DB_NAME = "CalendarEventsDB";
+const STORE_NAME = "events";
+const DB_VERSION = 2;
+
+interface CachedEventRow extends GoogleCalendarEvent {
+  cachedAt: number;
+}
+
+function stripCachedAt(row: CachedEventRow): GoogleCalendarEvent {
+  const copy: CachedEventRow = { ...row };
+  delete (copy as Partial<CachedEventRow>).cachedAt;
+  return copy;
+}
+
+export interface EventStore {
+  put(events: GoogleCalendarEvent[], cachedAt: number): Promise<void>;
+  getAll(now: number): Promise<GoogleCalendarEvent[]>;
+  clear(): Promise<void>;
+}
+
+export class InMemoryEventStore implements EventStore {
+  private rows = new Map<string, CachedEventRow>();
+
+  async put(events: GoogleCalendarEvent[], cachedAt: number): Promise<void> {
+    for (const event of events) {
+      this.rows.set(event.id, { ...event, cachedAt });
+    }
+  }
+
+  async getAll(now: number): Promise<GoogleCalendarEvent[]> {
+    const fresh: GoogleCalendarEvent[] = [];
+    for (const [id, row] of this.rows) {
+      if (now - row.cachedAt < EVENT_CACHE_TTL_MS) {
+        fresh.push(stripCachedAt(row));
+      } else {
+        this.rows.delete(id);
+      }
+    }
+    return fresh;
+  }
+
+  async clear(): Promise<void> {
+    this.rows.clear();
+  }
+}
+
+export class IndexedDBEventStore implements EventStore {
+  private db: IDBDatabase | null = null;
+  private initPromise: Promise<void> | null = null;
+
+  private init(): Promise<void> {
+    if (this.db) {
+      return Promise.resolve();
+    }
+    if (this.initPromise) {
+      return this.initPromise;
+    }
+    this.initPromise = new Promise((resolve, reject) => {
+      let request: IDBOpenDBRequest;
+      try {
+        request = indexedDB.open(DB_NAME, DB_VERSION);
+      } catch (error) {
+        this.initPromise = null;
+        reject(error);
+        return;
+      }
+
+      request.onerror = () => {
+        this.initPromise = null;
+        reject(request.error);
+      };
+
+      request.onsuccess = () => {
+        this.db = request.result;
+        resolve();
+      };
+
+      request.onupgradeneeded = (event) => {
+        const db = (event.target as IDBOpenDBRequest).result;
+        let objectStore: IDBObjectStore;
+        if (!db.objectStoreNames.contains(STORE_NAME)) {
+          objectStore = db.createObjectStore(STORE_NAME, { keyPath: "id" });
+          objectStore.createIndex("calendarId", "calendarId", {
+            unique: false,
+          });
+        } else {
+          objectStore = request.transaction!.objectStore(STORE_NAME);
+        }
+        if (!objectStore.indexNames.contains("cachedAt")) {
+          objectStore.createIndex("cachedAt", "cachedAt", { unique: false });
+        }
+      };
+    });
+    return this.initPromise;
+  }
+
+  async put(events: GoogleCalendarEvent[], cachedAt: number): Promise<void> {
+    await this.init();
+    if (!this.db) {
+      throw new Error("Database not initialized");
+    }
+    return new Promise((resolve, reject) => {
+      const transaction = this.db!.transaction([STORE_NAME], "readwrite");
+      const objectStore = transaction.objectStore(STORE_NAME);
+      for (const event of events) {
+        const row: CachedEventRow = { ...event, cachedAt };
+        objectStore.put(row);
+      }
+      transaction.oncomplete = () => resolve();
+      transaction.onerror = () => reject(transaction.error);
+    });
+  }
+
+  async getAll(now: number): Promise<GoogleCalendarEvent[]> {
+    await this.init();
+    if (!this.db) {
+      throw new Error("Database not initialized");
+    }
+    return new Promise((resolve, reject) => {
+      const transaction = this.db!.transaction([STORE_NAME], "readwrite");
+      const objectStore = transaction.objectStore(STORE_NAME);
+      const request = objectStore.getAll();
+      request.onsuccess = () => {
+        const rows = request.result as CachedEventRow[];
+        const fresh: GoogleCalendarEvent[] = [];
+        const expiredIds: string[] = [];
+        for (const row of rows) {
+          if (now - row.cachedAt < EVENT_CACHE_TTL_MS) {
+            fresh.push(stripCachedAt(row));
+          } else {
+            expiredIds.push(row.id);
+          }
+        }
+        for (const id of expiredIds) {
+          objectStore.delete(id);
+        }
+        resolve(fresh);
+      };
+      request.onerror = () => reject(request.error);
+    });
+  }
+
+  async clear(): Promise<void> {
+    await this.init();
+    if (!this.db) {
+      throw new Error("Database not initialized");
+    }
+    return new Promise((resolve, reject) => {
+      const transaction = this.db!.transaction([STORE_NAME], "readwrite");
+      const objectStore = transaction.objectStore(STORE_NAME);
+      const request = objectStore.clear();
+      request.onsuccess = () => resolve();
+      request.onerror = () => reject(request.error);
+    });
+  }
+}
+
+/**
+ * Pick the best-available store at construction time. When `indexedDB` is
+ * not present at all, return the in-memory implementation directly.
+ * Otherwise return the IndexedDB-backed store; the `EventCache` facade is
+ * responsible for catching any runtime failures and swapping in the
+ * in-memory store on the fly.
+ */
+export function selectEventStore(): EventStore {
+  if (typeof globalThis.indexedDB === "undefined") {
+    return new InMemoryEventStore();
+  }
+  return new IndexedDBEventStore();
+}
+
+export class EventCache {
+  private store: EventStore;
+  private hasFallenBack = false;
+
+  constructor(store?: EventStore) {
+    this.store = store ?? selectEventStore();
+  }
+
+  async saveEvents(events: GoogleCalendarEvent[]): Promise<void> {
+    return this.withFallback(
+      async (store) => store.put(events, Date.now()),
+      "EventCache.saveEvents"
+    );
+  }
+
+  async getEvents(): Promise<GoogleCalendarEvent[]> {
+    return this.withFallback(
+      async (store) => store.getAll(Date.now()),
+      "EventCache.getEvents"
+    );
+  }
+
+  private async withFallback<T>(
+    op: (store: EventStore) => Promise<T>,
+    context: string
+  ): Promise<T> {
+    try {
+      return await op(this.store);
+    } catch (error) {
+      if (this.hasFallenBack || this.store instanceof InMemoryEventStore) {
+        logger.error(error as Error, { context });
+        throw error;
+      }
+      logger.error(error as Error, {
+        context: `${context} (falling back to in-memory cache)`,
+      });
+      this.store = new InMemoryEventStore();
+      this.hasFallenBack = true;
+      return op(this.store);
+    }
+  }
+}
+
+export const eventCache = new EventCache();


### PR DESCRIPTION
Partially addresses #218.

## Summary

Reworks the event cache so reads filter against per-event `cachedAt`
timestamps (default 24h TTL), writes upsert by id instead of
clear-and-rewrite, and an in-memory `Map` transparently substitutes
when IndexedDB is unavailable or rejects a call at runtime.

The cache implementation moves out of `calendar-storage.ts` into a new
`src/lib/event-cache.ts` module. `calendar-storage.ts` re-exports the
singleton so the existing `CalendarProvider` import path is unchanged
and the existing `vi.mock("@/lib/calendar-storage", ...)` continues to
intercept correctly.

## Acceptance criteria mapping

From the issue:

- [x] Per-event TTL respected on read; expired rows are filtered out
      and evicted from the underlying store in the same pass
- [x] Wholesale clear-and-rewrite is gone — `EventStore.put` upserts
      by id, so partial-range refreshes don't blow away unrelated rows
      and there's no "cache empty" window between `clear` and the puts
- [x] In-memory fallback transparently substitutes when IndexedDB is
      unavailable; no caller code changes
- [x] Unit tests for TTL expiry, upsert, and the fallback path
- [ ] **Deferred:** `QuotaExceededError` → LRU eviction. Needs a
      recency index and an eviction-policy decision; will follow up.
- [ ] **Deferred:** background `visibilitychange` cleanup sweep. The
      read-time eviction already prevents stale rows from surfacing;
      this would be an additive sweep for cold caches.
- [ ] **Deferred:** wiring TTL to user settings. Would require a
      Prisma migration + settings UI; a 24h constant is a sensible
      default until that ships.

## Implementation notes

- Three-layer design: `EventStore` interface, `InMemoryEventStore`
  (also serves as the fallback), `IndexedDBEventStore` (production).
- The IDB store bumps the database version from `1` → `2` to add a
  `cachedAt` index for future range queries; the upgrade handler is
  idempotent and safe across reloads.
- `EventCache` (the public facade) catches any rejection from the
  active store, logs it, swaps to a fresh `InMemoryEventStore`, and
  retries the operation once. Subsequent calls go straight to the
  in-memory store.
- `selectEventStore()` picks the IDB-backed store when
  `typeof globalThis.indexedDB !== "undefined"` and otherwise returns
  the in-memory store directly. Test envs (jsdom) hit the latter path.

## Test plan

- [x] `pnpm test:run src/lib/__tests__/event-cache.test.ts` — 15/15
      passing (TTL filter, eviction, upsert, disjoint preservation,
      fallback retry, fallback re-throw, store selection)
- [x] `pnpm test:run` — 1587/1587 passing across 108 files
- [x] `pnpm lint:fix` clean on the changed files
- [x] `pnpm format:fix` clean
- [ ] `pnpm check-types` — pre-existing `AgendaList.test.tsx` failure
      on `main` (tracked by #244); the diff in this PR introduces no
      new type errors

## Caller impact

Single production caller is `CalendarProvider.tsx` via
`@/lib/calendar-storage`. The re-export keeps the import path stable
and the `saveEvents` / `getEvents` contract is unchanged.

https://claude.ai/code/session_01YPitVCE18u5GpjVW6V1HQa

---
_Generated by [Claude Code](https://claude.ai/code/session_01YPitVCE18u5GpjVW6V1HQa)_