### PR TITLE
fix(a11y): SSR-safe useReducedMotion eliminates AnimatedSwap hydration mismatch (#306)

### DIFF
--- a/.claude/commands/code-review-complexity.md
+++ b/.claude/commands/code-review-complexity.md
@@ -5,29 +5,37 @@ You are a specialized code review agent focused on **complexity and maintainabil
 ## Scope
 
 Scan all `.ts` and `.tsx` files in `src/` **excluding**:
+
 - `src/components/ui/` (third-party shadcn components)
 - Test files (`*.test.ts`, `*.test.tsx`, `__tests__/`)
 
 ## What to Look For
 
 ### 1. Long Functions (>40 lines)
+
 Read each source file and identify functions/methods exceeding 40 lines of actual logic (excluding blank lines and comments). These are prime candidates for extraction.
 
 ### 2. Large Files (>300 lines)
+
 Flag files exceeding 300 lines of source code. These often indicate multiple responsibilities crammed into one module.
 
 ### 3. Deep Nesting (3+ levels)
+
 Look for conditionals, loops, or try/catch blocks nested 3 or more levels deep. These are hard to follow and test.
 
 ### 4. High Parameter Count (4+)
+
 Functions with 4 or more parameters suggest the function is doing too much or needs a configuration object.
 
 ### 5. Excessive useEffect Chains
+
 In React components, look for multiple `useEffect` hooks that create implicit dependency chains. These are hard to reason about.
 
 ### 6. Approximate CRAP Score
+
 For each complex function, check if a corresponding test file exists. Code that is both complex AND untested is the highest priority.
-- CRAP = complexity * (1 - test_coverage)^2
+
+- CRAP = complexity \* (1 - test_coverage)^2
 - If no test file exists for a source file, assume 0% coverage for that file's functions.
 
 ## Output Format
@@ -42,6 +50,7 @@ EFFORT: {S|M|L}
 ```
 
 ## Severity Guide
+
 - **Critical**: CRAP score issue (complex + untested), or function >100 lines
 - **High**: Function >60 lines, or nesting >4 levels, or file >500 lines
 - **Medium**: Function >40 lines, or nesting 3 levels, or file >300 lines

--- a/.claude/commands/code-review-concerns.md
+++ b/.claude/commands/code-review-concerns.md
@@ -5,27 +5,34 @@ You are a specialized code review agent focused on **separation of concerns and 
 ## Scope
 
 Scan all `.ts` and `.tsx` files in `src/` **excluding**:
+
 - `src/components/ui/` (third-party shadcn components)
 - Test files (`*.test.ts`, `*.test.tsx`, `__tests__/`)
 
 ## What to Look For
 
 ### 1. Components Mixing Data Fetching with Presentation
+
 Look for React components that both fetch data (via `fetch`, API calls, database queries) AND render significant JSX. These should be split into container/presenter or use hooks for data.
 
 ### 2. God Providers / God Components
+
 Providers or components that handle too many concerns: data fetching, caching, state management, data transformation, error handling, AND rendering all in one file. Look for files with both `fetch`/`prisma` calls and complex JSX.
 
 ### 3. Business Logic in Route Handlers
+
 API routes (`src/app/api/`) should delegate to `lib/` functions for business logic. Flag routes where validation, computation, or complex data manipulation happens directly in the route handler instead of in a reusable utility.
 
 ### 4. Hooks Violating Single Responsibility
+
 Custom hooks that do too many unrelated things. A hook should have one clear purpose. Look for hooks with multiple unrelated state variables or effects.
 
 ### 5. Circular or Tangled Dependencies
+
 Check for files that import from each other, or import chains that suggest tight coupling between modules that should be independent.
 
 ### 6. Missing Abstraction Layers
+
 Look for repeated patterns that should be extracted - e.g., the same auth-check + error-handling pattern copy-pasted across multiple API routes, or similar data transformation logic in multiple places.
 
 ## Output Format
@@ -40,6 +47,7 @@ EFFORT: {S|M|L}
 ```
 
 ## Severity Guide
+
 - **Critical**: God component/provider (5+ distinct responsibilities in one file)
 - **High**: Component mixing data fetching and presentation, or heavy business logic in route handlers
 - **Medium**: Hook doing 2-3 unrelated things, or repeated auth/validation patterns not extracted

--- a/.claude/commands/code-review-dead-code.md
+++ b/.claude/commands/code-review-dead-code.md
@@ -9,36 +9,46 @@ Scan the entire `src/` directory and `package.json`.
 ## What to Look For
 
 ### 1. Unused shadcn/ui Components
+
 There are ~57 components in `src/components/ui/`. Use Grep to check which ones are actually imported by non-UI files. Any component not imported anywhere outside its own directory is potentially unused.
 
 ### 2. Unused Exports in lib/ Modules
+
 For each exported function/type/constant in `src/lib/`, verify it is imported somewhere. Pay special attention to:
+
 - `calendar-storage.ts` (many exported functions)
 - `calendar-helpers.ts`
 - `google-calendar.ts`
 - `proxy.ts`
 
 ### 3. Vestigial Code Post Server-Side Auth Migration
+
 The project migrated from client-side to server-side auth (PR #27). Look for:
+
 - References to `gapi-script` or Google API client-side libraries
 - `src/types/gapi.d.ts` - check if still needed
 - Any client-side OAuth flow code that should have been removed
 - LocalStorage/IndexedDB code that was replaced by server-side equivalents
 
 ### 4. Commented-Out Code Blocks
+
 Search for blocks of commented-out code (3+ consecutive commented lines that look like code, not documentation comments). These should either be restored or removed.
 
 ### 5. Demo/Test Pages
+
 Flag these pages as **Low severity** (they are intentional development scaffolding):
+
 - `src/app/demo-logging/`
 - `src/app/test/`
 - `src/app/components/`
 - `src/app/typography/`
 
 ### 6. Unused Dependencies
+
 Check `package.json` dependencies against actual imports in `src/`. Flag any package that appears in dependencies but is never imported.
 
 ### 7. Orphaned Test Files
+
 Test files whose corresponding source file has been deleted or significantly renamed.
 
 ## Output Format
@@ -53,6 +63,7 @@ EFFORT: {S|M|L}
 ```
 
 ## Severity Guide
+
 - **Critical**: Entire unused dependency in package.json adding to bundle size
 - **High**: Unused lib module or large block of vestigial code (>50 lines)
 - **Medium**: Unused UI component, unused export from an otherwise-used module

--- a/.claude/commands/code-review-fix.md
+++ b/.claude/commands/code-review-fix.md
@@ -7,14 +7,15 @@ You are the **remediation executor** for code review findings. Your job is to re
 List all open GitHub Issues with the `code-review` label:
 
 Use GitHub MCP tools (`mcp__github__list_issues` or `mcp__github__search_issues`) if available, otherwise use:
+
 ```bash
 gh issue list --label code-review --state open --json number,title,labels,body --limit 50
 ```
 
 Parse the issues and organize them into a table:
 
-| # | Severity | Category | File | Issue | Effort |
-|---|----------|----------|------|-------|--------|
+| #              | Severity               | Category               | File        | Issue               | Effort   |
+| -------------- | ---------------------- | ---------------------- | ----------- | ------------------- | -------- |
 | {issue number} | {severity from labels} | {category from labels} | {file path} | {brief description} | {effort} |
 
 Sort by: Critical first, then High, then Medium, then Low. Within the same severity, sort Small effort before Medium before Large.
@@ -22,6 +23,7 @@ Sort by: Critical first, then High, then Medium, then Low. Within the same sever
 ## Step 2: Ask User What to Fix
 
 Present the table and ask the user:
+
 - "Which issues would you like to address? (Enter issue numbers, 'all', or 'top N')"
 - Recommend starting with Critical+Small and High+Small items for maximum impact with minimum effort.
 
@@ -61,6 +63,7 @@ After all selected fixes are implemented and passing:
    ```
 
 Use GitHub MCP tools if available, otherwise:
+
 ```bash
 gh issue close {number} --comment "Resolved in commit {sha}. {summary}"
 ```
@@ -71,8 +74,8 @@ Present a summary:
 
 ### Remediation Summary
 
-| Issue | Status | Changes |
-|-------|--------|---------|
+| Issue              | Status                    | Changes            |
+| ------------------ | ------------------------- | ------------------ |
 | #{number}: {title} | Fixed / Skipped / Partial | {what was changed} |
 
 **Quality checks:** All passing / {details of any failures}

--- a/.claude/commands/code-review-patterns.md
+++ b/.claude/commands/code-review-patterns.md
@@ -5,12 +5,15 @@ You are a specialized code review agent focused on **pattern consistency across 
 ## Scope
 
 Scan all `.ts` and `.tsx` files in `src/` **excluding**:
+
 - `src/components/ui/` (third-party shadcn components)
 
 ## What to Look For
 
 ### 1. API Route Structure Consistency
+
 Compare all API routes in `src/app/api/`. Check for consistent patterns in:
+
 - Auth checking (do all routes verify the session the same way?)
 - Input validation approach
 - Error response format and status codes
@@ -20,13 +23,16 @@ Compare all API routes in `src/app/api/`. Check for consistent patterns in:
 Read at least 4-5 different route files and compare their patterns.
 
 ### 2. Error Handling Patterns
+
 - Are errors caught and handled the same way across the codebase?
 - Is `logger.error()` used consistently for all caught errors?
 - Are error responses to clients in a consistent format?
 - Look for bare `catch(e)` without logging vs. proper error handling.
 
 ### 3. Barrel Export Consistency
+
 Check which component directories have `index.ts` barrel files and which don't:
+
 - `src/components/profiles/` - has index?
 - `src/components/tasks/` - has index?
 - `src/components/calendar/` - has index?
@@ -38,12 +44,15 @@ Check which component directories have `index.ts` barrel files and which don't:
 Inconsistency here means imports are done differently depending on the module.
 
 ### 4. Import Style Consistency
+
 - Is the `@/` path alias used consistently, or do some files use relative paths?
 - Is import ordering consistent? (The project uses prettier-plugin-sort-imports)
 - Are type imports using `import type` where appropriate?
 
 ### 5. Component Structure Consistency
+
 Within component files, check for a consistent ordering:
+
 - Types/interfaces at the top
 - Helper functions
 - Component definition
@@ -52,12 +61,14 @@ Within component files, check for a consistent ordering:
 Compare 5-6 component files to see if they follow the same structure.
 
 ### 6. Test File Patterns
+
 - Are test files consistently placed? (Same directory? `__tests__/` subdirectory?)
 - Do all test files follow the same describe/it pattern?
 - Are test utilities and mocks handled consistently?
 - Do all testable modules actually have tests?
 
 ### 7. Type Definition Patterns
+
 - Are types defined in the component file, in a local `types.ts`, or in `src/types/`?
 - Is there a consistent approach, or is it mixed?
 
@@ -73,6 +84,7 @@ EFFORT: {S|M|L}
 ```
 
 ## Severity Guide
+
 - **Critical**: Inconsistent error handling that could mask bugs or leak information
 - **High**: Inconsistent API route patterns that make the codebase unpredictable
 - **Medium**: Mixed barrel export patterns, inconsistent component structure

--- a/.claude/commands/code-review-readability.md
+++ b/.claude/commands/code-review-readability.md
@@ -5,40 +5,50 @@ You are a specialized code review agent focused on **naming conventions, readabi
 ## Scope
 
 Scan all `.ts` and `.tsx` files in `src/` **excluding**:
+
 - `src/components/ui/` (third-party shadcn components)
 - Test files (`*.test.ts`, `*.test.tsx`, `__tests__/`)
 
 ## What to Look For
 
 ### 1. Inconsistent File Naming
+
 The project should use consistent file naming. Check for:
+
 - Mixed conventions in the same directory (e.g., `useLocalStorage.ts` camelCase vs `use-mobile.ts` kebab-case in `hooks/`)
 - Component files that don't match their default export name
 - Inconsistency between similar file types
 
 ### 2. Magic Numbers & Strings
+
 Look for literal numbers or strings used in logic without named constants. Common examples:
+
 - Timeout durations, retry counts, interval periods
 - Array indices used for specific meanings
 - Status codes used inline instead of constants
 - Configuration values embedded in logic
 
 ### 3. Unclear Variable/Function Names
+
 - Single-letter variables outside of trivial loop counters
 - Abbreviations that aren't universally understood (except standard ones like `id`, `url`, `db`)
 - Boolean variables/functions that don't read as yes/no questions (should be `isX`, `hasX`, `canX`, `shouldX`)
 - Functions whose names don't clearly describe what they do or return
 
 ### 4. Long Boolean Expressions
+
 Complex conditional expressions (3+ conditions joined by `&&`/`||`) that aren't extracted into a descriptively named variable or function.
 
 ### 5. Missing JSDoc on Public APIs
+
 Exported functions in `src/lib/` modules should have at minimum a one-line JSDoc comment explaining their purpose. Check for undocumented exports that aren't self-explanatory.
 
 ### 6. Misleading Comments
+
 Comments that describe what the code does (which should be obvious from the code) rather than WHY. Also flag comments that are outdated or contradict the code.
 
 ### 7. Inconsistent Patterns Within a File
+
 Within a single file, look for inconsistent approaches - e.g., some functions use early returns while others use if/else, or mixed async/await with .then() chains.
 
 ## Output Format
@@ -53,6 +63,7 @@ EFFORT: {S|M|L}
 ```
 
 ## Severity Guide
+
 - **Critical**: Misleading names that could cause bugs (e.g., a function named `getUser` that deletes something)
 - **High**: Magic numbers in critical logic, completely unclear function purposes
 - **Medium**: Inconsistent naming conventions, missing JSDoc on complex lib functions, long boolean expressions

--- a/.claude/commands/code-review.md
+++ b/.claude/commands/code-review.md
@@ -37,6 +37,7 @@ EFFORT: {S|M|L}
 ```
 
 Deduplicate:
+
 - If multiple agents flag the same file+line range, merge into one finding keeping the highest severity
 - If agents flag different issues in the same file, keep them as separate findings but note they can be addressed together
 
@@ -45,6 +46,7 @@ Deduplicate:
 For each finding (or group of related findings for the same file), create a GitHub Issue.
 
 First, check for existing open issues with the `code-review` label to avoid duplicates:
+
 - Use the GitHub MCP tool `mcp__github__search_issues` or `gh issue list --label code-review --state open`
 - If an existing issue covers the same file and concern, add a comment to update it instead of creating a new issue
 
@@ -75,6 +77,7 @@ Found during automated code review on {today's date}.
 ```
 
 **Label mapping:**
+
 - Severity labels: `critical`, `high`, `medium`, `low`
 - Category labels: `complexity`, `separation-of-concerns`, `dead-code`, `readability`, `pattern-consistency`
 - All issues get the `code-review` label
@@ -88,17 +91,19 @@ Present a summary to the user:
 ### Code Review Summary - {date}
 
 | Severity | Count |
-|----------|-------|
-| Critical | N |
-| High     | N |
-| Medium   | N |
-| Low      | N |
+| -------- | ----- |
+| Critical | N     |
+| High     | N     |
+| Medium   | N     |
+| Low      | N     |
 
 **Top 5 Actionable Items** (ranked by severity, then by effort ascending):
+
 1. {finding summary} - {issue link} - Effort: {S/M/L}
 2. ...
 
 **Baseline Check Results:**
+
 - ESLint: {pass/fail with count}
 - TypeScript: {pass/fail with count}
 

--- a/.github/workflows/main_nextjs-template-build.yml
+++ b/.github/workflows/main_nextjs-template-build.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Validate Prisma migration naming convention
         run: pnpm db:migrate:check-names
-        
+
       - name: Test
         run: pnpm test:run
 

--- a/src/components/calendar/__tests__/animated-swap.test.tsx
+++ b/src/components/calendar/__tests__/animated-swap.test.tsx
@@ -6,6 +6,8 @@
  * timer behavior under rapid swaps, and same-key re-render.
  */
 import { act, render, screen } from "@testing-library/react";
+import { hydrateRoot } from "react-dom/client";
+import { renderToString } from "react-dom/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AnimatedSwap } from "../animated-swap";
 
@@ -406,11 +408,13 @@ describe("AnimatedSwap", () => {
 
   describe("reduced motion mid-animation", () => {
     it("collapses to idle and clears pending timers when reduced-motion turns on mid-animation", () => {
-      // First mount with reduced-motion off.
+      // First mount with reduced-motion off. useSyncExternalStore re-reads
+      // the live snapshot when notified, so the mock must be a shared object
+      // whose `matches` field flips before the listener fires.
       let mqlListeners: ((e: MediaQueryListEvent) => void)[] = [];
-      window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      const sharedMql = {
         matches: false,
-        media: query,
+        media: "(prefers-reduced-motion: reduce)",
         addEventListener: (
           _evt: string,
           handler: (e: MediaQueryListEvent) => void
@@ -426,7 +430,12 @@ describe("AnimatedSwap", () => {
         addListener: vi.fn(),
         removeListener: vi.fn(),
         dispatchEvent: vi.fn(),
-      }));
+      };
+      window.matchMedia = vi
+        .fn()
+        .mockImplementation(
+          () => sharedMql
+        ) as unknown as typeof window.matchMedia;
 
       const { rerender } = render(
         <AnimatedSwap
@@ -452,8 +461,10 @@ describe("AnimatedSwap", () => {
 
       expect(screen.getByTestId("animated-swap-outgoing")).toBeInTheDocument();
 
-      // OS-level reduced motion turns on; hook's subscribed listener fires.
+      // OS-level reduced motion turns on; the live snapshot must reflect the
+      // new value before the listener fires so React picks it up.
       act(() => {
+        sharedMql.matches = true;
         mqlListeners.forEach((h) =>
           h({ matches: true } as MediaQueryListEvent)
         );
@@ -463,6 +474,97 @@ describe("AnimatedSwap", () => {
         screen.queryByTestId("animated-swap-outgoing")
       ).not.toBeInTheDocument();
       expect(screen.getByTestId("b")).toBeInTheDocument();
+    });
+  });
+
+  // Regression coverage for #306. Before the useReducedMotion fix, the SSR
+  // pass and the client's first render produced structurally different trees
+  // when the user had `prefers-reduced-motion: reduce` set, which surfaced as
+  // a hydration warning anchored at SimpleCalendar.
+  describe("hydration with prefers-reduced-motion (regression for #306)", () => {
+    it("server renders the idle wrapper so the client's first render matches", () => {
+      window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+        matches: query === "(prefers-reduced-motion: reduce)",
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }));
+
+      const ssrHtml = renderToString(
+        <AnimatedSwap
+          swapKey="a"
+          type="fade"
+          direction="forward"
+          durationMs={300}
+        >
+          <div data-testid="content">A</div>
+        </AnimatedSwap>
+      );
+
+      // The SSR pass must show the idle wrapper, not the skip-animation
+      // shortcut. Otherwise the client (which initializes useReducedMotion to
+      // false to match SSR) would diverge on hydration.
+      expect(ssrHtml).toContain("animated-swap-idle");
+    });
+
+    it("hydrates without React hydration warnings", () => {
+      // This test exercises the real React hydration path with prefers-reduced
+      // -motion enabled. Use real timers so the post-mount useEffect that
+      // syncs the live preference can run (it doesn't depend on timers, but
+      // hydrateRoot's own scheduling can interact with fake timers).
+      vi.useRealTimers();
+
+      window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+        matches: query === "(prefers-reduced-motion: reduce)",
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }));
+
+      const tree = (
+        <AnimatedSwap
+          swapKey="a"
+          type="fade"
+          direction="forward"
+          durationMs={300}
+        >
+          <div data-testid="content">A</div>
+        </AnimatedSwap>
+      );
+
+      const ssrHtml = renderToString(tree);
+      const container = document.createElement("div");
+      container.innerHTML = ssrHtml;
+      document.body.appendChild(container);
+
+      const errorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => undefined);
+
+      let root: ReturnType<typeof hydrateRoot> | null = null;
+      act(() => {
+        root = hydrateRoot(container, tree);
+      });
+
+      const hydrationErrors = errorSpy.mock.calls.filter((call) =>
+        call.some((arg) =>
+          typeof arg === "string" ? /hydrat/i.test(arg) : false
+        )
+      );
+
+      expect(hydrationErrors).toEqual([]);
+
+      act(() => {
+        root?.unmount();
+      });
+      errorSpy.mockRestore();
+      document.body.removeChild(container);
     });
   });
 

--- a/src/components/calendar/__tests__/animated-swap.test.tsx
+++ b/src/components/calendar/__tests__/animated-swap.test.tsx
@@ -511,10 +511,9 @@ describe("AnimatedSwap", () => {
     });
 
     it("hydrates without React hydration warnings", () => {
-      // This test exercises the real React hydration path with prefers-reduced
-      // -motion enabled. Use real timers so the post-mount useEffect that
-      // syncs the live preference can run (it doesn't depend on timers, but
-      // hydrateRoot's own scheduling can interact with fake timers).
+      // Exercises the real React hydration path under prefers-reduced-motion.
+      // Use real timers so hydrateRoot's internal Scheduler can flush without
+      // fake-timer interference.
       vi.useRealTimers();
 
       window.matchMedia = vi.fn().mockImplementation((query: string) => ({
@@ -552,10 +551,10 @@ describe("AnimatedSwap", () => {
         root = hydrateRoot(container, tree);
       });
 
+      // React 19 sometimes passes Error objects (not just strings) to
+      // console.error, so coerce every arg before pattern-matching.
       const hydrationErrors = errorSpy.mock.calls.filter((call) =>
-        call.some((arg) =>
-          typeof arg === "string" ? /hydrat/i.test(arg) : false
-        )
+        call.some((arg) => /hydrat/i.test(String(arg)))
       );
 
       expect(hydrationErrors).toEqual([]);

--- a/src/hooks/__tests__/use-reduced-motion.test.tsx
+++ b/src/hooks/__tests__/use-reduced-motion.test.tsx
@@ -2,6 +2,7 @@
  * Tests for useReducedMotion hook.
  */
 import { act, renderHook } from "@testing-library/react";
+import { renderToString } from "react-dom/server";
 import {
   type MockInstance,
   afterEach,
@@ -109,8 +110,11 @@ describe("useReducedMotion", () => {
     const { result } = renderHook(() => useReducedMotion());
     expect(result.current).toBe(false);
 
+    // useSyncExternalStore re-reads getSnapshot on subscription notifications,
+    // so flip the mock's matches value before firing the listener.
     const handler = mql.addEventListener.mock.calls[0][1];
     act(() => {
+      mql.matches = true;
       handler({ matches: true } as MediaQueryListEvent);
     });
 
@@ -126,9 +130,39 @@ describe("useReducedMotion", () => {
 
     const handler = mql.addEventListener.mock.calls[0][1];
     act(() => {
+      mql.matches = false;
       handler({ matches: false } as MediaQueryListEvent);
     });
 
     expect(result.current).toBe(false);
+  });
+
+  // Regression coverage for #306: the SSR pass and the client's first render
+  // must produce the same value (`false`), regardless of what matchMedia
+  // would report. Previously the function-initializer read window.matchMedia
+  // synchronously on the client's first render, producing a hydration mismatch
+  // whenever the user had `prefers-reduced-motion: reduce` enabled.
+  it("returns false during server-render even when matchMedia reports a match", () => {
+    const mql = createMockMediaQueryList(true);
+    window.matchMedia = vi.fn().mockReturnValue(mql);
+
+    function Probe() {
+      return <div data-testid="value">{String(useReducedMotion())}</div>;
+    }
+
+    const html = renderToString(<Probe />);
+
+    expect(html).toContain(">false<");
+    expect(html).not.toContain(">true<");
+  });
+
+  it("transitions to the live matchMedia value after mount", () => {
+    const mql = createMockMediaQueryList(true);
+    window.matchMedia = vi.fn().mockReturnValue(mql);
+
+    const { result } = renderHook(() => useReducedMotion());
+
+    // After mount, useSyncExternalStore reads the live snapshot.
+    expect(result.current).toBe(true);
   });
 });

--- a/src/hooks/__tests__/use-reduced-motion.test.tsx
+++ b/src/hooks/__tests__/use-reduced-motion.test.tsx
@@ -150,6 +150,11 @@ describe("useReducedMotion", () => {
       return <div data-testid="value">{String(useReducedMotion())}</div>;
     }
 
+    // renderToString triggers the useSyncExternalStore SSR path
+    // (getServerSnapshot) regardless of whether `window` exists in the test
+    // environment — React detects the SSR rendering context internally — so
+    // running this in jsdom with a stubbed matchMedia is still a valid proof
+    // that the SSR pass returns `false`.
     const html = renderToString(<Probe />);
 
     expect(html).toContain(">false<");
@@ -164,5 +169,26 @@ describe("useReducedMotion", () => {
 
     // After mount, useSyncExternalStore reads the live snapshot.
     expect(result.current).toBe(true);
+  });
+
+  // Older Android WebViews and a few JSDOM configs ship without
+  // `window.matchMedia`. Both `getSnapshot` and `subscribe` guard against this
+  // and degrade to `false` / no-op; this test exercises that path.
+  it("returns false when window.matchMedia is unavailable on the client", () => {
+    const original = window.matchMedia;
+    // Simulate an environment that does not expose matchMedia.
+    (
+      window as unknown as { matchMedia?: typeof window.matchMedia }
+    ).matchMedia = undefined;
+
+    try {
+      const { result, unmount } = renderHook(() => useReducedMotion());
+      expect(result.current).toBe(false);
+      // Unmounting must not throw even though subscribe never registered a
+      // listener.
+      expect(() => unmount()).not.toThrow();
+    } finally {
+      window.matchMedia = original;
+    }
   });
 });

--- a/src/hooks/use-reduced-motion.ts
+++ b/src/hooks/use-reduced-motion.ts
@@ -1,10 +1,10 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useSyncExternalStore } from "react";
 
 const MEDIA_QUERY = "(prefers-reduced-motion: reduce)";
 
-function getInitialPreference(): boolean {
+function getSnapshot(): boolean {
   if (
     typeof window === "undefined" ||
     typeof window.matchMedia !== "function"
@@ -14,34 +14,38 @@ function getInitialPreference(): boolean {
   return window.matchMedia(MEDIA_QUERY).matches;
 }
 
+function getServerSnapshot(): boolean {
+  // Returning the same value during SSR and during the client's hydration
+  // pass is what eliminates the hydration mismatch reported in #306. The
+  // client transitions to the live `getSnapshot()` value after mount.
+  return false;
+}
+
+function subscribe(onChange: () => void): () => void {
+  if (
+    typeof window === "undefined" ||
+    typeof window.matchMedia !== "function"
+  ) {
+    return () => undefined;
+  }
+  const mql = window.matchMedia(MEDIA_QUERY);
+  mql.addEventListener("change", onChange);
+  return () => {
+    mql.removeEventListener("change", onChange);
+  };
+}
+
 /**
  * Subscribes to the `prefers-reduced-motion` media query and returns the
- * current preference. SSR-safe — returns `false` outside the browser.
+ * current preference.
+ *
+ * Built on `useSyncExternalStore` so the SSR pass and the client's hydration
+ * render produce the same value (`false`), then the live preference is read
+ * after mount. This is the standard fix for the SSR/CSR divergence that #306
+ * surfaced as a hydration warning anchored at `SimpleCalendar`.
  *
  * Live updates: re-renders whenever the OS-level preference changes.
  */
 export function useReducedMotion(): boolean {
-  const [reduced, setReduced] = useState<boolean>(getInitialPreference);
-
-  useEffect(() => {
-    if (
-      typeof window === "undefined" ||
-      typeof window.matchMedia !== "function"
-    ) {
-      return;
-    }
-
-    const mql = window.matchMedia(MEDIA_QUERY);
-
-    const handler = (event: MediaQueryListEvent) => {
-      setReduced(event.matches);
-    };
-
-    mql.addEventListener("change", handler);
-    return () => {
-      mql.removeEventListener("change", handler);
-    };
-  }, []);
-
-  return reduced;
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }


### PR DESCRIPTION
Closes #306.

## Summary

Reduced-motion users hitting `/calendar` got a recoverable React hydration error anchored at `SimpleCalendar.tsx:206`. Root cause was in `src/hooks/use-reduced-motion.ts`: the `useState` initializer called `window.matchMedia(...).matches` synchronously, so the SSR pass returned `false` (no `window`) and the client's first render returned `true` whenever the OS preference was `reduce`. That `true` flowed into `AnimatedSwap.skipAnimation`, which selects between two structurally different trees — exactly what the hydration diff in the error showed.

## Fix

Rewrote `useReducedMotion` on top of `useSyncExternalStore`, which is purpose-built for SSR-safe external-source subscriptions:

- `getServerSnapshot()` returns `false` — used during SSR and during the client's hydration pass, guaranteeing the trees match.
- `getSnapshot()` reads the live `window.matchMedia(...).matches` after mount.
- `subscribe()` adds/removes the `change` listener and notifies React (no event payload — React re-reads `getSnapshot()`).

Reduced-motion users see one frame of the animating wrapper before the post-mount snapshot collapses it to the skip-animation tree. That's the standard SSR/a11y trade-off; the issue called this out as acceptable.

This dovetails with PR #308 (transition-speed setting) — both code paths now go through the same SSR-safe hook, so neither can reintroduce the mismatch.

## Tests (TDD)

- **Red phase** confirmed: a `renderToString`-based test asserting the SSR pass returns `false` even when `matchMedia` reports a match failed against the old hook.
- **Green phase**: that test plus a new `AnimatedSwap` regression covering both the SSR snapshot (must contain `animated-swap-idle`) and a full `renderToString` + `hydrateRoot` round-trip with `console.error` spying for hydration warnings.
- Updated two existing change-event tests on `useReducedMotion` and the mid-animation reduced-motion test on `AnimatedSwap` to mutate the shared `MediaQueryList.matches` mock before firing the listener — `useSyncExternalStore` re-reads the live snapshot on notify rather than consuming an event payload.
- Full suite: 1894 / 1894 pass.
- Lint, format, types: clean (5 pre-existing warnings unrelated to this change).

## Files

- `src/hooks/use-reduced-motion.ts` — rewritten on `useSyncExternalStore`
- `src/hooks/__tests__/use-reduced-motion.test.tsx` — renamed `.ts` → `.tsx`; added SSR-safety + post-mount transition tests; updated change-event tests
- `src/components/calendar/__tests__/animated-swap.test.tsx` — added hydration regression block; updated mid-animation reduced-motion test

No callers needed to change.

## Test plan

- [x] `pnpm test:run` — 1894 / 1894 pass
- [x] `pnpm lint:fix && pnpm format:fix && pnpm check-types` — clean
- [ ] Manual: enable `prefers-reduced-motion: reduce` (DevTools → Rendering → Emulate CSS media feature), hard-reload `/calendar`, confirm no hydration error in console


---
_Generated by [Claude Code](https://claude.ai/code/session_01GF1pyaqGhJZrHvmS2zytKK)_