### PR TITLE
chore(auth): drop NEXT_PUBLIC_ prefix from server-side OAuth client id (#275)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,8 +64,15 @@ TOKEN_ENCRYPTION_KEY=your-32-byte-base64-encryption-key
 #    - Google Calendar API
 #    - Google Tasks API
 
+# Server-only — read by NextAuth and the /api/auth/refresh-token route.
+# The unprefixed name keeps the value out of the browser bundle.
 GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=your-client-secret
 
-# Legacy: Used by old client-side auth (deprecated, will be removed)
+# Legacy: only the deprecated browser-side gapi/GIS path in
+# `src/lib/google-calendar.ts` reads this. The `NEXT_PUBLIC_` prefix forces
+# Next.js to inline the value into the browser bundle, which is required for
+# the legacy client-side auth flow but unnecessary once that flow retires.
+# New server-side code MUST read `GOOGLE_CLIENT_ID` instead. See
+# docs/google-calendar-setup.md.
 NEXT_PUBLIC_GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com

--- a/.env.example
+++ b/.env.example
@@ -70,9 +70,10 @@ GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=your-client-secret
 
 # Legacy: only the deprecated browser-side gapi/GIS path in
-# `src/lib/google-calendar.ts` reads this. The `NEXT_PUBLIC_` prefix forces
+# `src/lib/google-calendar.ts` reads these. The `NEXT_PUBLIC_` prefix forces
 # Next.js to inline the value into the browser bundle, which is required for
 # the legacy client-side auth flow but unnecessary once that flow retires.
 # New server-side code MUST read `GOOGLE_CLIENT_ID` instead. See
 # docs/google-calendar-setup.md.
 NEXT_PUBLIC_GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
+NEXT_PUBLIC_GOOGLE_API_KEY=your-google-api-key

--- a/.env.local.example
+++ b/.env.local.example
@@ -32,21 +32,35 @@ NEXT_PUBLIC_APPLICATIONINSIGHTS_CONNECTION_STRING=your-connection-string-here
 # Google Calendar API Configuration
 # =============================================================================
 
-# Google Calendar API credentials for client-side authentication
-# Follow setup instructions in docs/google-calendar-setup.md
+# Google Calendar API credentials. Follow the setup steps in
+# docs/google-calendar-setup.md.
+#
+# Two separate OAuth identities are referenced below:
+#   1. Server-only:  GOOGLE_CLIENT_ID + GOOGLE_CLIENT_SECRET
+#      Read by NextAuth and the /api/auth/refresh-token route. Unprefixed
+#      so Next.js does NOT inline these into the browser bundle.
+#   2. Browser-only: NEXT_PUBLIC_GOOGLE_CLIENT_ID + NEXT_PUBLIC_GOOGLE_API_KEY
+#      Read by the legacy client-side gapi/GIS flow in
+#      `src/lib/google-calendar.ts`. The `NEXT_PUBLIC_` prefix is required
+#      because the value is consumed in the browser. New server-side code
+#      MUST NOT read these — use the unprefixed pair instead.
+#
+# In practice the same OAuth 2.0 Client ID can be used for both pairs while
+# the legacy client-side flow exists.
 
-# Get this from Google Cloud Console > APIs & Services > Credentials
-# Create OAuth 2.0 Client ID for Web application
+# Server-side OAuth Client ID (used by NextAuth + token refresh)
+GOOGLE_CLIENT_ID=your-google-client-id.apps.googleusercontent.com
+
+# Server-side OAuth Client Secret (REQUIRED for token refresh functionality)
+# IMPORTANT: Keep this secret! Never commit to source control.
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+
+# Browser-side OAuth Client ID (legacy gapi/GIS flow only)
 NEXT_PUBLIC_GOOGLE_CLIENT_ID=your-google-client-id.apps.googleusercontent.com
 
-# Create API Key in Google Cloud Console > APIs & Services > Credentials
+# Browser-side API Key (legacy gapi/GIS flow only)
+# Create in Google Cloud Console > APIs & Services > Credentials
 NEXT_PUBLIC_GOOGLE_API_KEY=your-google-api-key
-
-# OAuth Client Secret (REQUIRED for token refresh functionality)
-# IMPORTANT: Keep this secret! Never commit to source control.
-# Get this from the same OAuth 2.0 Client ID credentials page
-# This is used server-side to refresh expired access tokens
-GOOGLE_CLIENT_SECRET=your-google-client-secret
 
 # =============================================================================
 # Other Configuration (Optional)

--- a/docs/google-calendar-setup.md
+++ b/docs/google-calendar-setup.md
@@ -89,12 +89,23 @@ This guide will walk you through setting up Google Calendar API credentials for 
 2. Open `.env.local` and add your credentials:
 
    ```
+   # Server-only — used by NextAuth and the token-refresh API route.
+   # Unprefixed so Next.js does NOT inline these into the browser bundle.
+   GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
+   GOOGLE_CLIENT_SECRET=your-client-secret
+
+   # Browser-only — required by the legacy client-side gapi/GIS flow in
+   # src/lib/google-calendar.ts. The NEXT_PUBLIC_ prefix is intentional:
+   # these values are consumed in the browser. The same OAuth 2.0 Client ID
+   # can be used for both server- and browser-side variables while the
+   # legacy flow is still in place.
    NEXT_PUBLIC_GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
    NEXT_PUBLIC_GOOGLE_API_KEY=your-api-key
-   GOOGLE_CLIENT_SECRET=your-client-secret
    ```
 
    ⚠️ **Important**: The `GOOGLE_CLIENT_SECRET` is used server-side to refresh access tokens automatically. Keep it secure and never expose it in client-side code.
+
+   ℹ️ **For contributors**: New server-side code (API routes, server components, NextAuth callbacks) MUST read `process.env.GOOGLE_CLIENT_ID`, never `process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID`. The `NEXT_PUBLIC_` prefix forces Next.js to inline the value into every browser bundle that transitively imports the file — which leaks the client id even when the consumer is server-only.
 
 3. Replace the placeholders with the values you copied in previous steps
 

--- a/src/app/api/auth/refresh-token/__tests__/route.test.ts
+++ b/src/app/api/auth/refresh-token/__tests__/route.test.ts
@@ -52,21 +52,22 @@ const SUCCESS_TOKENS = {
   token_type: "Bearer",
 };
 
-const ORIGINAL_ENV = { ...process.env };
-
 describe("POST /api/auth/refresh-token", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Server-only env vars used by the route.
-    process.env.GOOGLE_CLIENT_ID = "server-client-id";
-    process.env.GOOGLE_CLIENT_SECRET = "server-client-secret";
+    // `vi.stubEnv` mutates `process.env` in-place (preserving Node's special
+    // env object) and tracks each stub for `vi.unstubAllEnvs()` to revert in
+    // afterEach. Reassigning `process.env = { ... }` would break the special
+    // descriptor behaviour Node depends on.
+    vi.stubEnv("GOOGLE_CLIENT_ID", "server-client-id");
+    vi.stubEnv("GOOGLE_CLIENT_SECRET", "server-client-secret");
     // The legacy public var has a different value so any code path that still
     // reads it instead of GOOGLE_CLIENT_ID is caught by the assertion below.
-    process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID = "public-client-id-LEAKED";
+    vi.stubEnv("NEXT_PUBLIC_GOOGLE_CLIENT_ID", "public-client-id-LEAKED");
   });
 
   afterEach(() => {
-    process.env = { ...ORIGINAL_ENV };
+    vi.unstubAllEnvs();
   });
 
   it("returns 400 when refreshToken is missing", async () => {
@@ -84,10 +85,10 @@ describe("POST /api/auth/refresh-token", () => {
   });
 
   it("returns 500 when GOOGLE_CLIENT_ID is missing (does NOT fall back to NEXT_PUBLIC_GOOGLE_CLIENT_ID)", async () => {
-    delete process.env.GOOGLE_CLIENT_ID;
+    vi.stubEnv("GOOGLE_CLIENT_ID", undefined);
     // The public var is still set; if the route falls back to it the test
     // fails, which is the regression-prevention point of this case.
-    process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID = "public-client-id-LEAKED";
+    vi.stubEnv("NEXT_PUBLIC_GOOGLE_CLIENT_ID", "public-client-id-LEAKED");
 
     const request = createMockRequest("/api/auth/refresh-token", {
       method: "POST",
@@ -103,7 +104,7 @@ describe("POST /api/auth/refresh-token", () => {
   });
 
   it("returns 500 when GOOGLE_CLIENT_SECRET is missing", async () => {
-    delete process.env.GOOGLE_CLIENT_SECRET;
+    vi.stubEnv("GOOGLE_CLIENT_SECRET", undefined);
 
     const request = createMockRequest("/api/auth/refresh-token", {
       method: "POST",

--- a/src/app/api/auth/refresh-token/__tests__/route.test.ts
+++ b/src/app/api/auth/refresh-token/__tests__/route.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Integration tests for the /api/auth/refresh-token route.
+ *
+ * Issue #275: this server-only route used to read the OAuth client id from
+ * `process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID`, which Next.js inlines into the
+ * browser bundle even though the route is never imported client-side. The
+ * route now reads the unprefixed `GOOGLE_CLIENT_ID` (matching `auth.ts`); the
+ * "reads GOOGLE_CLIENT_ID, ignores NEXT_PUBLIC_GOOGLE_CLIENT_ID" cases below
+ * lock that in.
+ */
+import {
+  GoogleTokenRefreshError,
+  refreshGoogleAccessToken,
+} from "@/lib/auth/refresh-google-token";
+import {
+  type ApiErrorResponse,
+  createMockRequest,
+  parseResponse,
+} from "@/lib/test-utils/api-test-helpers";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { POST } from "../route";
+
+vi.mock("@/lib/auth/refresh-google-token", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/auth/refresh-google-token")
+  >("@/lib/auth/refresh-google-token");
+  return {
+    ...actual,
+    refreshGoogleAccessToken: vi.fn(),
+  };
+});
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    error: vi.fn(),
+    log: vi.fn(),
+    event: vi.fn(),
+  },
+}));
+
+interface RefreshSuccessResponse {
+  access_token: string;
+  expires_in: number;
+  scope?: string;
+  token_type?: string;
+}
+
+const SUCCESS_TOKENS = {
+  access_token: "ya29.new-access-token",
+  expires_in: 3600,
+  scope: "https://www.googleapis.com/auth/calendar.readonly",
+  token_type: "Bearer",
+};
+
+const ORIGINAL_ENV = { ...process.env };
+
+describe("POST /api/auth/refresh-token", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Server-only env vars used by the route.
+    process.env.GOOGLE_CLIENT_ID = "server-client-id";
+    process.env.GOOGLE_CLIENT_SECRET = "server-client-secret";
+    // The legacy public var has a different value so any code path that still
+    // reads it instead of GOOGLE_CLIENT_ID is caught by the assertion below.
+    process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID = "public-client-id-LEAKED";
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  it("returns 400 when refreshToken is missing", async () => {
+    const request = createMockRequest("/api/auth/refresh-token", {
+      method: "POST",
+      body: {},
+    });
+
+    const response = await POST(request);
+    const { status, data } = await parseResponse<ApiErrorResponse>(response);
+
+    expect(status).toBe(400);
+    expect(data.error).toBe("Refresh token is required");
+    expect(refreshGoogleAccessToken).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when GOOGLE_CLIENT_ID is missing (does NOT fall back to NEXT_PUBLIC_GOOGLE_CLIENT_ID)", async () => {
+    delete process.env.GOOGLE_CLIENT_ID;
+    // The public var is still set; if the route falls back to it the test
+    // fails, which is the regression-prevention point of this case.
+    process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID = "public-client-id-LEAKED";
+
+    const request = createMockRequest("/api/auth/refresh-token", {
+      method: "POST",
+      body: { refreshToken: "rt-abc" },
+    });
+
+    const response = await POST(request);
+    const { status, data } = await parseResponse<ApiErrorResponse>(response);
+
+    expect(status).toBe(500);
+    expect(data.error).toBe("Server configuration error");
+    expect(refreshGoogleAccessToken).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when GOOGLE_CLIENT_SECRET is missing", async () => {
+    delete process.env.GOOGLE_CLIENT_SECRET;
+
+    const request = createMockRequest("/api/auth/refresh-token", {
+      method: "POST",
+      body: { refreshToken: "rt-abc" },
+    });
+
+    const response = await POST(request);
+    const { status, data } = await parseResponse<ApiErrorResponse>(response);
+
+    expect(status).toBe(500);
+    expect(data.error).toBe("Server configuration error");
+    expect(refreshGoogleAccessToken).not.toHaveBeenCalled();
+  });
+
+  it("passes server-only GOOGLE_CLIENT_ID (not NEXT_PUBLIC_GOOGLE_CLIENT_ID) to refreshGoogleAccessToken", async () => {
+    vi.mocked(refreshGoogleAccessToken).mockResolvedValue(SUCCESS_TOKENS);
+
+    const request = createMockRequest("/api/auth/refresh-token", {
+      method: "POST",
+      body: { refreshToken: "rt-abc" },
+    });
+
+    await POST(request);
+
+    expect(refreshGoogleAccessToken).toHaveBeenCalledTimes(1);
+    expect(refreshGoogleAccessToken).toHaveBeenCalledWith(
+      "rt-abc",
+      "server-client-id",
+      "server-client-secret"
+    );
+    // Belt-and-braces: the public-prefixed value must never reach Google.
+    const [, clientId] = vi.mocked(refreshGoogleAccessToken).mock.calls[0]!;
+    expect(clientId).not.toBe("public-client-id-LEAKED");
+    expect(clientId).not.toMatch(/LEAKED/);
+  });
+
+  it("returns the parsed tokens on success", async () => {
+    vi.mocked(refreshGoogleAccessToken).mockResolvedValue(SUCCESS_TOKENS);
+
+    const request = createMockRequest("/api/auth/refresh-token", {
+      method: "POST",
+      body: { refreshToken: "rt-abc" },
+    });
+
+    const response = await POST(request);
+    const { status, data } =
+      await parseResponse<RefreshSuccessResponse>(response);
+
+    expect(status).toBe(200);
+    expect(data.access_token).toBe(SUCCESS_TOKENS.access_token);
+    expect(data.expires_in).toBe(SUCCESS_TOKENS.expires_in);
+    expect(data.scope).toBe(SUCCESS_TOKENS.scope);
+    expect(data.token_type).toBe(SUCCESS_TOKENS.token_type);
+  });
+
+  it("returns 401 + requiresReauth on invalid_grant from Google", async () => {
+    vi.mocked(refreshGoogleAccessToken).mockRejectedValue(
+      new GoogleTokenRefreshError(400, {
+        error: "invalid_grant",
+        error_description: "Token has been expired or revoked.",
+      })
+    );
+
+    const request = createMockRequest("/api/auth/refresh-token", {
+      method: "POST",
+      body: { refreshToken: "revoked-rt" },
+    });
+
+    const response = await POST(request);
+    const { status, data } = await parseResponse<ApiErrorResponse>(response);
+
+    expect(status).toBe(401);
+    expect(data.error).toBe("Invalid or expired refresh token");
+    expect(data.requiresReauth).toBe(true);
+  });
+
+  it("returns 401 + requiresReauth on invalid_request from Google", async () => {
+    vi.mocked(refreshGoogleAccessToken).mockRejectedValue(
+      new GoogleTokenRefreshError(400, { error: "invalid_request" })
+    );
+
+    const request = createMockRequest("/api/auth/refresh-token", {
+      method: "POST",
+      body: { refreshToken: "rt" },
+    });
+
+    const response = await POST(request);
+    const { status, data } = await parseResponse<ApiErrorResponse>(response);
+
+    expect(status).toBe(401);
+    expect(data.requiresReauth).toBe(true);
+  });
+
+  it("forwards the upstream status on other GoogleTokenRefreshError shapes", async () => {
+    vi.mocked(refreshGoogleAccessToken).mockRejectedValue(
+      new GoogleTokenRefreshError(503, { error: "service_unavailable" })
+    );
+
+    const request = createMockRequest("/api/auth/refresh-token", {
+      method: "POST",
+      body: { refreshToken: "rt" },
+    });
+
+    const response = await POST(request);
+    const { status, data } = await parseResponse<ApiErrorResponse>(response);
+
+    expect(status).toBe(503);
+    expect(data.error).toBe("Failed to refresh token");
+    expect(data.requiresReauth).toBeUndefined();
+  });
+
+  it("returns 500 on unexpected non-GoogleTokenRefreshError throws", async () => {
+    vi.mocked(refreshGoogleAccessToken).mockRejectedValue(
+      new Error("network melted")
+    );
+
+    const request = createMockRequest("/api/auth/refresh-token", {
+      method: "POST",
+      body: { refreshToken: "rt" },
+    });
+
+    const response = await POST(request);
+    const { status, data } = await parseResponse<ApiErrorResponse>(response);
+
+    expect(status).toBe(500);
+    expect(data.error).toBe("Internal server error");
+  });
+});

--- a/src/app/api/auth/refresh-token/route.ts
+++ b/src/app/api/auth/refresh-token/route.ts
@@ -20,7 +20,11 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const clientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID;
+    // Server-only credentials. Use the unprefixed `GOOGLE_CLIENT_ID` to
+    // avoid Next.js inlining the value into the browser bundle (which the
+    // `NEXT_PUBLIC_` prefix would force, even from server-only routes).
+    // Mirrors `auth.ts`, the only other server-side consumer.
+    const clientId = process.env.GOOGLE_CLIENT_ID;
     const clientSecret = process.env.GOOGLE_CLIENT_SECRET;
 
     if (!clientId || !clientSecret) {


### PR DESCRIPTION
Closes #275.

## Summary

`/api/auth/refresh-token` was reading the OAuth client id from `process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID`. The `NEXT_PUBLIC_` prefix tells Next.js to inline the value into every client bundle that transitively imports the file, so the route was leaking the client id into the browser even though it only runs server-side.

This switches the route to the unprefixed `GOOGLE_CLIENT_ID` (matching `auth.ts`, the only other server-side consumer), and clarifies in the env examples and setup docs which variables are server-only vs. browser-only.

## Scope

Change is intentionally narrow:

- `src/app/api/auth/refresh-token/route.ts` — read `GOOGLE_CLIENT_ID` instead of `NEXT_PUBLIC_GOOGLE_CLIENT_ID`. Comment cites why the unprefixed name matters.
- `src/lib/google-calendar.ts` — **left as-is.** It's the legacy browser-side gapi/GIS path; `process.env.NEXT_PUBLIC_GOOGLE_*` reads there are correct because the value is consumed in the browser. (And in current main, this file is only `import type`d outside its own tests, so the runtime side is effectively dead — see verification below.)
- `.env.example`, `.env.local.example`, `docs/google-calendar-setup.md` — split the GOOGLE OAuth section into "server-only" (`GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET`) and "browser-only legacy" (`NEXT_PUBLIC_GOOGLE_CLIENT_ID` / `NEXT_PUBLIC_GOOGLE_API_KEY`), with a note that new server-side code MUST use the unprefixed pair.

## TDD

New tests in `src/app/api/auth/refresh-token/__tests__/route.test.ts` (9 cases). The two regression-prevention cases are the load-bearing ones:

- `returns 500 when GOOGLE_CLIENT_ID is missing (does NOT fall back to NEXT_PUBLIC_GOOGLE_CLIENT_ID)` — sets only `NEXT_PUBLIC_GOOGLE_CLIENT_ID="public-client-id-LEAKED"`, expects 500. Catches any future re-introduction of the public-prefixed read.
- `passes server-only GOOGLE_CLIENT_ID (not NEXT_PUBLIC_GOOGLE_CLIENT_ID) to refreshGoogleAccessToken` — sets both vars to distinct values, asserts the unprefixed value is what reaches the helper.

Both fail on the pre-fix code (verified locally) and pass on the post-fix code.

## Verification

`pnpm lint:fix && pnpm format:fix && pnpm check-types && pnpm test:run` — all green (1844/1844).

Standalone production build sanity check (`pnpm build` with distinct marker values for both env vars, then grep `.next/standalone`):

```
let r=process.env.GOOGLE_CLIENT_ID,n=process.env.GOOGLE_CLIENT_SECRET;
```

is what the compiled refresh-token chunk now contains. `NEXT_PUBLIC_GOOGLE_CLIENT_ID` does not appear in the route's chunk, and neither marker value leaks into `.next/static/*`. (Re: the public marker, it doesn't appear because every non-test import of `google-calendar.ts` is `import type` only — the runtime side that reads `NEXT_PUBLIC_GOOGLE_*` is currently dead code.)

## Test plan

- [x] Unit: 9 new route cases pass; full suite green
- [x] Type check / lint / format clean
- [x] Production build succeeds; grep `.next` confirms no server-only client id leakage and that `NEXT_PUBLIC_GOOGLE_CLIENT_ID` is no longer read in the refresh-token chunk
- [ ] Smoke: in a real deployment, sign in → wait for token expiry → confirm the refresh-token endpoint still issues a fresh access token (only `GOOGLE_CLIENT_ID` is required to be set; previously `NEXT_PUBLIC_GOOGLE_CLIENT_ID` would have sufficed)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DdoDbbYMRZnvgK6oTVofVz)_