### PR TITLE
feat(tasks): add TasksProvider for shared client state (#331)

### DIFF
--- a/src/components/providers/TasksProvider.tsx
+++ b/src/components/providers/TasksProvider.tsx
@@ -31,7 +31,7 @@ import type {
 import { type UseTasksReturn, useTasks } from "@/components/tasks/use-tasks";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
 import type React from "react";
-import { createContext, useContext } from "react";
+import { createContext, useContext, useEffect } from "react";
 
 /** Tasks UI view mode. Mirrors the Calendar `view` axis. */
 export type TasksViewMode = "list" | "grouped-by-list";
@@ -43,6 +43,14 @@ export const TASKS_ACTIVE_CONFIG_LS_KEY = "tasks.activeConfigId";
 export const TASKS_VIEW_MODE_LS_KEY = "tasks.viewMode";
 
 const DEFAULT_VIEW_MODE: TasksViewMode = "list";
+const VALID_VIEW_MODES: ReadonlySet<string> = new Set([
+  "list",
+  "grouped-by-list",
+]);
+
+function isValidViewMode(value: unknown): value is TasksViewMode {
+  return typeof value === "string" && VALID_VIEW_MODES.has(value);
+}
 
 export interface ITasksContext extends UseTasksReturn {
   /**
@@ -111,38 +119,86 @@ export function TasksProvider({
     TASKS_ACTIVE_CONFIG_LS_KEY,
     initialActiveConfigId ?? null
   );
-  const [viewMode, setStoredViewMode] = useLocalStorage<TasksViewMode>(
+  const [storedViewMode, setStoredViewMode] = useLocalStorage<TasksViewMode>(
     TASKS_VIEW_MODE_LS_KEY,
     initialViewMode ?? DEFAULT_VIEW_MODE
   );
+
+  // Apply override props on mount when they're provided. `useLocalStorage`
+  // is backed by `useSyncExternalStore`, so the `initialValue` argument is
+  // only used when the storage key is absent; for a returning user with a
+  // persisted value the override would be silently ignored without this
+  // mount-only write through. Mirrors `CalendarProvider.initialView` /
+  // `initialAgendaMode` (#150 / #238). Capturing the props once is
+  // intentional: subsequent prop changes are owned by the parent
+  // component (e.g. it remounts the provider on a URL change).
+  useEffect(() => {
+    if (initialActiveConfigId !== undefined) {
+      setStoredConfigId(initialActiveConfigId);
+    }
+    if (initialViewMode !== undefined) {
+      setStoredViewMode(initialViewMode);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Resolve `activeConfig` with a stale-id fallback: if the persisted id
   // points at a config the user has since deleted (or to nothing on the
   // very first mount), fall through to the first available config rather
   // than rendering an empty surface that "should" have content.
-  const activeConfig =
-    configs.find((c) => c.id === storedConfigId) ?? configs[0] ?? null;
+  const resolvedConfig = configs.find((c) => c.id === storedConfigId);
+  const activeConfig = resolvedConfig ?? configs[0] ?? null;
 
-  const setActiveConfigId = (id: string) => {
-    setStoredConfigId(id);
-  };
+  // Reconcile a stale `storedConfigId` so the next reload starts on the
+  // correct config without re-firing the fallback every render. Skipped
+  // when `configs` is empty (no canonical id to write through yet).
+  useEffect(() => {
+    if (
+      storedConfigId !== null &&
+      !resolvedConfig &&
+      activeConfig !== null &&
+      activeConfig.id !== storedConfigId
+    ) {
+      setStoredConfigId(activeConfig.id);
+    }
+  }, [storedConfigId, resolvedConfig, activeConfig, setStoredConfigId]);
 
-  const setViewMode = (mode: TasksViewMode) => {
-    setStoredViewMode(mode);
-  };
+  // Validate the stored view mode against the current union. A
+  // corrupted/manually-edited value (or one written by a future build
+  // and read by an older one) is typed as `TasksViewMode` at compile
+  // time but might not match the union at runtime; fall back to the
+  // default rather than render with a value the rest of the codebase
+  // doesn't recognise.
+  const viewMode: TasksViewMode = isValidViewMode(storedViewMode)
+    ? storedViewMode
+    : DEFAULT_VIEW_MODE;
 
   const lists = activeConfig ? activeConfig.lists.filter((l) => l.enabled) : [];
 
-  const tasksApi = useTasks(activeConfig);
+  // Destructure the exact `useTasks` keys we forward instead of spreading,
+  // so a future addition to `UseTasksReturn` whose name collides with a
+  // provider-owned key (e.g. both expose `loading`) is caught by the type
+  // checker at the assignment below rather than silently shadowing the
+  // provider's value at runtime.
+  const { tasks, loading, error, refreshTasks, updateTask } =
+    useTasks(activeConfig);
 
+  // Setters are exposed directly — they don't add type narrowing,
+  // logging, or side effects, so wrapping them only adds a closure that
+  // the React Compiler can't reason about. The public types in
+  // `ITasksContext` constrain callers to the intended argument shape.
   const value: ITasksContext = {
-    ...tasksApi,
+    tasks,
+    loading,
+    error,
+    refreshTasks,
+    updateTask,
     configs,
     activeConfig,
-    setActiveConfigId,
+    setActiveConfigId: setStoredConfigId,
     lists,
     viewMode,
-    setViewMode,
+    setViewMode: setStoredViewMode,
   };
 
   return (

--- a/src/components/providers/TasksProvider.tsx
+++ b/src/components/providers/TasksProvider.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+/**
+ * TasksProvider — shared client-state container for the Tasks surface
+ * (issue #331). Analogous to `CalendarProvider` for the calendar surface.
+ *
+ * Owns ephemeral UI state only:
+ *
+ *   - `activeConfig` — the `TaskListConfig` currently being rendered.
+ *     Resolved by id against the `configs` prop with a stale-id fallback,
+ *     so a removed config never leaves the surface in a wedged "no view"
+ *     state.
+ *   - `viewMode` — `"list"` or `"grouped-by-list"`, persisted across
+ *     reloads.
+ *
+ * DB-backed settings (`taskSortOrder`, `showCompletedTasks`,
+ * `defaultTaskListId`) deliberately stay with `useUserSettings` /
+ * `ProfileSettings` and are NOT mirrored here — the provider is for
+ * ephemeral UI state, not a second source of truth.
+ *
+ * The provider also calls `useTasks(activeConfig)` once and re-exposes
+ * its `{ tasks, loading, error, refreshTasks, updateTask }` so descendants
+ * (`TaskList`, `TasksSettingsPanel`, future `TasksPage`) read from one
+ * canonical fetch lifecycle instead of each calling `useTasks` and racing
+ * each other on the same config.
+ */
+import type {
+  TaskListConfig,
+  TaskListSelection,
+} from "@/components/tasks/types";
+import { type UseTasksReturn, useTasks } from "@/components/tasks/use-tasks";
+import { useLocalStorage } from "@/hooks/useLocalStorage";
+import type React from "react";
+import { createContext, useContext } from "react";
+
+/** Tasks UI view mode. Mirrors the Calendar `view` axis. */
+export type TasksViewMode = "list" | "grouped-by-list";
+
+/** localStorage key for the user's last-active `TaskListConfig` id. */
+export const TASKS_ACTIVE_CONFIG_LS_KEY = "tasks.activeConfigId";
+
+/** localStorage key for the user's last-selected view mode. */
+export const TASKS_VIEW_MODE_LS_KEY = "tasks.viewMode";
+
+const DEFAULT_VIEW_MODE: TasksViewMode = "list";
+
+export interface ITasksContext extends UseTasksReturn {
+  /**
+   * All known `TaskListConfig` rows the provider can pick from. The
+   * provider does not fetch these itself — the caller is expected to
+   * supply them (for now hard-coded; #332 will populate from the DB).
+   */
+  configs: TaskListConfig[];
+  /** The currently-rendered config. `null` when `configs` is empty. */
+  activeConfig: TaskListConfig | null;
+  /**
+   * Switch the active config. Persists the id to `localStorage` so the
+   * choice survives a reload.
+   */
+  setActiveConfigId: (id: string) => void;
+  /**
+   * Effective enabled lists from `activeConfig`. Empty when there is
+   * no active config or every list is disabled.
+   */
+  lists: TaskListSelection[];
+  /** Ephemeral UI view mode. */
+  viewMode: TasksViewMode;
+  /** Switch the view mode. Persists to `localStorage`. */
+  setViewMode: (mode: TasksViewMode) => void;
+}
+
+const TasksContext = createContext<ITasksContext | null>(null);
+
+/**
+ * Read the Tasks context. Throws if called outside `TasksProvider` so
+ * mis-mounted descendants fail loudly instead of silently no-op'ing.
+ */
+export function useTasksContext(): ITasksContext {
+  const ctx = useContext(TasksContext);
+  if (!ctx) {
+    throw new Error("useTasksContext must be used within TasksProvider");
+  }
+  return ctx;
+}
+
+export interface TasksProviderProps {
+  children: React.ReactNode;
+  /**
+   * The set of `TaskListConfig` rows the user can pick from. Defaults
+   * to `[]` so the provider can mount before any configs exist (e.g.
+   * the empty-state path on `/tasks`).
+   */
+  configs?: TaskListConfig[];
+  /**
+   * Optional override for the initial active config id. Used by deep
+   * links (e.g. `/tasks?listConfig=...`) to win over the persisted
+   * value on first mount.
+   */
+  initialActiveConfigId?: string;
+  /** Optional override for the initial view mode. Same semantics. */
+  initialViewMode?: TasksViewMode;
+}
+
+export function TasksProvider({
+  children,
+  configs = [],
+  initialActiveConfigId,
+  initialViewMode,
+}: TasksProviderProps) {
+  const [storedConfigId, setStoredConfigId] = useLocalStorage<string | null>(
+    TASKS_ACTIVE_CONFIG_LS_KEY,
+    initialActiveConfigId ?? null
+  );
+  const [viewMode, setStoredViewMode] = useLocalStorage<TasksViewMode>(
+    TASKS_VIEW_MODE_LS_KEY,
+    initialViewMode ?? DEFAULT_VIEW_MODE
+  );
+
+  // Resolve `activeConfig` with a stale-id fallback: if the persisted id
+  // points at a config the user has since deleted (or to nothing on the
+  // very first mount), fall through to the first available config rather
+  // than rendering an empty surface that "should" have content.
+  const activeConfig =
+    configs.find((c) => c.id === storedConfigId) ?? configs[0] ?? null;
+
+  const setActiveConfigId = (id: string) => {
+    setStoredConfigId(id);
+  };
+
+  const setViewMode = (mode: TasksViewMode) => {
+    setStoredViewMode(mode);
+  };
+
+  const lists = activeConfig ? activeConfig.lists.filter((l) => l.enabled) : [];
+
+  const tasksApi = useTasks(activeConfig);
+
+  const value: ITasksContext = {
+    ...tasksApi,
+    configs,
+    activeConfig,
+    setActiveConfigId,
+    lists,
+    viewMode,
+    setViewMode,
+  };
+
+  return (
+    <TasksContext.Provider value={value}>{children}</TasksContext.Provider>
+  );
+}

--- a/src/components/providers/__tests__/TasksProvider.integration.test.tsx
+++ b/src/components/providers/__tests__/TasksProvider.integration.test.tsx
@@ -23,10 +23,12 @@ import {
 import type { TaskListConfig } from "@/components/tasks/types";
 import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+// Use `vi.stubGlobal` so the patched `fetch` is automatically restored by
+// `vi.unstubAllGlobals()` in `afterEach` — assigning to `global.fetch`
+// directly would persist across test files in the same Vitest worker.
 const mockFetch = vi.fn();
-global.fetch = mockFetch as unknown as typeof fetch;
 
 const configA: TaskListConfig = {
   id: "config-a",
@@ -77,6 +79,11 @@ describe("TasksProvider — integration with real useTasks", () => {
   beforeEach(() => {
     window.localStorage.clear();
     mockFetch.mockReset();
+    vi.stubGlobal("fetch", mockFetch);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it("renders tasks fetched for the active config", async () => {

--- a/src/components/providers/__tests__/TasksProvider.integration.test.tsx
+++ b/src/components/providers/__tests__/TasksProvider.integration.test.tsx
@@ -1,0 +1,173 @@
+/**
+ * Integration test for `TasksProvider` (#331) consumed by a `TaskList`-shaped
+ * descendant.
+ *
+ * The unit tests in `TasksProvider.test.tsx` mock `useTasks` to assert the
+ * provider's pass-through contract in isolation. This file goes one layer
+ * deeper: it lets the real `useTasks` hook run inside the provider, mocks
+ * only `fetch`, and confirms that:
+ *
+ *   1. tasks fetched against the active config render in a descendant that
+ *      reads `useTasksContext().tasks` (not the `config` prop on
+ *      `TaskList`).
+ *   2. switching `activeConfigId` triggers a re-fetch against the new
+ *      config's lists.
+ *
+ * This is the seam that #329 (`/tasks` page) and #333 (TasksSettingsPanel)
+ * will rely on, so we want a regression net here before either lands.
+ */
+import {
+  TasksProvider,
+  useTasksContext,
+} from "@/components/providers/TasksProvider";
+import type { TaskListConfig } from "@/components/tasks/types";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+const configA: TaskListConfig = {
+  id: "config-a",
+  title: "Config A",
+  showCompleted: false,
+  sortBy: "dueDate",
+  lists: [
+    { listId: "list-a", listTitle: "List A", color: "#3b82f6", enabled: true },
+  ],
+};
+
+const configB: TaskListConfig = {
+  id: "config-b",
+  title: "Config B",
+  showCompleted: false,
+  sortBy: "dueDate",
+  lists: [
+    { listId: "list-b", listTitle: "List B", color: "#22c55e", enabled: true },
+  ],
+};
+
+function ContextConsumer() {
+  const { activeConfig, tasks, loading, configs, setActiveConfigId } =
+    useTasksContext();
+  return (
+    <div>
+      <span data-testid="active-config">{activeConfig?.id ?? "none"}</span>
+      <span data-testid="loading">{String(loading)}</span>
+      <ul data-testid="tasks">
+        {tasks.map((t) => (
+          <li key={t.id}>{t.title}</li>
+        ))}
+      </ul>
+      {configs.map((c) => (
+        <button
+          key={c.id}
+          type="button"
+          onClick={() => setActiveConfigId(c.id)}
+        >
+          {`switch-${c.id}`}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+describe("TasksProvider — integration with real useTasks", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    mockFetch.mockReset();
+  });
+
+  it("renders tasks fetched for the active config", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        tasks: [
+          {
+            id: "t1",
+            title: "Buy groceries",
+            status: "needsAction",
+            updated: "2024-06-14T00:00:00Z",
+            position: "00000000000000000000",
+          },
+        ],
+      }),
+    });
+
+    render(
+      <TasksProvider configs={[configA]}>
+        <ContextConsumer />
+      </TasksProvider>
+    );
+
+    expect(screen.getByTestId("active-config")).toHaveTextContent("config-a");
+
+    await waitFor(() => {
+      expect(screen.getByText("Buy groceries")).toBeInTheDocument();
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).toContain("listId=list-a");
+  });
+
+  it("re-fetches when the active config changes", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          tasks: [
+            {
+              id: "t1",
+              title: "Task in A",
+              status: "needsAction",
+              updated: "2024-06-14T00:00:00Z",
+              position: "00000000000000000000",
+            },
+          ],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          tasks: [
+            {
+              id: "t2",
+              title: "Task in B",
+              status: "needsAction",
+              updated: "2024-06-14T00:00:00Z",
+              position: "00000000000000000000",
+            },
+          ],
+        }),
+      });
+
+    const user = userEvent.setup();
+
+    render(
+      <TasksProvider configs={[configA, configB]}>
+        <ContextConsumer />
+      </TasksProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Task in A")).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      await user.click(screen.getByText("switch-config-b"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("active-config")).toHaveTextContent("config-b");
+    });
+    await waitFor(() => {
+      expect(screen.getByText("Task in B")).toBeInTheDocument();
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    const secondUrl = mockFetch.mock.calls[1][0] as string;
+    expect(secondUrl).toContain("listId=list-b");
+  });
+});

--- a/src/components/providers/__tests__/TasksProvider.test.tsx
+++ b/src/components/providers/__tests__/TasksProvider.test.tsx
@@ -128,7 +128,7 @@ describe("TasksProvider — activeConfig resolution", () => {
     expect(result.current.activeConfig?.id).toBe("config-b");
   });
 
-  it("falls back to the first config when the persisted id no longer exists", () => {
+  it("falls back to the first config when the persisted id no longer exists and reconciles localStorage", async () => {
     window.localStorage.setItem(
       TASKS_ACTIVE_CONFIG_LS_KEY,
       JSON.stringify("config-stale")
@@ -143,6 +143,46 @@ describe("TasksProvider — activeConfig resolution", () => {
     });
 
     expect(result.current.activeConfig?.id).toBe("config-a");
+
+    // Reconciliation effect heals the stale key so the next reload starts
+    // on the correct config without re-firing the fallback every render.
+    await waitFor(() => {
+      expect(
+        JSON.parse(
+          window.localStorage.getItem(TASKS_ACTIVE_CONFIG_LS_KEY) ?? "null"
+        )
+      ).toBe("config-a");
+    });
+  });
+
+  it("initialActiveConfigId wins over a previously-persisted id", async () => {
+    window.localStorage.setItem(
+      TASKS_ACTIVE_CONFIG_LS_KEY,
+      JSON.stringify("config-a")
+    );
+
+    const configs = [
+      makeConfig({ id: "config-a" }),
+      makeConfig({ id: "config-b" }),
+    ];
+    const { result } = renderHook(() => useTasksContext(), {
+      wrapper: ({ children }) => (
+        <TasksProvider configs={configs} initialActiveConfigId="config-b">
+          {children}
+        </TasksProvider>
+      ),
+    });
+
+    await waitFor(() => {
+      expect(result.current.activeConfig?.id).toBe("config-b");
+    });
+
+    // Override is also written through to storage so reload preserves it.
+    expect(
+      JSON.parse(
+        window.localStorage.getItem(TASKS_ACTIVE_CONFIG_LS_KEY) ?? "null"
+      )
+    ).toBe("config-b");
   });
 
   it("computes lists as the enabled subset of the active config", () => {
@@ -267,6 +307,43 @@ describe("TasksProvider — viewMode", () => {
     expect(screen.getByTestId("view-mode")).toHaveTextContent(
       "grouped-by-list"
     );
+  });
+
+  it("falls back to default viewMode when the stored value is not in the union", () => {
+    // Corrupted/manually-edited or future-build payload — runtime value
+    // doesn't match the current `TasksViewMode` union.
+    window.localStorage.setItem(
+      TASKS_VIEW_MODE_LS_KEY,
+      JSON.stringify("nonsense")
+    );
+
+    render(
+      <TasksProvider configs={[]}>
+        <ViewModeProbe />
+      </TasksProvider>
+    );
+
+    expect(screen.getByTestId("view-mode")).toHaveTextContent("list");
+  });
+
+  it("initialViewMode wins over a previously-persisted value", async () => {
+    window.localStorage.setItem(
+      TASKS_VIEW_MODE_LS_KEY,
+      JSON.stringify("grouped-by-list")
+    );
+
+    render(
+      <TasksProvider configs={[]} initialViewMode="list">
+        <ViewModeProbe />
+      </TasksProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("view-mode")).toHaveTextContent("list");
+    });
+    expect(
+      JSON.parse(window.localStorage.getItem(TASKS_VIEW_MODE_LS_KEY) ?? "null")
+    ).toBe("list");
   });
 });
 

--- a/src/components/providers/__tests__/TasksProvider.test.tsx
+++ b/src/components/providers/__tests__/TasksProvider.test.tsx
@@ -1,0 +1,305 @@
+/**
+ * Tests for TasksProvider (#331).
+ *
+ * Covers ephemeral client state only — `activeConfig` resolution from a
+ * `configs` prop, `viewMode` toggling, localStorage persistence, the
+ * `useTasksContext()` error guard, and the pass-through of `useTasks`
+ * results scoped to the active config.
+ *
+ * The DB-backed settings (`taskSortOrder`, `showCompletedTasks`,
+ * `defaultTaskListId`) live in `UserSettings`/`ProfileSettings` and are
+ * deliberately NOT owned by this provider — those tests live with the
+ * settings hooks.
+ */
+import {
+  TASKS_ACTIVE_CONFIG_LS_KEY,
+  TASKS_VIEW_MODE_LS_KEY,
+  TasksProvider,
+  useTasksContext,
+} from "@/components/providers/TasksProvider";
+import type { TaskListConfig } from "@/components/tasks/types";
+import type React from "react";
+import { render, renderHook, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock useTasks at the module boundary so the provider's pass-through path
+// can be asserted without the fetch lifecycle. The real `useTasks` is
+// covered by its own suite.
+const useTasksMock = vi.fn();
+vi.mock("@/components/tasks/use-tasks", () => ({
+  useTasks: (config: TaskListConfig | null) => useTasksMock(config),
+}));
+
+const baseUseTasksReturn = {
+  tasks: [],
+  loading: false,
+  error: null,
+  refreshTasks: vi.fn(),
+  updateTask: vi.fn(),
+};
+
+function makeConfig(overrides: Partial<TaskListConfig> = {}): TaskListConfig {
+  return {
+    id: "config-a",
+    title: "My Tasks",
+    showCompleted: false,
+    sortBy: "dueDate",
+    lists: [
+      {
+        listId: "list-1",
+        listTitle: "Work",
+        color: "#3b82f6",
+        enabled: true,
+      },
+      {
+        listId: "list-2",
+        listTitle: "Archived",
+        color: "#9ca3af",
+        enabled: false,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function wrap(configs: TaskListConfig[] = []) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <TasksProvider configs={configs}>{children}</TasksProvider>;
+  };
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  useTasksMock.mockReset();
+  useTasksMock.mockReturnValue(baseUseTasksReturn);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useTasksContext", () => {
+  it("throws a useful error when used outside TasksProvider", () => {
+    // Suppress the React error-boundary console output for the throw path.
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => renderHook(() => useTasksContext())).toThrow(/TasksProvider/);
+    errorSpy.mockRestore();
+  });
+});
+
+describe("TasksProvider — activeConfig resolution", () => {
+  it("returns null activeConfig and empty lists when configs is empty", () => {
+    const { result } = renderHook(() => useTasksContext(), {
+      wrapper: wrap([]),
+    });
+
+    expect(result.current.activeConfig).toBeNull();
+    expect(result.current.lists).toEqual([]);
+    expect(result.current.configs).toEqual([]);
+  });
+
+  it("defaults activeConfig to the first config when nothing is persisted", () => {
+    const configs = [
+      makeConfig({ id: "config-a" }),
+      makeConfig({ id: "config-b" }),
+    ];
+    const { result } = renderHook(() => useTasksContext(), {
+      wrapper: wrap(configs),
+    });
+
+    expect(result.current.activeConfig?.id).toBe("config-a");
+  });
+
+  it("rehydrates the active config from localStorage on mount", () => {
+    window.localStorage.setItem(
+      TASKS_ACTIVE_CONFIG_LS_KEY,
+      JSON.stringify("config-b")
+    );
+
+    const configs = [
+      makeConfig({ id: "config-a" }),
+      makeConfig({ id: "config-b" }),
+    ];
+    const { result } = renderHook(() => useTasksContext(), {
+      wrapper: wrap(configs),
+    });
+
+    expect(result.current.activeConfig?.id).toBe("config-b");
+  });
+
+  it("falls back to the first config when the persisted id no longer exists", () => {
+    window.localStorage.setItem(
+      TASKS_ACTIVE_CONFIG_LS_KEY,
+      JSON.stringify("config-stale")
+    );
+
+    const configs = [
+      makeConfig({ id: "config-a" }),
+      makeConfig({ id: "config-b" }),
+    ];
+    const { result } = renderHook(() => useTasksContext(), {
+      wrapper: wrap(configs),
+    });
+
+    expect(result.current.activeConfig?.id).toBe("config-a");
+  });
+
+  it("computes lists as the enabled subset of the active config", () => {
+    const configs = [makeConfig({ id: "config-a" })];
+    const { result } = renderHook(() => useTasksContext(), {
+      wrapper: wrap(configs),
+    });
+
+    expect(result.current.lists).toHaveLength(1);
+    expect(result.current.lists[0].listId).toBe("list-1");
+  });
+});
+
+describe("TasksProvider — switching active config", () => {
+  function ActiveConfigProbe() {
+    const { activeConfig, configs, setActiveConfigId } = useTasksContext();
+    return (
+      <div>
+        <span data-testid="active">{activeConfig?.id ?? "none"}</span>
+        {configs.map((c) => (
+          <button
+            key={c.id}
+            type="button"
+            onClick={() => setActiveConfigId(c.id)}
+          >
+            {`switch-${c.id}`}
+          </button>
+        ))}
+      </div>
+    );
+  }
+
+  it("setActiveConfigId switches activeConfig and persists to localStorage", async () => {
+    const user = userEvent.setup();
+    const configs = [
+      makeConfig({ id: "config-a" }),
+      makeConfig({ id: "config-b" }),
+    ];
+
+    render(
+      <TasksProvider configs={configs}>
+        <ActiveConfigProbe />
+      </TasksProvider>
+    );
+
+    expect(screen.getByTestId("active")).toHaveTextContent("config-a");
+
+    await user.click(screen.getByText("switch-config-b"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("active")).toHaveTextContent("config-b");
+    });
+
+    expect(
+      JSON.parse(
+        window.localStorage.getItem(TASKS_ACTIVE_CONFIG_LS_KEY) ?? "null"
+      )
+    ).toBe("config-b");
+  });
+});
+
+describe("TasksProvider — viewMode", () => {
+  function ViewModeProbe() {
+    const { viewMode, setViewMode } = useTasksContext();
+    return (
+      <div>
+        <span data-testid="view-mode">{viewMode}</span>
+        <button type="button" onClick={() => setViewMode("grouped-by-list")}>
+          group
+        </button>
+        <button type="button" onClick={() => setViewMode("list")}>
+          flat
+        </button>
+      </div>
+    );
+  }
+
+  it("defaults viewMode to 'list'", () => {
+    render(
+      <TasksProvider configs={[]}>
+        <ViewModeProbe />
+      </TasksProvider>
+    );
+
+    expect(screen.getByTestId("view-mode")).toHaveTextContent("list");
+  });
+
+  it("setViewMode toggles and persists to localStorage", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TasksProvider configs={[]}>
+        <ViewModeProbe />
+      </TasksProvider>
+    );
+
+    await user.click(screen.getByText("group"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("view-mode")).toHaveTextContent(
+        "grouped-by-list"
+      );
+    });
+
+    expect(
+      JSON.parse(window.localStorage.getItem(TASKS_VIEW_MODE_LS_KEY) ?? "null")
+    ).toBe("grouped-by-list");
+  });
+
+  it("rehydrates viewMode from localStorage on mount", () => {
+    window.localStorage.setItem(
+      TASKS_VIEW_MODE_LS_KEY,
+      JSON.stringify("grouped-by-list")
+    );
+
+    render(
+      <TasksProvider configs={[]}>
+        <ViewModeProbe />
+      </TasksProvider>
+    );
+
+    expect(screen.getByTestId("view-mode")).toHaveTextContent(
+      "grouped-by-list"
+    );
+  });
+});
+
+describe("TasksProvider — useTasks pass-through", () => {
+  it("calls useTasks with the active config and exposes its return values", () => {
+    const refreshTasks = vi.fn();
+    const updateTask = vi.fn();
+    useTasksMock.mockReturnValue({
+      tasks: [{ id: "t1" }],
+      loading: true,
+      error: null,
+      refreshTasks,
+      updateTask,
+    });
+
+    const configs = [makeConfig({ id: "config-a" })];
+    const { result } = renderHook(() => useTasksContext(), {
+      wrapper: wrap(configs),
+    });
+
+    expect(useTasksMock).toHaveBeenCalled();
+    const lastArg = useTasksMock.mock.calls.at(-1)?.[0];
+    expect(lastArg?.id).toBe("config-a");
+
+    expect(result.current.tasks).toEqual([{ id: "t1" }]);
+    expect(result.current.loading).toBe(true);
+    expect(result.current.refreshTasks).toBe(refreshTasks);
+    expect(result.current.updateTask).toBe(updateTask);
+  });
+
+  it("calls useTasks with null when configs is empty", () => {
+    renderHook(() => useTasksContext(), { wrapper: wrap([]) });
+
+    expect(useTasksMock).toHaveBeenCalledWith(null);
+  });
+});


### PR DESCRIPTION
Closes #331.

## Summary

Adds `TasksProvider` — the Calendar-style shared client-state container the Tasks track has been waiting on. It is the foundation for #329 (`/tasks` page), #332 (TaskListConfig CRUD UI), and #333 (TasksSettingsPanel), all of which need a single source for "the currently rendered config" and the `useTasks` lifecycle.

## What it owns (ephemeral UI state only)

- **`activeConfig`** — resolved by id from a `configs: TaskListConfig[]` prop with a stale-id fallback (persisted id → first available → null). Avoids leaving the surface wedged when a config is deleted.
- **`viewMode`** — `"list" | "grouped-by-list"`, persisted to `localStorage` under `tasks.viewMode`.
- **`lists`** — enabled subset of the active config.
- **`useTasks(activeConfig)` pass-through** — `tasks`, `loading`, `error`, `refreshTasks`, `updateTask`. Descendants share one fetch lifecycle instead of each calling `useTasks` and racing on the same config.

## What it deliberately does not own

DB-backed settings (`taskSortOrder`, `showCompletedTasks`, `defaultTaskListId`) keep flowing through `useUserSettings` / `ProfileSettings` — the provider is for ephemeral UI state, not a second source of truth. This matches the issue spec.

## API

```tsx
<TasksProvider configs={configs} initialActiveConfigId={...} initialViewMode={...}>
  <TaskList />
</TasksProvider>

const {
  configs, activeConfig, setActiveConfigId,
  lists, viewMode, setViewMode,
  tasks, loading, error, refreshTasks, updateTask,
} = useTasksContext();
```

`useTasksContext()` throws when used outside the provider so misuse fails loudly.

## React Compiler compliance

No `useCallback` / `useMemo` / `React.memo` per `docs/react-compiler.md` — the issue spec calls this out and the file follows it.

## Tests

12 new unit tests in `src/components/providers/__tests__/TasksProvider.test.tsx`:
- `useTasksContext` throws outside provider
- empty-`configs` returns `null` activeConfig + empty `lists`
- defaults activeConfig to first when nothing is persisted
- rehydrates activeConfigId from localStorage on mount
- falls back to first when persisted id is stale
- computes `lists` as enabled subset of activeConfig
- `setActiveConfigId` switches and persists to localStorage
- defaults `viewMode` to `"list"`
- `setViewMode` toggles and persists
- rehydrates `viewMode` from localStorage on mount
- `useTasks` is called with the active config and its return values are passed through (incl. `null` when configs is empty)

Full repo suite: 2031 / 2031 passing. Lint, format, and check-types clean.

## Deferred to sibling sub-issues

- Wiring DB-backed `configs` source — #332 (TaskListConfig CRUD UI). Provider currently accepts `configs` as a prop so the eventual repository hook can drop straight in.
- Mounting on a real page — #329 (`/tasks` route).
- Settings popover consumer — #333.
- Persisting `taskSortOrder` / `showCompletedTasks` to `ProfileSettings` — #334.

## Test plan
- [x] `pnpm test` — 2031 / 2031
- [x] `pnpm lint:fix` — no new errors
- [x] `pnpm format:fix` — no diff
- [x] `pnpm check-types` — clean

https://claude.ai/code/session_019aDuo26G6JMTEjwrgUR8vH

---
_Generated by [Claude Code](https://claude.ai/code/session_019aDuo26G6JMTEjwrgUR8vH)_