### PR TITLE
chore(calendar): consume useSlideDirection hook in SimpleCalendar (#284)

### DIFF
--- a/src/components/calendar/SimpleCalendar.tsx
+++ b/src/components/calendar/SimpleCalendar.tsx
@@ -3,6 +3,7 @@
 import { AnimatedSwap } from "@/components/calendar/animated-swap";
 import { useCalendar } from "@/components/providers/CalendarProvider";
 import { Button } from "@/components/ui/button";
+import { useSlideDirection } from "@/hooks/use-slide-direction";
 import { useEventDelete } from "@/hooks/useEventDelete";
 import { getShortWeekdayLabels } from "@/lib/calendar-helpers";
 import {
@@ -101,22 +102,10 @@ export function SimpleCalendar() {
     weekRows.push(allCells.slice(i, i + 7));
   }
 
-  // Track the previously rendered month so we can derive slide direction
-  // automatically as the user navigates (next/prev buttons, today, keyboard,
-  // mini-calendar). Uses the React-recommended "setState during render" pattern
-  // (same as AnimatedSwap) so the direction is settled in a single pass; React
-  // Compiler handles memoization automatically — no useMemo/useCallback needed.
-  const currentMonthIndex = absoluteMonthIndex(monthStart);
-  const [prevMonthIndex, setPrevMonthIndex] = useState(currentMonthIndex);
-  const [slideDirection, setSlideDirection] = useState<"forward" | "backward">(
-    "forward"
-  );
-  if (prevMonthIndex !== currentMonthIndex) {
-    setSlideDirection(
-      currentMonthIndex < prevMonthIndex ? "backward" : "forward"
-    );
-    setPrevMonthIndex(currentMonthIndex);
-  }
+  // Slide direction follows the absolute-month-index delta so navigating
+  // forward/backward (next/prev, today, keyboard, mini-calendar) is detected
+  // uniformly. Day/Week/Year views use the same hook.
+  const slideDirection = useSlideDirection(absoluteMonthIndex(monthStart));
 
   const previousMonth = () => {
     const newDate = new Date(selectedDate);


### PR DESCRIPTION
## Summary

Closes #284.

`SimpleCalendar` was open-coding the prev-index / `setSlideDirection` pattern that PR #250 extracted into the shared `useSlideDirection` hook. Replacing the duplicate with the hook:

- Keeps month-slide direction logic in one place across Day / Week / Year / Month views (Day/Week/Year already adopted the hook via #250 and #299).
- Removes a future-bug source — a fix to the hook would otherwise not propagate to `SimpleCalendar`.
- Net `-16 / +5` lines in `SimpleCalendar.tsx`; no other files touched.

## Behavior change

None. Direction is still derived from `absoluteMonthIndex(monthStart)`, the same monotonic index the open-coded version used. The hook implements the identical "setState during render" pattern, so:

- First render returns `"forward"` — same as before.
- Index unchanged → previous direction retained — same as before.
- Index increased → `"forward"` — same as before.
- Index decreased → `"backward"` — same as before.

## Test plan

The existing `Month navigation slide direction` describe block in `SimpleCalendar.test.tsx` (lines 780–852) is the regression guard:

- [x] `slides the outgoing grid left (translateX(-100%)) on Next month`
- [x] `slides the outgoing grid right (translateX(100%)) on Previous month`
- [x] `keeps the role='grid' element stable across month changes (no remount)`
- [x] All 61 SimpleCalendar + useSlideDirection tests pass
- [x] Full suite: 126 files / 1890 tests pass
- [x] `pnpm lint:fix && pnpm format:fix && pnpm check-types` — clean

No new behavior, so per CLAUDE.md TDD policy the existing tests are the spec; no test additions or weakenings were made.

## Acceptance criteria from #284

- [x] `SimpleCalendar` imports and uses `useSlideDirection`
- [x] No duplicate slide-direction logic remains in `SimpleCalendar`
- [x] Existing tests pass without modification


---
_Generated by [Claude Code](https://claude.ai/code/session_01T8RCwgRMQVMGYDKGSPF4EE)_