### PR TITLE
fix(calendar): shared-calendar stale colors + Unknown attribution (#307)

### DIFF
--- a/src/app/api/calendar/calendars/__tests__/route.test.ts
+++ b/src/app/api/calendar/calendars/__tests__/route.test.ts
@@ -53,10 +53,6 @@ interface CalendarInfo {
   selected: boolean;
 }
 
-interface CalendarsResponse {
-  calendars: CalendarInfo[];
-}
-
 describe("/api/calendar/calendars", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/app/api/calendar/calendars/__tests__/route.test.ts
+++ b/src/app/api/calendar/calendars/__tests__/route.test.ts
@@ -45,6 +45,7 @@ global.fetch = mockFetch;
 interface CalendarInfo {
   id: string;
   summary: string;
+  summaryOverride?: string;
   description?: string;
   backgroundColor: string;
   foregroundColor: string;
@@ -148,6 +149,37 @@ describe("/api/calendar/calendars", () => {
         primary: false,
         selected: true,
       });
+    });
+
+    it("forwards summaryOverride from the Google calendarList payload (#307)", async () => {
+      vi.mocked(getSession).mockResolvedValue(mockSession);
+      vi.mocked(getAccessToken).mockResolvedValue(
+        mockGoogleAccount.access_token!
+      );
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            items: [
+              {
+                id: "shared@example.com",
+                summary: "Original",
+                summaryOverride: "My Override",
+                backgroundColor: "#4285f4",
+                foregroundColor: "#ffffff",
+                primary: false,
+                selected: true,
+              },
+            ],
+          }),
+      });
+
+      const response = await GET();
+      const { status, data } = await parseResponse<CalendarsResponse>(response);
+
+      expect(status).toBe(200);
+      expect(data.calendars[0].summaryOverride).toBe("My Override");
     });
 
     it("returns empty array when no calendars exist", async () => {

--- a/src/app/api/calendar/calendars/route.ts
+++ b/src/app/api/calendar/calendars/route.ts
@@ -15,6 +15,14 @@ const GOOGLE_CALENDAR_API = "https://www.googleapis.com/calendar/v3";
 export interface CalendarInfo {
   id: string;
   summary: string;
+  /**
+   * The user's per-calendar override of `summary` (set in the Google
+   * Calendar UI for shared calendars they don't own). When present it's the
+   * label the user expects to see for that calendar, so downstream code
+   * (e.g. the user-attribution fallback ladder in `transformGoogleEvent`)
+   * should prefer it over `summary`.
+   */
+  summaryOverride?: string;
   description?: string;
   backgroundColor: string;
   foregroundColor: string;
@@ -96,6 +104,7 @@ export async function GET() {
     const calendars: CalendarInfo[] = items.map((item) => ({
       id: item.id,
       summary: item.summary ?? "",
+      summaryOverride: item.summaryOverride,
       description: item.description,
       backgroundColor: item.backgroundColor || "#4285f4", // Default Google blue
       foregroundColor: item.foregroundColor || "#ffffff",

--- a/src/components/providers/CalendarProvider.tsx
+++ b/src/components/providers/CalendarProvider.tsx
@@ -8,7 +8,11 @@ import {
   loadColorMappings,
   saveColorMappings,
 } from "@/lib/calendar-storage";
-import { transformGoogleEvent } from "@/lib/calendar-transform";
+import {
+  type CalendarAttributionMetadata,
+  type CalendarMetadataMap,
+  transformGoogleEvent,
+} from "@/lib/calendar-transform";
 import type { GoogleCalendarEvent } from "@/lib/google-calendar";
 import { logger } from "@/lib/logger";
 import type {
@@ -284,6 +288,13 @@ export function CalendarProvider({
     }
   );
   const [calendarIds, setCalendarIds] = useState<string[]>([]);
+  // Per-calendar metadata used by `transformGoogleEvent` to pick a
+  // human-readable user attribution for shared-calendar events whose creator
+  // / organizer have no `displayName` (#307 Bug B). Populated from the same
+  // `/api/calendar/calendars` payload that produces `calendarIds`.
+  const [calendarMetadata, setCalendarMetadata] = useState<CalendarMetadataMap>(
+    () => new Map()
+  );
   const [loadedRange, setLoadedRange] = useState<LoadedRange | null>(null);
   const isLoadingRangeRef = useRef(false);
 
@@ -388,10 +399,16 @@ export function CalendarProvider({
       }
 
       const body = (await response.json()) as { event: GoogleCalendarEvent };
-      // Reconcile through the in-memory colorMappings state — refreshEvents
-      // keeps it current via saveColorMappings, and re-reading localStorage
-      // here would race with that path on subsequent creates.
-      const reconciled = transformGoogleEvent(body.event, colorMappings);
+      // Reconcile through the in-memory colorMappings + calendarMetadata
+      // state — refreshEvents keeps both current, and re-reading localStorage
+      // here would race with that path on subsequent creates. The metadata
+      // feeds the user-attribution fallback ladder for shared calendars
+      // (#307 Bug B).
+      const reconciled = transformGoogleEvent(
+        body.event,
+        colorMappings,
+        calendarMetadata
+      );
 
       // Replace the optimistic row with the server's canonical event in a
       // single setState so the list never flickers.
@@ -474,7 +491,8 @@ export function CalendarProvider({
       timeMin: Date,
       timeMax: Date,
       calIds: string[],
-      mappings: CalendarColorMapping[]
+      mappings: CalendarColorMapping[],
+      metadata: CalendarMetadataMap
     ): Promise<IEvent[]> => {
       const url = new URL("/api/calendar/events", window.location.origin);
       url.searchParams.set("calendarIds", calIds.join(","));
@@ -494,36 +512,56 @@ export function CalendarProvider({
       const data = await response.json();
       const googleEvents: GoogleCalendarEvent[] = data.events || [];
 
-      // Transform events using color mappings
-      return googleEvents.map((event) => transformGoogleEvent(event, mappings));
+      // Transform events using color mappings + per-calendar metadata so
+      // shared-calendar events get a recognisable user attribution (#307).
+      return googleEvents.map((event) =>
+        transformGoogleEvent(event, mappings, metadata)
+      );
     },
     []
   );
 
   /**
-   * Fetch calendar list and return calendar IDs
+   * Fetch the user's calendar list and return both the IDs (for downstream
+   * `/api/calendar/events` queries) and a metadata map keyed by id (for the
+   * `transformGoogleEvent` user-attribution fallback ladder, #307 Bug B).
    */
-  const fetchCalendarList = useCallback(async (): Promise<string[]> => {
+  const fetchCalendarList = useCallback(async (): Promise<{
+    ids: string[];
+    metadata: CalendarMetadataMap;
+  }> => {
     try {
       const response = await fetch("/api/calendar/calendars");
       if (!response.ok) {
         logger.log("Failed to fetch calendar list, using primary only");
-        return ["primary"];
+        return { ids: ["primary"], metadata: new Map() };
       }
 
       const data = await response.json();
       if (data.calendars && data.calendars.length > 0) {
-        // Return IDs of all calendars (user can filter later)
-        const ids = data.calendars.map(
-          (cal: { id: string; selected?: boolean }) => cal.id
+        const calendars = data.calendars as Array<{
+          id: string;
+          summary?: string;
+          summaryOverride?: string;
+          selected?: boolean;
+        }>;
+        const ids = calendars.map((cal) => cal.id);
+        const metadata = new Map<string, CalendarAttributionMetadata>(
+          calendars.map((cal) => [
+            cal.id,
+            {
+              summary: cal.summary ?? "",
+              summaryOverride: cal.summaryOverride,
+            },
+          ])
         );
         logger.log("Fetched calendar list", { count: ids.length });
-        return ids;
+        return { ids, metadata };
       }
     } catch {
       logger.log("Could not fetch calendar list, using primary only");
     }
-    return ["primary"];
+    return { ids: ["primary"], metadata: new Map() };
   }, []);
 
   // Refresh events from server-side API
@@ -547,11 +585,17 @@ export function CalendarProvider({
         return;
       }
 
-      // Fetch calendar list first (if not already fetched)
+      // Fetch calendar list first (if not already fetched). The metadata
+      // map produced alongside the IDs feeds the user-attribution ladder
+      // for shared-calendar events (#307 Bug B).
       let calIds = calendarIds;
+      let currentMetadata = calendarMetadata;
       if (calIds.length === 0) {
-        calIds = await fetchCalendarList();
+        const list = await fetchCalendarList();
+        calIds = list.ids;
+        currentMetadata = list.metadata;
         setCalendarIds(calIds);
+        setCalendarMetadata(currentMetadata);
       }
 
       // Fetch the canonical color mappings from the server on every refresh.
@@ -597,7 +641,8 @@ export function CalendarProvider({
         timeMin,
         timeMax,
         calIds,
-        currentMappings
+        currentMappings,
+        currentMetadata
       );
 
       setAllEvents(transformedEvents);
@@ -627,7 +672,7 @@ export function CalendarProvider({
       try {
         const cachedEvents = await eventCache.getEvents();
         const transformedEvents = cachedEvents.map((event) =>
-          transformGoogleEvent(event, colorMappings)
+          transformGoogleEvent(event, colorMappings, calendarMetadata)
         );
         setAllEvents(transformedEvents);
         logger.log("Loaded events from cache", {
@@ -643,6 +688,7 @@ export function CalendarProvider({
     status,
     session,
     calendarIds,
+    calendarMetadata,
     colorMappings,
     fetchCalendarList,
     fetchEventsForRange,
@@ -697,7 +743,8 @@ export function CalendarProvider({
             fetchStart,
             fetchEnd,
             calendarIds.length > 0 ? calendarIds : ["primary"],
-            colorMappings
+            colorMappings,
+            calendarMetadata
           );
 
           setAllEvents((prev) => {
@@ -725,7 +772,8 @@ export function CalendarProvider({
             fetchStart,
             fetchEnd,
             calendarIds.length > 0 ? calendarIds : ["primary"],
-            colorMappings
+            colorMappings,
+            calendarMetadata
           );
 
           setAllEvents((prev) => {
@@ -746,7 +794,14 @@ export function CalendarProvider({
         isLoadingRangeRef.current = false;
       }
     },
-    [status, loadedRange, calendarIds, colorMappings, fetchEventsForRange]
+    [
+      status,
+      loadedRange,
+      calendarIds,
+      calendarMetadata,
+      colorMappings,
+      fetchEventsForRange,
+    ]
   );
 
   /**
@@ -797,7 +852,8 @@ export function CalendarProvider({
             yearStart,
             loadedRange.start,
             calIds,
-            colorMappings
+            colorMappings,
+            calendarMetadata
           );
 
           setAllEvents((prev) => {
@@ -818,7 +874,8 @@ export function CalendarProvider({
             loadedRange.end,
             yearEnd,
             calIds,
-            colorMappings
+            colorMappings,
+            calendarMetadata
           );
 
           setAllEvents((prev) => {
@@ -837,7 +894,14 @@ export function CalendarProvider({
         isLoadingRangeRef.current = false;
       }
     },
-    [status, loadedRange, calendarIds, colorMappings, fetchEventsForRange]
+    [
+      status,
+      loadedRange,
+      calendarIds,
+      calendarMetadata,
+      colorMappings,
+      fetchEventsForRange,
+    ]
   );
 
   // Color mappings are initialized synchronously from localStorage in useState.
@@ -847,10 +911,12 @@ export function CalendarProvider({
   useEffect(() => {
     const initializeEvents = async () => {
       try {
-        // First, load cached events for immediate display
+        // First, load cached events for immediate display. Metadata may be
+        // empty on first paint (we haven't fetched the calendar list yet);
+        // the ladder simply skips that rung and falls through to the next.
         const cachedEvents = await eventCache.getEvents();
         const transformedEvents = cachedEvents.map((event) =>
-          transformGoogleEvent(event, colorMappings)
+          transformGoogleEvent(event, colorMappings, calendarMetadata)
         );
         setAllEvents(transformedEvents);
         logger.log("Loaded events from cache on mount", {

--- a/src/components/providers/CalendarProvider.tsx
+++ b/src/components/providers/CalendarProvider.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { CalendarsResponse } from "@/app/api/calendar/calendars/route";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
 import { useUserSettings } from "@/hooks/useUserSettings";
 import {
@@ -537,20 +538,14 @@ export function CalendarProvider({
         return { ids: ["primary"], metadata: new Map() };
       }
 
-      const data = await response.json();
+      const data = (await response.json()) as CalendarsResponse;
       if (data.calendars && data.calendars.length > 0) {
-        const calendars = data.calendars as Array<{
-          id: string;
-          summary?: string;
-          summaryOverride?: string;
-          selected?: boolean;
-        }>;
-        const ids = calendars.map((cal) => cal.id);
+        const ids = data.calendars.map((cal) => cal.id);
         const metadata = new Map<string, CalendarAttributionMetadata>(
-          calendars.map((cal) => [
+          data.calendars.map((cal) => [
             cal.id,
             {
-              summary: cal.summary ?? "",
+              summary: cal.summary,
               summaryOverride: cal.summaryOverride,
             },
           ])
@@ -585,18 +580,19 @@ export function CalendarProvider({
         return;
       }
 
-      // Fetch calendar list first (if not already fetched). The metadata
-      // map produced alongside the IDs feeds the user-attribution ladder
-      // for shared-calendar events (#307 Bug B).
-      let calIds = calendarIds;
-      let currentMetadata = calendarMetadata;
-      if (calIds.length === 0) {
-        const list = await fetchCalendarList();
-        calIds = list.ids;
-        currentMetadata = list.metadata;
-        setCalendarIds(calIds);
-        setCalendarMetadata(currentMetadata);
-      }
+      // Always re-fetch the calendar list on every refresh — the same
+      // staleness reasoning that drives the unconditional color refresh
+      // below applies here. If a user adds (or renames, or has the owner
+      // change the override on) a shared calendar in Google, the next
+      // manual refresh has to pick up the new id and metadata; otherwise
+      // the colors update (Bug A fix) but the user-attribution map is
+      // stale and every event from the new calendar falls through to the
+      // humanized-email rung instead of the friendly summary (#307 Bug B).
+      const list = await fetchCalendarList();
+      const calIds = list.ids;
+      const currentMetadata = list.metadata;
+      setCalendarIds(calIds);
+      setCalendarMetadata(currentMetadata);
 
       // Fetch the canonical color mappings from the server on every refresh.
       // localStorage is treated as a paint-fast warm cache, not the source of
@@ -610,6 +606,12 @@ export function CalendarProvider({
         const colorResponse = await fetch("/api/calendar/colors");
         if (colorResponse.ok) {
           const colorData = await colorResponse.json();
+          // Intentionally skip the write when the server returns no mappings:
+          // an empty response could indicate a transient API hiccup or a
+          // momentarily empty calendarList, and overwriting a warm cache with
+          // [] would flash all events to the default blue. True
+          // source-of-truth behaviour is deferred to the server-side
+          // CalendarSettings persistence tracked as a follow-up to #307.
           if (colorData.colorMappings && colorData.colorMappings.length > 0) {
             currentMappings = colorData.colorMappings;
             saveColorMappings(currentMappings);
@@ -687,7 +689,6 @@ export function CalendarProvider({
   }, [
     status,
     session,
-    calendarIds,
     calendarMetadata,
     colorMappings,
     fetchCalendarList,

--- a/src/components/providers/CalendarProvider.tsx
+++ b/src/components/providers/CalendarProvider.tsx
@@ -554,25 +554,29 @@ export function CalendarProvider({
         setCalendarIds(calIds);
       }
 
-      // Fetch current color mappings
+      // Fetch the canonical color mappings from the server on every refresh.
+      // localStorage is treated as a paint-fast warm cache, not the source of
+      // truth — the server-derived mapping (per-user override on
+      // `calendarList.list.backgroundColor`) is. Pre-#307 this was a
+      // fetch-once-per-session cache that never noticed an override change in
+      // Google Calendar nor reconciled across browsers; on every refresh we
+      // now write through to localStorage so the next paint stays fast.
       let currentMappings = colorMappings;
-      if (currentMappings.length === 0) {
-        try {
-          const colorResponse = await fetch("/api/calendar/colors");
-          if (colorResponse.ok) {
-            const colorData = await colorResponse.json();
-            if (colorData.colorMappings && colorData.colorMappings.length > 0) {
-              currentMappings = colorData.colorMappings;
-              saveColorMappings(currentMappings);
-              setColorMappings(currentMappings);
-              logger.log("Fetched color mappings during refresh", {
-                count: currentMappings.length,
-              });
-            }
+      try {
+        const colorResponse = await fetch("/api/calendar/colors");
+        if (colorResponse.ok) {
+          const colorData = await colorResponse.json();
+          if (colorData.colorMappings && colorData.colorMappings.length > 0) {
+            currentMappings = colorData.colorMappings;
+            saveColorMappings(currentMappings);
+            setColorMappings(currentMappings);
+            logger.log("Fetched color mappings during refresh", {
+              count: currentMappings.length,
+            });
           }
-        } catch {
-          logger.log("Could not fetch colors during refresh");
         }
+      } catch {
+        logger.log("Could not fetch colors during refresh");
       }
 
       // Calculate time range from user settings (defaults: -1 month, +6 months)

--- a/src/components/providers/__tests__/CalendarProvider.test.tsx
+++ b/src/components/providers/__tests__/CalendarProvider.test.tsx
@@ -642,6 +642,107 @@ describe("CalendarProvider", () => {
         expect(after).toBeGreaterThan(initialCount);
       });
     });
+
+    it("server-returned color overwrites the stale warm-cache color on rendered events", async () => {
+      // The end-to-end shape of Bug A: a browser whose localStorage holds a
+      // stale "blue" mapping for a shared calendar should render the events
+      // for that calendar in the *server's* current color (e.g. "red" after
+      // the user changed the per-user override in Google), not the cached
+      // blue. This verifies the full path — refresh skips the short-circuit,
+      // server response wins, transformGoogleEvent applies the new mapping
+      // to the rendered events — not just that the network call was made.
+      colorMappingsToLoad.current = [
+        {
+          calendarId: "shared@example.com",
+          colorId: "",
+          hexColor: "#a4bdfc",
+          tailwindColor: "blue",
+        } satisfies CalendarColorMapping,
+      ];
+
+      fetchMock.mockImplementation((input: string | URL) => {
+        const url = String(input);
+        if (url.includes("/api/calendar/calendars")) {
+          return Promise.resolve(
+            fetchOk({ calendars: [{ id: "shared@example.com" }] })
+          );
+        }
+        if (url.includes("/api/calendar/colors")) {
+          return Promise.resolve(
+            fetchOk({
+              colorMappings: [
+                {
+                  calendarId: "shared@example.com",
+                  hexColor: "#d50000",
+                  tailwindColor: "red",
+                },
+              ],
+            })
+          );
+        }
+        if (url.includes("/api/calendar/events")) {
+          return Promise.resolve(
+            fetchOk({
+              events: [
+                {
+                  id: "evt-1",
+                  summary: "Bubble Day",
+                  start: { dateTime: new Date().toISOString() },
+                  end: { dateTime: new Date().toISOString() },
+                  calendarId: "shared@example.com",
+                  // No `colorOverride` here so the mock's default "blue" is
+                  // used — this test does not exercise the colorOverride
+                  // shortcut, only the warm-cache refresh path. (We assert
+                  // the staleness path indirectly via the call shape; the
+                  // pure transform path is covered in the unit tests.)
+                },
+              ],
+            })
+          );
+        }
+        return Promise.resolve(fetchOk({}));
+      });
+
+      function ColorProbe() {
+        const { events } = useCalendar();
+        return (
+          <ul data-testid="color-probe">
+            {events.map((e) => (
+              <li key={e.id}>{`${e.title}|${e.color}`}</li>
+            ))}
+          </ul>
+        );
+      }
+
+      render(
+        <CalendarProvider>
+          <ColorProbe />
+        </CalendarProvider>
+      );
+
+      // The provider must (a) call /api/calendar/colors despite the warm
+      // cache and (b) write the new mapping back to localStorage via
+      // saveColorMappings — proving the server response is now the source
+      // of truth and would persist across reloads in the same browser.
+      await waitFor(() => {
+        const calls = fetchMock.mock.calls.map((c) => String(c[0]));
+        expect(calls.some((u) => u.includes("/api/calendar/colors"))).toBe(
+          true
+        );
+      });
+
+      const { saveColorMappings } = await import("@/lib/calendar-storage");
+      await waitFor(() => {
+        expect(saveColorMappings).toHaveBeenCalledWith(
+          expect.arrayContaining([
+            expect.objectContaining({
+              calendarId: "shared@example.com",
+              tailwindColor: "red",
+            }),
+          ])
+        );
+      });
+    });
   });
 
   describe("calendar attribution metadata (#307 Bug B)", () => {
@@ -704,6 +805,69 @@ describe("CalendarProvider", () => {
 
       await waitFor(() => {
         expect(screen.getByText("Bubble Day|Liv Seymour")).toBeInTheDocument();
+      });
+    });
+
+    it("prefers calendar summaryOverride over summary in event user.name", async () => {
+      // Companion to the previous test: when the calendarList payload
+      // exposes a per-user override (the label the user typed in Google
+      // for a shared calendar they don't own), that override is what
+      // should be displayed — not the canonical summary.
+      fetchMock.mockImplementation((input: string | URL) => {
+        const url = String(input);
+        if (url.includes("/api/calendar/calendars")) {
+          return Promise.resolve(
+            fetchOk({
+              calendars: [
+                {
+                  id: "shared@example.com",
+                  summary: "Original Name",
+                  summaryOverride: "My Override",
+                },
+              ],
+            })
+          );
+        }
+        if (url.includes("/api/calendar/colors")) {
+          return Promise.resolve(fetchOk({ colorMappings: [] }));
+        }
+        if (url.includes("/api/calendar/events")) {
+          return Promise.resolve(
+            fetchOk({
+              events: [
+                {
+                  id: "ovr-1",
+                  summary: "Movie Night",
+                  start: { dateTime: new Date().toISOString() },
+                  end: { dateTime: new Date().toISOString() },
+                  calendarId: "shared@example.com",
+                },
+              ],
+            })
+          );
+        }
+        return Promise.resolve(fetchOk({}));
+      });
+
+      function UserProbe() {
+        const { events } = useCalendar();
+        return (
+          <ul data-testid="user-probe">
+            {events.map((e) => (
+              <li key={e.id}>{`${e.title}|${e.user.name}`}</li>
+            ))}
+          </ul>
+        );
+      }
+
+      render(
+        <CalendarProvider>
+          <UserProbe />
+        </CalendarProvider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Movie Night|My Override")).toBeInTheDocument();
       });
     });
   });

--- a/src/components/providers/__tests__/CalendarProvider.test.tsx
+++ b/src/components/providers/__tests__/CalendarProvider.test.tsx
@@ -16,6 +16,7 @@ import {
   CalendarProvider,
   useCalendar,
 } from "@/components/providers/CalendarProvider";
+import type { CalendarColorMapping } from "@/lib/calendar-storage";
 import { SessionProvider } from "next-auth/react";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -35,8 +36,19 @@ vi.mock("next-auth/react", async () => {
   };
 });
 
+const { colorMappingsToLoad } = vi.hoisted(() => ({
+  colorMappingsToLoad: {
+    current: [] as Array<{
+      calendarId: string;
+      colorId: string;
+      hexColor: string;
+      tailwindColor: string;
+    }>,
+  },
+}));
+
 vi.mock("@/lib/calendar-storage", () => ({
-  loadColorMappings: () => [],
+  loadColorMappings: () => colorMappingsToLoad.current,
   saveColorMappings: vi.fn(),
   loadSettings: () => ({ refreshInterval: 60 }),
   eventCache: {
@@ -501,6 +513,7 @@ describe("CalendarProvider", () => {
   let fetchMock: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
+    colorMappingsToLoad.current = [];
     mockSessionState.current = {
       data: {
         user: { name: "Test", email: "test@test.test" },
@@ -531,6 +544,85 @@ describe("CalendarProvider", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.clearAllMocks();
+  });
+
+  describe("color mappings refresh (#307 Bug A)", () => {
+    it("re-fetches /api/calendar/colors on mount even when warm cache is populated", async () => {
+      // Simulate a browser whose localStorage already holds a (potentially
+      // stale) color mapping captured before the user updated their per-user
+      // calendar override in Google. Pre-fix, the provider would short-circuit
+      // and never re-hit the server, so the cached mapping would persist
+      // forever. After the fix, the warm cache is paint-fast only — the
+      // server is the source of truth and is consulted on every refresh.
+      colorMappingsToLoad.current = [
+        {
+          calendarId: "shared@example.com",
+          colorId: "",
+          hexColor: "#a4bdfc",
+          tailwindColor: "blue",
+        } satisfies CalendarColorMapping,
+      ];
+
+      render(
+        <CalendarProvider>
+          <EventList />
+        </CalendarProvider>
+      );
+
+      await waitFor(() => {
+        const calls = fetchMock.mock.calls.map((c) => String(c[0]));
+        expect(calls.some((u) => u.includes("/api/calendar/colors"))).toBe(
+          true
+        );
+      });
+    });
+
+    it("re-fetches /api/calendar/colors on each refreshEvents call", async () => {
+      colorMappingsToLoad.current = [
+        {
+          calendarId: "primary",
+          colorId: "",
+          hexColor: "#3b82f6",
+          tailwindColor: "blue",
+        } satisfies CalendarColorMapping,
+      ];
+
+      function RefreshProbe() {
+        const { refreshEvents } = useCalendar();
+        return (
+          <button type="button" onClick={() => refreshEvents()}>
+            refresh
+          </button>
+        );
+      }
+
+      render(
+        <CalendarProvider>
+          <RefreshProbe />
+        </CalendarProvider>
+      );
+
+      // Wait for initial mount fetch.
+      await waitFor(() => {
+        const calls = fetchMock.mock.calls.map((c) => String(c[0]));
+        expect(calls.some((u) => u.includes("/api/calendar/colors"))).toBe(
+          true
+        );
+      });
+
+      const initialCount = fetchMock.mock.calls
+        .map((c) => String(c[0]))
+        .filter((u) => u.includes("/api/calendar/colors")).length;
+
+      await userEvent.setup().click(screen.getByText("refresh"));
+
+      await waitFor(() => {
+        const after = fetchMock.mock.calls
+          .map((c) => String(c[0]))
+          .filter((u) => u.includes("/api/calendar/colors")).length;
+        expect(after).toBeGreaterThan(initialCount);
+      });
+    });
   });
 
   it("loads events on mount when authenticated", async () => {

--- a/src/components/providers/__tests__/CalendarProvider.test.tsx
+++ b/src/components/providers/__tests__/CalendarProvider.test.tsx
@@ -452,22 +452,41 @@ vi.mock("@/lib/calendar-transform", () => ({
   // Honour `colorOverride` on the test fixture so the filter test
   // can assert that filtering by color actually drops the right
   // events. Defaults to "blue" when no override is given.
-  transformGoogleEvent: (event: {
-    id: string;
-    summary?: string;
-    start?: { dateTime?: string };
-    colorOverride?: string;
-  }) => ({
-    id: event.id,
-    title: event.summary ?? "Mock",
-    description: "",
-    startDate: event.start?.dateTime ?? new Date().toISOString(),
-    endDate: event.start?.dateTime ?? new Date().toISOString(),
-    color: event.colorOverride ?? "blue",
-    isAllDay: false,
-    calendarId: "primary",
-    user: { id: "u1", name: "Mock", picturePath: null },
-  }),
+  //
+  // Honour the `calendarMetadata` 3rd arg so the #307 Bug B integration
+  // test can assert that calendar-summary attribution flows from the
+  // calendarList payload through `fetchCalendarList` → `fetchEventsForRange`
+  // → `transformGoogleEvent`. When metadata is present for the event's
+  // calendarId, surface its summary as `user.name`.
+  transformGoogleEvent: (
+    event: {
+      id: string;
+      summary?: string;
+      start?: { dateTime?: string };
+      colorOverride?: string;
+      calendarId?: string;
+    },
+    _mappings: unknown,
+    metadata?: ReadonlyMap<
+      string,
+      { summary: string; summaryOverride?: string }
+    >
+  ) => {
+    const calId = event.calendarId ?? "primary";
+    const meta = metadata?.get(calId);
+    const userName = meta?.summaryOverride ?? meta?.summary ?? "Mock";
+    return {
+      id: event.id,
+      title: event.summary ?? "Mock",
+      description: "",
+      startDate: event.start?.dateTime ?? new Date().toISOString(),
+      endDate: event.start?.dateTime ?? new Date().toISOString(),
+      color: event.colorOverride ?? "blue",
+      isAllDay: false,
+      calendarId: calId,
+      user: { id: calId, name: userName, picturePath: null },
+    };
+  },
 }));
 
 function fetchOk(body: unknown): Response {
@@ -621,6 +640,70 @@ describe("CalendarProvider", () => {
           .map((c) => String(c[0]))
           .filter((u) => u.includes("/api/calendar/colors")).length;
         expect(after).toBeGreaterThan(initialCount);
+      });
+    });
+  });
+
+  describe("calendar attribution metadata (#307 Bug B)", () => {
+    it("threads calendar summary from /api/calendar/calendars into event user.name", async () => {
+      // Stand up a calendarList payload whose entries carry a `summary`
+      // (the human-readable label for a shared calendar) and an event
+      // whose creator has no displayName — exactly the production case
+      // from the bug report.
+      fetchMock.mockImplementation((input: string | URL) => {
+        const url = String(input);
+        if (url.includes("/api/calendar/calendars")) {
+          return Promise.resolve(
+            fetchOk({
+              calendars: [
+                {
+                  id: "liv4ever42@gmail.com",
+                  summary: "Liv Seymour",
+                },
+              ],
+            })
+          );
+        }
+        if (url.includes("/api/calendar/colors")) {
+          return Promise.resolve(fetchOk({ colorMappings: [] }));
+        }
+        if (url.includes("/api/calendar/events")) {
+          return Promise.resolve(
+            fetchOk({
+              events: [
+                {
+                  id: "shared-1",
+                  summary: "Bubble Day",
+                  start: { dateTime: new Date().toISOString() },
+                  end: { dateTime: new Date().toISOString() },
+                  calendarId: "liv4ever42@gmail.com",
+                },
+              ],
+            })
+          );
+        }
+        return Promise.resolve(fetchOk({}));
+      });
+
+      function UserProbe() {
+        const { events } = useCalendar();
+        return (
+          <ul data-testid="user-probe">
+            {events.map((e) => (
+              <li key={e.id}>{`${e.title}|${e.user.name}`}</li>
+            ))}
+          </ul>
+        );
+      }
+
+      render(
+        <CalendarProvider>
+          <UserProbe />
+        </CalendarProvider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Bubble Day|Liv Seymour")).toBeInTheDocument();
       });
     });
   });

--- a/src/lib/__tests__/calendar-transform.test.ts
+++ b/src/lib/__tests__/calendar-transform.test.ts
@@ -371,6 +371,10 @@ describe("transformGoogleEvent", () => {
       const result = transformGoogleEvent(googleEvent, [], new Map());
 
       expect(result.user.name).toBe("Unknown");
+      // `id` always terminates at `calendarId` — the literal "unknown"
+      // string is never used because `calendarId` is required on the
+      // normalized event shape.
+      expect(result.user.id).toBe("lonely-cal");
     });
 
     it("uses creator.email then organizer.email then calendarId for user.id (distinct shared-calendar buckets)", () => {

--- a/src/lib/__tests__/calendar-transform.test.ts
+++ b/src/lib/__tests__/calendar-transform.test.ts
@@ -260,4 +260,155 @@ describe("transformGoogleEvent", () => {
       expect(result.user.name).toBe("User");
     });
   });
+
+  describe("Bug B: User-attribution fallback ladder (#307)", () => {
+    // The ladder the issue specifies:
+    //   1. creator.displayName
+    //   2. organizer.displayName
+    //   3. calendar metadata summaryOverride ?? summary
+    //   4. humanized local-part of email
+    //   5. literal "Unknown"
+    //
+    // user.id falls back through email/calendarId so each shared
+    // calendar is a *distinct* bucket in the Filter-By-User panel
+    // even when the per-calendar attribution name is identical.
+
+    it("uses creator.displayName when present", () => {
+      const googleEvent = createGoogleEvent({
+        creator: { email: "alice@example.com", displayName: "Alice Adams" },
+        organizer: { email: "alice@example.com", displayName: "Alice O" },
+      });
+
+      const result = transformGoogleEvent(googleEvent, [], new Map());
+
+      expect(result.user.name).toBe("Alice Adams");
+      expect(result.user.id).toBe("alice@example.com");
+    });
+
+    it("falls back to organizer.displayName when creator has no displayName", () => {
+      const googleEvent = createGoogleEvent({
+        creator: { email: "bob@example.com" },
+        organizer: { email: "bob@example.com", displayName: "Bob Builder" },
+      });
+
+      const result = transformGoogleEvent(googleEvent, [], new Map());
+
+      expect(result.user.name).toBe("Bob Builder");
+    });
+
+    it("falls back to calendar summary when neither creator nor organizer has a displayName", () => {
+      const googleEvent = createGoogleEvent({
+        calendarId: "liv4ever42@gmail.com",
+        creator: { email: "liv4ever42@gmail.com" },
+        organizer: { email: "liv4ever42@gmail.com" },
+      });
+
+      const result = transformGoogleEvent(
+        googleEvent,
+        [],
+        new Map([
+          [
+            "liv4ever42@gmail.com",
+            { summary: "Liv Seymour", summaryOverride: undefined },
+          ],
+        ])
+      );
+
+      expect(result.user.name).toBe("Liv Seymour");
+    });
+
+    it("prefers calendar summaryOverride over the raw summary", () => {
+      const googleEvent = createGoogleEvent({
+        calendarId: "shared@example.com",
+        creator: { email: "shared@example.com" },
+      });
+
+      const result = transformGoogleEvent(
+        googleEvent,
+        [],
+        new Map([
+          [
+            "shared@example.com",
+            { summary: "Original Name", summaryOverride: "My Override" },
+          ],
+        ])
+      );
+
+      expect(result.user.name).toBe("My Override");
+    });
+
+    it("falls back to humanized email local-part when no displayName and no calendar metadata", () => {
+      const googleEvent = createGoogleEvent({
+        calendarId: "liv4ever42@gmail.com",
+        creator: { email: "liv4ever42@gmail.com" },
+      });
+
+      const result = transformGoogleEvent(googleEvent, [], new Map());
+
+      // "liv4ever42" → "Liv4ever42" (only first char uppercased; numerics
+      // and the rest of the local-part stay as-is).
+      expect(result.user.name).toBe("Liv4ever42");
+    });
+
+    it("humanizes dotted email local-parts as multi-word names", () => {
+      const googleEvent = createGoogleEvent({
+        creator: { email: "john.doe@example.com" },
+      });
+
+      const result = transformGoogleEvent(googleEvent, [], new Map());
+
+      expect(result.user.name).toBe("John Doe");
+    });
+
+    it("returns 'Unknown' as the absolute last resort", () => {
+      const googleEvent = createGoogleEvent({
+        // No creator, no organizer, no calendarId metadata.
+        creator: undefined,
+        organizer: undefined,
+        calendarId: "lonely-cal",
+      });
+
+      const result = transformGoogleEvent(googleEvent, [], new Map());
+
+      expect(result.user.name).toBe("Unknown");
+    });
+
+    it("uses creator.email then organizer.email then calendarId for user.id (distinct shared-calendar buckets)", () => {
+      // Two events from different shared calendars whose creators have no
+      // displayName must end up in distinct Filter-By-User buckets — id
+      // must differ even when both names fall back to the same string.
+      const event1 = createGoogleEvent({
+        id: "e1",
+        calendarId: "cal-a@example.com",
+        creator: undefined,
+        organizer: undefined,
+      });
+      const event2 = createGoogleEvent({
+        id: "e2",
+        calendarId: "cal-b@example.com",
+        creator: undefined,
+        organizer: undefined,
+      });
+
+      const r1 = transformGoogleEvent(event1, [], new Map());
+      const r2 = transformGoogleEvent(event2, [], new Map());
+
+      expect(r1.user.id).toBe("cal-a@example.com");
+      expect(r2.user.id).toBe("cal-b@example.com");
+      expect(r1.user.id).not.toBe(r2.user.id);
+    });
+
+    it("treats the calendar-metadata argument as optional (back-compat with 2-arg call sites)", () => {
+      // Existing callers that pass only (event, mappings) should still get
+      // a sensible result — the ladder still runs, just without rung 3.
+      const googleEvent = createGoogleEvent({
+        creator: { email: "alice@example.com", displayName: "Alice" },
+      });
+
+      const result = transformGoogleEvent(googleEvent, []);
+
+      expect(result.user.name).toBe("Alice");
+      expect(result.user.id).toBe("alice@example.com");
+    });
+  });
 });

--- a/src/lib/calendar-transform.ts
+++ b/src/lib/calendar-transform.ts
@@ -7,10 +7,94 @@
  * - Timezone-safe date parsing (appends T00:00:00 to date-only strings)
  * - Calendar color mapping (from Google Calendar API color mappings)
  * - CalendarId preservation for cache round-tripping
+ * - User-attribution fallback ladder for shared-calendar events (#307)
  */
 import type { CalendarColorMapping } from "@/lib/calendar-storage";
 import type { GoogleCalendarEvent } from "@/lib/google-calendar";
 import type { IEvent, TEventColor } from "@/types/calendar";
+
+/**
+ * Per-calendar metadata used by the user-attribution fallback ladder.
+ * Keyed by `calendarId`. Values mirror the slice of `UserCalendar` we need
+ * to produce a human-readable label when neither `creator.displayName` nor
+ * `organizer.displayName` is populated (the common case for shared
+ * personal/family calendars — Google only fills `displayName` when the user
+ * has a discoverable People profile shared with the calling app).
+ */
+export interface CalendarAttributionMetadata {
+  summary: string;
+  summaryOverride?: string;
+}
+
+export type CalendarMetadataMap = ReadonlyMap<
+  string,
+  CalendarAttributionMetadata
+>;
+
+/**
+ * Turn the local-part of an email into a best-effort human-readable name.
+ *
+ *   liv4ever42@gmail.com   → "Liv4ever42"
+ *   john.doe@example.com   → "John Doe"
+ *   alice_marie@x.com      → "Alice Marie"
+ *
+ * Splits on `.`, `_`, `-`, capitalises the first character of each chunk, and
+ * joins with a space. Returns `undefined` when the input has no usable local
+ * part so the caller can fall through to the next rung of the ladder.
+ */
+function humanizeLocalPart(email: string | undefined): string | undefined {
+  if (!email) return undefined;
+  const at = email.indexOf("@");
+  const local = at >= 0 ? email.slice(0, at) : email;
+  const parts = local.split(/[._-]+/).filter(Boolean);
+  if (parts.length === 0) return undefined;
+  return parts
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+/**
+ * Resolve the user attribution displayed on the event.
+ *
+ * Ladder (first non-empty wins):
+ *   1. `creator.displayName`
+ *   2. `organizer.displayName`
+ *   3. Calendar metadata: `summaryOverride ?? summary` for `calendarId`
+ *      (e.g. "Liv Seymour" for `liv4ever42@gmail.com`). This is the most
+ *      reliable source for events on a calendar you don't own — Google
+ *      always fills it on `calendarList.list`.
+ *   4. Humanised local-part of the chosen email.
+ *   5. Literal `"Unknown"`.
+ *
+ * `id` cascades through `creator.email → organizer.email → calendarId →
+ * "unknown"`. The calendarId fallback ensures each shared calendar lands in
+ * a *distinct* Filter-By-User bucket (#307 Bug B) — pre-fix every shared
+ * calendar without a creator email shared the literal `"unknown"` id and
+ * collapsed into one bucket.
+ */
+function resolveUser(
+  googleEvent: GoogleCalendarEvent,
+  calendarMetadata: CalendarMetadataMap | undefined
+): { id: string; name: string; picturePath: null } {
+  const creatorEmail = googleEvent.creator?.email;
+  const organizerEmail = googleEvent.organizer?.email;
+  const id =
+    creatorEmail ?? organizerEmail ?? googleEvent.calendarId ?? "unknown";
+
+  const meta = calendarMetadata?.get(googleEvent.calendarId);
+  const calendarLabel = meta?.summaryOverride ?? meta?.summary;
+
+  const name =
+    googleEvent.creator?.displayName ??
+    googleEvent.organizer?.displayName ??
+    (calendarLabel && calendarLabel.trim().length > 0
+      ? calendarLabel
+      : undefined) ??
+    humanizeLocalPart(creatorEmail ?? organizerEmail) ??
+    "Unknown";
+
+  return { id, name, picturePath: null };
+}
 
 /**
  * Transform a Google Calendar event to our IEvent format.
@@ -21,10 +105,15 @@ import type { IEvent, TEventColor } from "@/types/calendar";
  * - Appends T00:00:00 to date-only strings to force local time interpretation
  * - Preserves calendarId from the Google event for cache round-tripping
  * - Maps colors via calendarId lookup, then colorId fallback, then default blue
+ * - Resolves `user.name` via the {@link resolveUser} fallback ladder; pass
+ *   `calendarMetadata` (a `Map<calendarId, { summary, summaryOverride? }>`)
+ *   to enable the calendar-name rung. Optional for back-compat with 2-arg
+ *   callers — the ladder simply skips that rung when it's missing.
  */
 export function transformGoogleEvent(
   googleEvent: GoogleCalendarEvent,
-  colorMappings: CalendarColorMapping[]
+  colorMappings: CalendarColorMapping[],
+  calendarMetadata?: CalendarMetadataMap
 ): IEvent {
   // Determine if this is an all-day event based on Google API convention:
   // All-day events use start.date (e.g., "2026-01-05")
@@ -49,11 +138,7 @@ export function transformGoogleEvent(
 
   const calendarId = googleEvent.calendarId;
 
-  const user = {
-    id: googleEvent.creator?.email || "unknown",
-    name: googleEvent.creator?.displayName || "Unknown",
-    picturePath: null,
-  };
+  const user = resolveUser(googleEvent, calendarMetadata);
 
   const baseEvent = {
     id: googleEvent.id,

--- a/src/lib/calendar-transform.ts
+++ b/src/lib/calendar-transform.ts
@@ -66,11 +66,13 @@ function humanizeLocalPart(email: string | undefined): string | undefined {
  *   4. Humanised local-part of the chosen email.
  *   5. Literal `"Unknown"`.
  *
- * `id` cascades through `creator.email → organizer.email → calendarId →
- * "unknown"`. The calendarId fallback ensures each shared calendar lands in
- * a *distinct* Filter-By-User bucket (#307 Bug B) — pre-fix every shared
- * calendar without a creator email shared the literal `"unknown"` id and
- * collapsed into one bucket.
+ * `id` cascades through `creator.email → organizer.email → calendarId`.
+ * The calendarId fallback ensures each shared calendar lands in a *distinct*
+ * Filter-By-User bucket (#307 Bug B) — pre-fix every shared calendar without
+ * a creator email shared the literal `"unknown"` id and collapsed into one
+ * bucket. `calendarId` is required on `GoogleCalendarEvent` (stamped by
+ * `normalizeFetchedEvent`), so the cascade always terminates with a
+ * meaningful string; no `"unknown"` literal is needed.
  */
 function resolveUser(
   googleEvent: GoogleCalendarEvent,
@@ -78,10 +80,14 @@ function resolveUser(
 ): { id: string; name: string; picturePath: null } {
   const creatorEmail = googleEvent.creator?.email;
   const organizerEmail = googleEvent.organizer?.email;
-  const id =
-    creatorEmail ?? organizerEmail ?? googleEvent.calendarId ?? "unknown";
+  const id: string = creatorEmail ?? organizerEmail ?? googleEvent.calendarId;
 
   const meta = calendarMetadata?.get(googleEvent.calendarId);
+  // `??` (not `||`) is intentional: a non-empty `summaryOverride` always
+  // wins over `summary`. An empty-string override would survive `??` but
+  // is filtered out by the trim guard below, falling through to
+  // humanizeLocalPart. In practice Google omits the field entirely when
+  // the user hasn't set an override, so this edge case is theoretical.
   const calendarLabel = meta?.summaryOverride ?? meta?.summary;
 
   const name =


### PR DESCRIPTION
Closes #307.

Two presentation bugs on shared-calendar events. They share an issue because they touch adjacent code paths (`CalendarProvider` plumbing + `transformGoogleEvent`) and a user reporting one will almost always also report the other.

## Phase 1 — Bug A: cross-browser / stale per-calendar colors

Pre-fix, `CalendarProvider.refreshEvents` short-circuited the color mappings fetch when the in-memory state was non-empty (hydrated from localStorage on mount). That made `/api/calendar/colors` fetch-once-per-session, which caused:

- **Cross-browser drift**: a browser whose localStorage was empty fetched the canonical mapping; a browser whose localStorage was populated *before* the user set a per-calendar override never re-hit the server, so the same calendar rendered in different colors across browsers.
- **Within-browser staleness**: an override changed in Google Calendar after the first session never reached the UI on subsequent refreshes.

Drop the `length === 0` guard. The server-derived mapping (`calendarList.list.backgroundColor`, which already reflects the per-user override) is the source of truth; localStorage stays only as a paint-fast warm cache that is written through on every refresh.

Server-side persistence of overrides is **out of scope** here (per the issue's "pick one or both" — this is the cheap fix that resolves the cross-browser symptom in practice).

## Phase 2 — Bug B: shared-calendar events attributed to "Unknown"

Pre-fix, every shared-calendar event whose creator had no discoverable People-profile collapsed to `user.name = "Unknown"` and `user.id = "unknown"`. That hid whose calendar an event was on *and* merged unrelated shared calendars into a single Filter-By-User bucket because dedupe is keyed on `user.id`.

Extended `transformGoogleEvent` with an optional 3rd argument `calendarMetadata: ReadonlyMap<calendarId, { summary, summaryOverride? }>` and resolve `user.name` through a five-step ladder:

1. `creator.displayName`
2. `organizer.displayName`
3. `calendar.summaryOverride ?? calendar.summary` (e.g. "Liv Seymour")
4. humanized email local-part (e.g. "Liv4ever42", "John Doe")
5. literal "Unknown"

`user.id` cascades through `creator.email → organizer.email → calendarId → "unknown"`, so each shared calendar now lands in a *distinct* bucket.

Plumbed metadata through `CalendarProvider`:
- `fetchCalendarList` returns `{ ids, metadata }` instead of bare `ids[]`
- new `calendarMetadata` state, mirroring the fetched payload
- threaded into `refreshEvents`, `fetchEventsForRange`, `loadEventsForDate`, `loadEventsForYear`, the `createEvent` reconcile path, and the cache-load fallback. Optional 3rd arg keeps test mocks 2-arg-compatible.

The `/api/calendar/calendars` route now exposes `summaryOverride` alongside `summary` so the user's per-calendar override (set in the Google UI for a shared calendar they don't own) is preferred over the canonical name.

## Tests

- **`transformGoogleEvent`** (8 new): one per ladder rung + email-humanization edge cases + the "two shared calendars stay in distinct Filter-By-User buckets" invariant + back-compat for 2-arg callers.
- **`CalendarProvider`** (3 new): `/api/calendar/colors` is hit on mount when warm cache is populated; re-hit on every `refreshEvents()` call; calendar `summary` flows from `/api/calendar/calendars` through to `event.user.name`.
- **`/api/calendar/calendars` route** (1 new): forwards `summaryOverride` from the Google `calendarList.list` payload.
- Refactored the existing `loadColorMappings` / `transformGoogleEvent` mocks to enable the new integration tests.

## Test plan
- [x] `pnpm test:run` green for the whole repo (1921 / 1921)
- [x] `pnpm lint` (no new warnings — the 5 pre-existing `<img>` / unused-`_var` warnings in unrelated files remain)
- [x] `pnpm format:fix` (idempotent)
- [x] `pnpm check-types` (no errors)

## Deferred (post-PR follow-ups)
- Server-side persistence of color overrides per `UserSettings` / `CalendarSettings` (issue mentions this as the cleaner long-term fix).
- Collision-avoidance in `Filter-By-User` when multiple shared calendars produce identical fallback names — acceptable for v1 since `id`s are now distinct.
