### PR TITLE
feat(calendar): Clock view — floating off-arc title labels with connector lines (#311)

### DIFF
--- a/e2e/analog-clock-floating-labels.spec.ts
+++ b/e2e/analog-clock-floating-labels.spec.ts
@@ -1,0 +1,84 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Floating off-arc title labels (#311).
+ *
+ * Exercises the overflow path on top of #310's 2-line wrap: when a title
+ * cannot fit even on two curved lines (or sits on a sub-30° arc whose
+ * single-line budget is too tight), the in-arc title is suppressed and a
+ * sibling FloatingLabel renders the full text outside the clock face with
+ * a thin connector back to the arc midpoint.
+ *
+ * The default scenario is sufficient: "Team Standup" (12 chars) sits on a
+ * 15° arc whose single-line budget is well below 12 chars, so the title
+ * overflows and a floating label renders.
+ */
+test.describe("Analog Clock — floating off-arc labels (#311)", () => {
+  test("renders a floating label for an event whose title overflows the arc", async ({
+    page,
+  }) => {
+    await page.goto("/test/analog-clock?scenario=default&hour=10&min=10");
+    await expect(page.getByTestId("analog-clock")).toBeVisible();
+
+    const layer = page.getByTestId("floating-labels-layer");
+    await expect(layer).toBeAttached();
+
+    // d3 ("Team Standup") sits on a 15° arc; its 12-char title overflows.
+    const label = page.getByTestId("floating-label-d3");
+    await expect(label).toBeVisible();
+
+    const text = page.getByTestId("floating-label-text-d3");
+    await expect(text).toHaveText("Team Standup");
+  });
+
+  test("suppresses the in-arc title for an overflowing event but keeps the colored arc", async ({
+    page,
+  }) => {
+    await page.goto("/test/analog-clock?scenario=default&hour=10&min=10");
+    await expect(page.getByTestId("analog-clock")).toBeVisible();
+
+    // The arc fill is still painted.
+    await expect(page.getByTestId("event-arc-d3")).toBeVisible();
+    // …but no in-arc title text is rendered (would otherwise be event-title-d3).
+    await expect(page.getByTestId("event-title-d3")).toHaveCount(0);
+  });
+
+  test("renders a connector line in the event's color back to the arc midpoint", async ({
+    page,
+  }) => {
+    await page.goto("/test/analog-clock?scenario=default&hour=10&min=10");
+    const connector = page.getByTestId("floating-label-connector-d3");
+    await expect(connector).toBeAttached();
+    // d3 is the blue Team Standup event.
+    await expect(connector).toHaveAttribute("stroke", "#3B82F6");
+  });
+
+  test("the analog clock SVG carries overflow='visible' so labels can paint outside the viewBox", async ({
+    page,
+  }) => {
+    await page.goto("/test/analog-clock?scenario=default&hour=10&min=10");
+    const svg = page.getByTestId("analog-clock");
+    await expect(svg).toHaveAttribute("overflow", "visible");
+  });
+
+  test("does not render a floating label for an event whose title fits inside the arc", async ({
+    page,
+  }) => {
+    await page.goto("/test/analog-clock?scenario=default&hour=10&min=10");
+    // d1 ("Family Game Night") sits on a 45° arc — fits across two lines.
+    await expect(page.getByTestId("event-title-d1")).toBeVisible();
+    await expect(page.getByTestId("floating-label-d1")).toHaveCount(0);
+  });
+
+  test("captures a screenshot of the default scenario showing the floating label layer", async ({
+    page,
+  }) => {
+    await page.goto("/test/analog-clock?scenario=default&hour=10&min=10");
+    await expect(page.getByTestId("analog-clock")).toBeVisible();
+    await expect(page.getByTestId("floating-label-d3")).toBeVisible();
+    await page.screenshot({
+      path: "test-results/screenshots/clock-floating-labels-default.png",
+      fullPage: true,
+    });
+  });
+});

--- a/src/components/calendar/analog-clock/__tests__/analog-clock.test.tsx
+++ b/src/components/calendar/analog-clock/__tests__/analog-clock.test.tsx
@@ -223,6 +223,148 @@ describe("AnalogClock", () => {
     expect(svg.getAttribute("role")).toBe("img");
   });
 
+  describe("floating off-arc title labels (#311)", () => {
+    /**
+     * Build a 30°-arc event whose cleanTitle is long enough to overflow even
+     * the 2-line wrap from #310. With size=600 and arcThickness=48, the
+     * resulting char budget per line on a 30° arc is small enough that
+     * "the quick brown fox jumps over the lazy dog" (43 chars) overflows.
+     */
+    const overflowEvent: ClockEvent = {
+      id: "evt-overflow",
+      title: "the quick brown fox jumps over the lazy dog",
+      cleanTitle: "the quick brown fox jumps over the lazy dog",
+      startAngle: 90,
+      endAngle: 120,
+      color: "#22C55E",
+      eventEmoji: "🎮",
+      isAllDay: false,
+    };
+
+    const shortEvent: ClockEvent = {
+      id: "evt-short",
+      title: "Lunch",
+      cleanTitle: "Lunch",
+      startAngle: 200,
+      endAngle: 220,
+      color: "#3B82F6",
+      isAllDay: false,
+    };
+
+    it("renders a FloatingLabel for events whose title overflows the arc budget", () => {
+      render(
+        <AnalogClock
+          events={[overflowEvent]}
+          currentTime={new Date(2026, 3, 12, 10, 10, 0)}
+        />
+      );
+      expect(
+        screen.getByTestId("floating-label-evt-overflow")
+      ).toBeInTheDocument();
+      const text = screen.getByTestId("floating-label-text-evt-overflow");
+      expect(text.textContent).toBe(overflowEvent.cleanTitle);
+    });
+
+    it("does not render an in-arc title <g> for an overflowing event", () => {
+      render(
+        <AnalogClock
+          events={[overflowEvent]}
+          currentTime={new Date(2026, 3, 12, 10, 10, 0)}
+        />
+      );
+      expect(
+        screen.queryByTestId("event-title-evt-overflow")
+      ).not.toBeInTheDocument();
+    });
+
+    it("still renders the leading event emoji on the overflowing arc", () => {
+      render(
+        <AnalogClock
+          events={[overflowEvent]}
+          currentTime={new Date(2026, 3, 12, 10, 10, 0)}
+        />
+      );
+      expect(
+        screen.getByTestId("event-emoji-evt-overflow")
+      ).toBeInTheDocument();
+    });
+
+    it("does NOT render a FloatingLabel for events whose title fits in-arc", () => {
+      render(
+        <AnalogClock
+          events={[shortEvent]}
+          currentTime={new Date(2026, 3, 12, 10, 10, 0)}
+        />
+      );
+      expect(
+        screen.queryByTestId("floating-label-evt-short")
+      ).not.toBeInTheDocument();
+      // ...and the in-arc title is still rendered.
+      expect(screen.getByTestId("event-title-evt-short")).toBeInTheDocument();
+    });
+
+    it("renders FloatingLabel for an overflowing event even when it has no leading emoji", () => {
+      const noEmojiOverflow: ClockEvent = {
+        ...overflowEvent,
+        id: "evt-noemoji",
+        eventEmoji: undefined,
+      };
+      render(
+        <AnalogClock
+          events={[noEmojiOverflow]}
+          currentTime={new Date(2026, 3, 12, 10, 10, 0)}
+        />
+      );
+      expect(
+        screen.getByTestId("floating-label-evt-noemoji")
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByTestId("event-emoji-evt-noemoji")
+      ).not.toBeInTheDocument();
+    });
+
+    it("renders the FloatingLabel layer in a sibling <g data-testid='floating-labels-layer'>", () => {
+      render(
+        <AnalogClock
+          events={[overflowEvent]}
+          currentTime={new Date(2026, 3, 12, 10, 10, 0)}
+        />
+      );
+      const layer = screen.getByTestId("floating-labels-layer");
+      expect(layer).toBeInTheDocument();
+      // The label group must be a descendant of the dedicated layer.
+      expect(
+        layer.querySelector('[data-testid="floating-label-evt-overflow"]')
+      ).not.toBeNull();
+    });
+
+    it("forwards onEventClick to FloatingLabel — clicking the label fires the same callback", () => {
+      const onEventClick = vi.fn();
+      render(
+        <AnalogClock
+          events={[overflowEvent]}
+          currentTime={new Date(2026, 3, 12, 10, 10, 0)}
+          onEventClick={onEventClick}
+        />
+      );
+      const label = screen.getByTestId("floating-label-evt-overflow");
+      fireEvent.click(label);
+      expect(onEventClick).toHaveBeenCalledTimes(1);
+      expect(onEventClick).toHaveBeenCalledWith("evt-overflow", label);
+    });
+
+    it("renders the SVG with overflow='visible' so labels can paint outside the clock-face viewBox", () => {
+      render(
+        <AnalogClock
+          events={[overflowEvent]}
+          currentTime={new Date(2026, 3, 12, 10, 10, 0)}
+        />
+      );
+      const svg = screen.getByTestId("analog-clock");
+      expect(svg.getAttribute("overflow")).toBe("visible");
+    });
+  });
+
   it("handles overlapping events by stacking at different radii", () => {
     const overlapping: ClockEvent[] = [
       {

--- a/src/components/calendar/analog-clock/__tests__/analog-clock.test.tsx
+++ b/src/components/calendar/analog-clock/__tests__/analog-clock.test.tsx
@@ -289,6 +289,30 @@ describe("AnalogClock", () => {
       ).toBeInTheDocument();
     });
 
+    it("does NOT render a FloatingLabel for sub-10° arcs even when didOverflow=true", () => {
+      // A 5° arc is below the emoji-visibility threshold; per spec the
+      // floating-label trigger requires the arc to be wide enough to render
+      // visibly. fitTitleToArc reports didOverflow=true (budget collapses
+      // to ~0–2 chars) but no floating label should appear.
+      const slivers: ClockEvent[] = [
+        {
+          ...overflowEvent,
+          id: "evt-sliver",
+          startAngle: 90,
+          endAngle: 95, // 5° span
+        },
+      ];
+      render(
+        <AnalogClock
+          events={slivers}
+          currentTime={new Date(2026, 3, 12, 10, 10, 0)}
+        />
+      );
+      expect(
+        screen.queryByTestId("floating-label-evt-sliver")
+      ).not.toBeInTheDocument();
+    });
+
     it("does NOT render a FloatingLabel for events whose title fits in-arc", () => {
       render(
         <AnalogClock

--- a/src/components/calendar/analog-clock/__tests__/arc-title-layout.test.ts
+++ b/src/components/calendar/analog-clock/__tests__/arc-title-layout.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+import {
+  TITLE_FONT_SIZE_MAX,
+  TITLE_FONT_SIZE_RATIO,
+  TITLE_RADIUS_RATIO,
+  TWO_LINE_MIN_SPAN_DEGREES,
+  computeArcTitleLayout,
+} from "../arc-title-layout";
+
+const baseInput = {
+  cleanTitle: "Family Game Night",
+  innerRadius: 244,
+  outerRadius: 292,
+};
+
+describe("computeArcTitleLayout", () => {
+  describe("maxLines branching", () => {
+    it("returns maxLines=2 at exactly TWO_LINE_MIN_SPAN_DEGREES", () => {
+      const r = computeArcTitleLayout({
+        ...baseInput,
+        arcSpan: TWO_LINE_MIN_SPAN_DEGREES,
+      });
+      expect(r.maxLines).toBe(2);
+    });
+
+    it("returns maxLines=2 above TWO_LINE_MIN_SPAN_DEGREES", () => {
+      const r = computeArcTitleLayout({
+        ...baseInput,
+        arcSpan: TWO_LINE_MIN_SPAN_DEGREES + 15,
+      });
+      expect(r.maxLines).toBe(2);
+    });
+
+    it("returns maxLines=1 below TWO_LINE_MIN_SPAN_DEGREES", () => {
+      const r = computeArcTitleLayout({
+        ...baseInput,
+        arcSpan: TWO_LINE_MIN_SPAN_DEGREES - 1,
+      });
+      expect(r.maxLines).toBe(1);
+    });
+  });
+
+  describe("titleRadius geometry", () => {
+    it("places the title baseline at innerRadius + arcHeight × TITLE_RADIUS_RATIO", () => {
+      const r = computeArcTitleLayout({ ...baseInput, arcSpan: 60 });
+      const arcHeight = baseInput.outerRadius - baseInput.innerRadius;
+      expect(r.titleRadius).toBe(
+        baseInput.innerRadius + arcHeight * TITLE_RADIUS_RATIO
+      );
+    });
+
+    it("scales titleRadius linearly with the arc band thickness", () => {
+      const thin = computeArcTitleLayout({
+        cleanTitle: "x",
+        innerRadius: 200,
+        outerRadius: 220,
+        arcSpan: 60,
+      });
+      const thick = computeArcTitleLayout({
+        cleanTitle: "x",
+        innerRadius: 200,
+        outerRadius: 280,
+        arcSpan: 60,
+      });
+      expect(thin.titleRadius).toBe(200 + 20 * TITLE_RADIUS_RATIO);
+      expect(thick.titleRadius).toBe(200 + 80 * TITLE_RADIUS_RATIO);
+    });
+  });
+
+  describe("titleFontSize cap", () => {
+    it("scales titleFontSize with arc height by TITLE_FONT_SIZE_RATIO", () => {
+      const r = computeArcTitleLayout({
+        ...baseInput,
+        arcSpan: 60,
+      });
+      const arcHeight = baseInput.outerRadius - baseInput.innerRadius;
+      expect(r.titleFontSize).toBeLessThanOrEqual(TITLE_FONT_SIZE_MAX);
+      expect(r.titleFontSize).toBeCloseTo(arcHeight * TITLE_FONT_SIZE_RATIO, 4);
+    });
+
+    it("caps titleFontSize at TITLE_FONT_SIZE_MAX on very thick arcs", () => {
+      const r = computeArcTitleLayout({
+        cleanTitle: "x",
+        innerRadius: 100,
+        outerRadius: 600, // arcHeight=500, ratio=0.3 → 150 unclamped
+        arcSpan: 60,
+      });
+      expect(r.titleFontSize).toBe(TITLE_FONT_SIZE_MAX);
+    });
+  });
+
+  describe("fit / didOverflow signal", () => {
+    it("reports didOverflow=false for a title that fits the arc budget", () => {
+      const r = computeArcTitleLayout({
+        cleanTitle: "Lunch",
+        innerRadius: 244,
+        outerRadius: 292,
+        arcSpan: 60,
+      });
+      expect(r.fit.didOverflow).toBe(false);
+    });
+
+    it("reports didOverflow=true for a title that exceeds even the 2-line budget", () => {
+      const r = computeArcTitleLayout({
+        cleanTitle: "the quick brown fox jumps over the lazy dog",
+        innerRadius: 244,
+        outerRadius: 292,
+        arcSpan: 30, // 2-line budget is small here
+      });
+      expect(r.fit.didOverflow).toBe(true);
+    });
+
+    it("reports didOverflow=true for a long single-line arc that cannot fit on 1 line", () => {
+      const r = computeArcTitleLayout({
+        cleanTitle: "Team Standup",
+        innerRadius: 244,
+        outerRadius: 292,
+        arcSpan: 15, // < TWO_LINE_MIN_SPAN_DEGREES → maxLines=1
+      });
+      expect(r.maxLines).toBe(1);
+      expect(r.fit.didOverflow).toBe(true);
+    });
+
+    it("returns the same FitTitleResult shape regardless of arcSpan", () => {
+      const r = computeArcTitleLayout({ ...baseInput, arcSpan: 60 });
+      expect(r.fit).toMatchObject({
+        lines: expect.any(Array),
+        didOverflow: expect.any(Boolean),
+      });
+    });
+  });
+
+  describe("shared-source-of-truth invariant", () => {
+    /**
+     * AnalogClock uses `fit.didOverflow` to decide whether to render a
+     * sibling FloatingLabel; EventArc consumes the same `fit` to decide
+     * whether to render in-arc title lines. Calling the helper twice with
+     * the same inputs MUST produce strictly identical results so the two
+     * surfaces never disagree.
+     */
+    it("is deterministic — two calls with identical inputs produce identical output", () => {
+      const a = computeArcTitleLayout({ ...baseInput, arcSpan: 45 });
+      const b = computeArcTitleLayout({ ...baseInput, arcSpan: 45 });
+      expect(a.titleRadius).toBe(b.titleRadius);
+      expect(a.titleFontSize).toBe(b.titleFontSize);
+      expect(a.maxLines).toBe(b.maxLines);
+      expect(a.fit.lines).toEqual(b.fit.lines);
+      expect(a.fit.didOverflow).toBe(b.fit.didOverflow);
+    });
+  });
+});

--- a/src/components/calendar/analog-clock/__tests__/clamp-label.test.ts
+++ b/src/components/calendar/analog-clock/__tests__/clamp-label.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { clampLabelPosition } from "../clamp-label";
+
+const clockBox = {
+  top: 100,
+  bottom: 700,
+  height: 600,
+};
+
+describe("clampLabelPosition", () => {
+  it("returns the input unchanged when y is inside the allowed band", () => {
+    const result = clampLabelPosition({ x: 250, y: 400 }, clockBox);
+    expect(result).toEqual({ x: 250, y: 400 });
+  });
+
+  it("preserves x exactly when no clamp is needed", () => {
+    const result = clampLabelPosition({ x: 123.456, y: 400 }, clockBox);
+    expect(result.x).toBe(123.456);
+  });
+
+  it("preserves x exactly when y is clamped at the top", () => {
+    const result = clampLabelPosition({ x: 123.456, y: -1000 }, clockBox);
+    expect(result.x).toBe(123.456);
+  });
+
+  it("preserves x exactly when y is clamped at the bottom", () => {
+    const result = clampLabelPosition({ x: 123.456, y: 99999 }, clockBox);
+    expect(result.x).toBe(123.456);
+  });
+
+  it("clamps y to clockTop - 0.10 × clockHeight when label is far above", () => {
+    // top=100, height=600 → upper limit = 100 - 60 = 40
+    const result = clampLabelPosition({ x: 250, y: -500 }, clockBox);
+    expect(result.y).toBe(40);
+  });
+
+  it("clamps y to the upper limit when ideal y is just above the limit", () => {
+    // upper limit = 40; pass y=39 → clamp to 40
+    const result = clampLabelPosition({ x: 250, y: 39 }, clockBox);
+    expect(result.y).toBe(40);
+  });
+
+  it("clamps y to clockBottom + 0.10 × clockHeight when label is far below", () => {
+    // bottom=700, height=600 → lower limit = 700 + 60 = 760
+    const result = clampLabelPosition({ x: 250, y: 9999 }, clockBox);
+    expect(result.y).toBe(760);
+  });
+
+  it("clamps y to the lower limit when ideal y is just below the limit", () => {
+    // lower limit = 760; pass y=761 → clamp to 760
+    const result = clampLabelPosition({ x: 250, y: 761 }, clockBox);
+    expect(result.y).toBe(760);
+  });
+
+  it("does not clamp y exactly at the upper limit", () => {
+    const result = clampLabelPosition({ x: 250, y: 40 }, clockBox);
+    expect(result.y).toBe(40);
+  });
+
+  it("does not clamp y exactly at the lower limit", () => {
+    const result = clampLabelPosition({ x: 250, y: 760 }, clockBox);
+    expect(result.y).toBe(760);
+  });
+
+  it("uses the provided height (not bottom - top) for the 10% allowance", () => {
+    // Provide a non-physical clockBox where height differs from bottom-top to
+    // confirm the allowance is computed from the explicit `height` field.
+    const oddBox = { top: 100, bottom: 700, height: 1000 };
+    // Allowance is 100; upper limit = 100 - 100 = 0; lower limit = 700 + 100 = 800
+    expect(clampLabelPosition({ x: 0, y: -50 }, oddBox).y).toBe(0);
+    expect(clampLabelPosition({ x: 0, y: 900 }, oddBox).y).toBe(800);
+  });
+});

--- a/src/components/calendar/analog-clock/__tests__/event-arc.test.tsx
+++ b/src/components/calendar/analog-clock/__tests__/event-arc.test.tsx
@@ -170,6 +170,28 @@ describe("EventArc", () => {
     expect(group.getAttribute("aria-label")).toBe("Event: Family Game Night");
   });
 
+  describe("forceHideTitle", () => {
+    it("does not render the title <g> when true (overflow path delegates to FloatingLabel)", () => {
+      renderArc({ forceHideTitle: true });
+      expect(screen.queryByTestId("event-title-evt-1")).not.toBeInTheDocument();
+    });
+
+    it("still renders the leading event emoji on the arc when true", () => {
+      renderArc({ forceHideTitle: true });
+      expect(screen.getByTestId("event-emoji-evt-1")).toBeInTheDocument();
+    });
+
+    it("still renders the colored arc background when true", () => {
+      renderArc({ forceHideTitle: true });
+      expect(screen.getByTestId("event-arc-evt-1")).toBeInTheDocument();
+    });
+
+    it("renders the title normally when false (default)", () => {
+      renderArc({ forceHideTitle: false });
+      expect(screen.getByTestId("event-title-evt-1")).toBeInTheDocument();
+    });
+  });
+
   it("renders different colored arcs for different events", () => {
     const redEvent: ClockEvent = {
       ...baseEvent,

--- a/src/components/calendar/analog-clock/__tests__/floating-label.test.tsx
+++ b/src/components/calendar/analog-clock/__tests__/floating-label.test.tsx
@@ -1,0 +1,226 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { ClockBox } from "../clamp-label";
+import { FloatingLabel, type FloatingLabelProps } from "../floating-label";
+
+const baseProps: FloatingLabelProps = {
+  id: "evt-1",
+  text: "the quick brown fox jumps",
+  anchorAngle: 45, // top-right quadrant (0° = 12 o'clock, clockwise)
+  anchorRadius: 240,
+  labelRadius: 270,
+  color: "#22C55E",
+  cx: 250,
+  cy: 250,
+  clockBox: { top: 50, bottom: 450, height: 400 } satisfies ClockBox,
+};
+
+function renderLabel(overrides: Partial<FloatingLabelProps> = {}) {
+  return render(
+    <svg viewBox="0 0 500 500">
+      <FloatingLabel {...baseProps} {...overrides} />
+    </svg>
+  );
+}
+
+function num(el: Element, attr: string): number {
+  const v = el.getAttribute(attr);
+  if (v === null) throw new Error(`missing attribute ${attr}`);
+  return Number.parseFloat(v);
+}
+
+describe("FloatingLabel", () => {
+  it("renders the connector line, background rect, and label text", () => {
+    renderLabel();
+    expect(screen.getByTestId("floating-label-evt-1")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("floating-label-connector-evt-1")
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("floating-label-rect-evt-1")).toBeInTheDocument();
+    const text = screen.getByTestId("floating-label-text-evt-1");
+    expect(text).toBeInTheDocument();
+    expect(text.textContent).toBe(baseProps.text);
+  });
+
+  it("uses the event color for the connector stroke at low opacity", () => {
+    renderLabel();
+    const connector = screen.getByTestId("floating-label-connector-evt-1");
+    expect(connector.getAttribute("stroke")).toBe(baseProps.color);
+    const opacity = Number.parseFloat(
+      connector.getAttribute("stroke-opacity") ?? "1"
+    );
+    expect(opacity).toBeGreaterThan(0);
+    expect(opacity).toBeLessThan(1);
+  });
+
+  it("anchors the connector start at the arc midpoint outer radius", () => {
+    // anchor at angle=45, radius=240, center=(250,250)
+    // x = 250 + 240*cos((45-90)*PI/180) = 250 + 240*cos(-45°) ≈ 419.71
+    // y = 250 + 240*sin(-45°) ≈ 80.29
+    renderLabel();
+    const connector = screen.getByTestId("floating-label-connector-evt-1");
+    const x1 = num(connector, "x1");
+    const y1 = num(connector, "y1");
+    expect(x1).toBeCloseTo(419.7, 0);
+    expect(y1).toBeCloseTo(80.3, 0);
+  });
+
+  it("places the rect centered on the (clamped) label position on the outer circle", () => {
+    renderLabel();
+    const rect = screen.getByTestId("floating-label-rect-evt-1");
+    const x = num(rect, "x");
+    const y = num(rect, "y");
+    const w = num(rect, "width");
+    const h = num(rect, "height");
+    const centerX = x + w / 2;
+    const centerY = y + h / 2;
+    // ideal label center at angle=45, labelRadius=270 → (440.92, 59.08)
+    // clockBox top=50, height=400 → upper limit = 50 - 40 = 10
+    // Since 59.08 > 10, no clamp; centerY ≈ 59.08
+    expect(centerX).toBeCloseTo(440.9, 0);
+    expect(centerY).toBeCloseTo(59.1, 0);
+  });
+
+  it("clamps the label vertical position when ideal position would exceed the top band", () => {
+    // anchorAngle=0 (12 o'clock), labelRadius=270 → ideal label center y = cy-270 = -20
+    // clockBox top=50, height=400 → upper limit = 50 - 40 = 10. So clamp to y=10.
+    renderLabel({ anchorAngle: 0 });
+    const rect = screen.getByTestId("floating-label-rect-evt-1");
+    const y = num(rect, "y");
+    const h = num(rect, "height");
+    expect(y + h / 2).toBeCloseTo(10, 1);
+  });
+
+  it("clamps the label vertical position when ideal position would exceed the bottom band", () => {
+    // anchorAngle=180 (6 o'clock), labelRadius=270 → ideal label center y = cy+270 = 520
+    // clockBox bottom=450, height=400 → lower limit = 450 + 40 = 490. So clamp to y=490.
+    renderLabel({ anchorAngle: 180 });
+    const rect = screen.getByTestId("floating-label-rect-evt-1");
+    const y = num(rect, "y");
+    const h = num(rect, "height");
+    expect(y + h / 2).toBeCloseTo(490, 1);
+  });
+
+  /**
+   * For each quadrant, assert that the connector's far endpoint sits on the
+   * rect's boundary (not inside, not outside) and on the side of the rect
+   * facing the anchor — i.e. between the rect centre and the anchor along
+   * each axis. This is the geometric invariant the spec actually cares about,
+   * agnostic to whether a wide-but-flat label exits through a side or top/
+   * bottom edge.
+   */
+  function assertConnectorEndsOnRectBoundaryFacingAnchor(): void {
+    const connector = screen.getByTestId("floating-label-connector-evt-1");
+    const rect = screen.getByTestId("floating-label-rect-evt-1");
+    const x1 = num(connector, "x1");
+    const y1 = num(connector, "y1");
+    const x2 = num(connector, "x2");
+    const y2 = num(connector, "y2");
+    const rx = num(rect, "x");
+    const ry = num(rect, "y");
+    const rw = num(rect, "width");
+    const rh = num(rect, "height");
+    const cxRect = rx + rw / 2;
+    const cyRect = ry + rh / 2;
+
+    // Endpoint is inside the rect (inclusive) — not floating in the air past it.
+    expect(x2).toBeGreaterThanOrEqual(rx - 0.01);
+    expect(x2).toBeLessThanOrEqual(rx + rw + 0.01);
+    expect(y2).toBeGreaterThanOrEqual(ry - 0.01);
+    expect(y2).toBeLessThanOrEqual(ry + rh + 0.01);
+
+    // Endpoint sits on the rect boundary — at least one coordinate hits an edge.
+    const onLeft = Math.abs(x2 - rx) < 0.5;
+    const onRight = Math.abs(x2 - (rx + rw)) < 0.5;
+    const onTop = Math.abs(y2 - ry) < 0.5;
+    const onBottom = Math.abs(y2 - (ry + rh)) < 0.5;
+    expect(onLeft || onRight || onTop || onBottom).toBe(true);
+
+    // Endpoint is between the rect centre and the anchor — i.e. the connector
+    // exits on the side facing the anchor, not the far side.
+    if (Math.abs(x1 - cxRect) > 0.5) {
+      expect(Math.sign(x2 - cxRect)).toBe(Math.sign(x1 - cxRect));
+    }
+    if (Math.abs(y1 - cyRect) > 0.5) {
+      expect(Math.sign(y2 - cyRect)).toBe(Math.sign(y1 - cyRect));
+    }
+  }
+
+  it("connector terminates on the rect boundary facing the anchor — top-right quadrant", () => {
+    renderLabel({ anchorAngle: 45 });
+    assertConnectorEndsOnRectBoundaryFacingAnchor();
+  });
+
+  it("connector terminates on the rect boundary facing the anchor — top-left quadrant", () => {
+    renderLabel({ anchorAngle: 315 });
+    assertConnectorEndsOnRectBoundaryFacingAnchor();
+  });
+
+  it("connector terminates on the rect boundary facing the anchor — bottom-right quadrant", () => {
+    renderLabel({ anchorAngle: 135 });
+    assertConnectorEndsOnRectBoundaryFacingAnchor();
+  });
+
+  it("connector terminates on the rect boundary facing the anchor — bottom-left quadrant", () => {
+    renderLabel({ anchorAngle: 225 });
+    assertConnectorEndsOnRectBoundaryFacingAnchor();
+  });
+
+  it("uses the event color for the rect border at low opacity, with a non-coloured fill", () => {
+    renderLabel();
+    const rect = screen.getByTestId("floating-label-rect-evt-1");
+    expect(rect.getAttribute("stroke")).toBe(baseProps.color);
+    expect(rect.getAttribute("fill")).not.toBe(baseProps.color);
+  });
+
+  it("renders as a non-interactive group when no onClick is provided", () => {
+    renderLabel();
+    const group = screen.getByTestId("floating-label-evt-1");
+    expect(group.getAttribute("role")).not.toBe("button");
+    expect(group.getAttribute("tabindex")).toBeNull();
+  });
+
+  describe("when onClick is provided", () => {
+    it("renders as role='button' with tabIndex=0", () => {
+      const onClick = vi.fn();
+      renderLabel({ onClick });
+      const group = screen.getByTestId("floating-label-evt-1");
+      expect(group.getAttribute("role")).toBe("button");
+      expect(group.getAttribute("tabindex")).toBe("0");
+    });
+
+    it("invokes onClick with the event id and the <g> element on click", () => {
+      const onClick = vi.fn();
+      renderLabel({ onClick });
+      const group = screen.getByTestId("floating-label-evt-1");
+      fireEvent.click(group);
+      expect(onClick).toHaveBeenCalledTimes(1);
+      expect(onClick).toHaveBeenCalledWith("evt-1", group);
+    });
+
+    it("invokes onClick on Enter and Space keypresses", () => {
+      const onClick = vi.fn();
+      renderLabel({ onClick });
+      const group = screen.getByTestId("floating-label-evt-1");
+      fireEvent.keyDown(group, { key: "Enter" });
+      fireEvent.keyDown(group, { key: " " });
+      expect(onClick).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not invoke onClick on other keys", () => {
+      const onClick = vi.fn();
+      renderLabel({ onClick });
+      const group = screen.getByTestId("floating-label-evt-1");
+      fireEvent.keyDown(group, { key: "Tab" });
+      fireEvent.keyDown(group, { key: "Escape" });
+      expect(onClick).not.toHaveBeenCalled();
+    });
+
+    it("exposes an aria-label that includes the label text", () => {
+      const onClick = vi.fn();
+      renderLabel({ onClick });
+      const group = screen.getByTestId("floating-label-evt-1");
+      expect(group.getAttribute("aria-label")).toContain(baseProps.text);
+    });
+  });
+});

--- a/src/components/calendar/analog-clock/analog-clock.tsx
+++ b/src/components/calendar/analog-clock/analog-clock.tsx
@@ -10,6 +10,7 @@
  * Overlapping events are stacked at different radii (inner rings).
  */
 import { useEffect, useState } from "react";
+import { computeArcTitleLayout } from "./arc-title-layout";
 import { ClockFace } from "./clock-face";
 import {
   eventsToClockEvents,
@@ -17,6 +18,7 @@ import {
   getPeriodBounds,
 } from "./clock-utils";
 import { EventArc } from "./event-arc";
+import { FloatingLabel } from "./floating-label";
 import type { AnalogClockProps, ClockEvent } from "./types";
 
 /** Default clock diameter in pixels */
@@ -115,6 +117,46 @@ export function AnalogClock({
   const ringGap = ringCount > 1 ? Math.max(2, arcThickness * 0.06) : 0;
   const ringThickness = (arcThickness - (ringCount - 1) * ringGap) / ringCount;
 
+  // Per-event layout so we can decide which titles overflow the in-arc
+  // budget and need to render as floating labels (#311). Computed once and
+  // shared between EventArc and FloatingLabel — see arc-title-layout.ts.
+  const eventLayouts = resolvedEvents.map((event) => {
+    const ringIndex = ringIndices.get(event.id) ?? 0;
+    const ringOuterRadius = outerRadius - ringIndex * (ringThickness + ringGap);
+    const ringInnerRadius = Math.max(
+      ringOuterRadius - ringThickness,
+      clockRadius
+    );
+    const arcSpan = event.endAngle - event.startAngle;
+    const layout = computeArcTitleLayout({
+      cleanTitle: event.cleanTitle,
+      arcSpan,
+      innerRadius: ringInnerRadius,
+      outerRadius: ringOuterRadius,
+    });
+    return {
+      event,
+      ringIndex,
+      ringOuterRadius,
+      ringInnerRadius,
+      layout,
+    };
+  });
+
+  // Floating-label geometry shared by every overflowing event:
+  // - labelRadius sits slightly beyond the outermost arc ring.
+  // - clockBox spans the SVG y-extents of the clock face plus arc band; the
+  //   vertical clamp keeps every label inside [top - 0.10×h, bottom + 0.10×h]
+  //   so overflowing events do not grow the AnalogClockView grid row height.
+  const labelRadius = outerRadius + arcThickness * 0.6;
+  const clockTop = cy - outerRadius;
+  const clockBottom = cy + outerRadius;
+  const clockBox = {
+    top: clockTop,
+    bottom: clockBottom,
+    height: clockBottom - clockTop,
+  };
+
   // When the clock is interactive (onEventClick provided), the inner arcs are
   // role="button" descendants. role="img" on the parent <svg> would tell AT to
   // treat the whole SVG as a single opaque graphic, hiding those buttons from
@@ -129,28 +171,55 @@ export function AnalogClock({
       role={onEventClick ? "group" : "img"}
       aria-label={`Analog clock showing ${time.toLocaleTimeString()} with ${resolvedEvents.length} events`}
       className="select-none"
+      // Floating off-arc labels (#311) sit beyond the SVG viewBox; the
+      // `overflow` SVG attribute lets them paint outside the nominal box.
+      overflow="visible"
     >
       {/* Event arcs layer (behind clock face numbers but in front of background) */}
       <g data-testid="event-arcs-layer">
-        {resolvedEvents.map((event) => {
-          const ringIndex = ringIndices.get(event.id) ?? 0;
-          const ringOuterRadius =
-            outerRadius - ringIndex * (ringThickness + ringGap);
-          const ringInnerRadius = ringOuterRadius - ringThickness;
-
-          return (
+        {eventLayouts.map(
+          ({ event, ringIndex, ringOuterRadius, ringInnerRadius, layout }) => (
             <EventArc
               key={event.id}
               event={event}
               outerRadius={ringOuterRadius}
-              innerRadius={Math.max(ringInnerRadius, clockRadius)}
+              innerRadius={ringInnerRadius}
               cx={cx}
               cy={cy}
               ringIndex={ringIndex}
               onEventClick={onEventClick}
+              forceHideTitle={layout.fit.didOverflow}
             />
-          );
-        })}
+          )
+        )}
+      </g>
+
+      {/* Floating off-arc title labels for overflowing events (#311). Painted
+          above the arcs but below the clock face so the hands draw over any
+          label that bleeds toward the centre. */}
+      <g data-testid="floating-labels-layer">
+        {eventLayouts
+          .filter(({ layout }) => layout.fit.didOverflow)
+          .sort((a, b) => a.event.startAngle - b.event.startAngle)
+          .map(({ event, ringOuterRadius, layout }) => {
+            const midAngle = (event.startAngle + event.endAngle) / 2;
+            return (
+              <FloatingLabel
+                key={event.id}
+                id={event.id}
+                text={event.cleanTitle}
+                anchorAngle={midAngle}
+                anchorRadius={ringOuterRadius}
+                labelRadius={labelRadius}
+                color={event.color}
+                cx={cx}
+                cy={cy}
+                clockBox={clockBox}
+                fontSize={layout.titleFontSize}
+                onClick={onEventClick}
+              />
+            );
+          })}
       </g>
 
       {/* Clock face with hands (rendered on top) */}

--- a/src/components/calendar/analog-clock/analog-clock.tsx
+++ b/src/components/calendar/analog-clock/analog-clock.tsx
@@ -28,6 +28,14 @@ const DEFAULT_SIZE = 600;
 const DEFAULT_ARC_THICKNESS = 48;
 
 /**
+ * Arc-span threshold (degrees) at which an arc is wide enough to render its
+ * leading event emoji. Mirrors the `showEmoji` gate inside `EventArc`. The
+ * floating-label feature (#311) uses the same threshold so labels never
+ * point at arc slivers too narrow to display anything.
+ */
+const EMOJI_MIN_SPAN_DEGREES = 10;
+
+/**
  * Detect overlapping events and assign ring indices.
  * Events that overlap in angle range get pushed to inner rings.
  */
@@ -134,12 +142,20 @@ export function AnalogClock({
       innerRadius: ringInnerRadius,
       outerRadius: ringOuterRadius,
     });
+    // Per spec: floating-label trigger is `didOverflow=true` AND the arc
+    // is wide enough to render visibly (the same emoji-visibility threshold
+    // EventArc applies). Sub-10° arcs render no emoji and no in-arc title;
+    // a floating label there would point at a near-invisible sliver.
+    const isOverflow =
+      layout.fit.didOverflow && arcSpan >= EMOJI_MIN_SPAN_DEGREES;
     return {
       event,
       ringIndex,
       ringOuterRadius,
       ringInnerRadius,
+      arcSpan,
       layout,
+      isOverflow,
     };
   });
 
@@ -178,7 +194,14 @@ export function AnalogClock({
       {/* Event arcs layer (behind clock face numbers but in front of background) */}
       <g data-testid="event-arcs-layer">
         {eventLayouts.map(
-          ({ event, ringIndex, ringOuterRadius, ringInnerRadius, layout }) => (
+          ({
+            event,
+            ringIndex,
+            ringOuterRadius,
+            ringInnerRadius,
+            layout,
+            isOverflow,
+          }) => (
             <EventArc
               key={event.id}
               event={event}
@@ -188,7 +211,8 @@ export function AnalogClock({
               cy={cy}
               ringIndex={ringIndex}
               onEventClick={onEventClick}
-              forceHideTitle={layout.fit.didOverflow}
+              forceHideTitle={isOverflow}
+              precomputedLayout={layout}
             />
           )
         )}
@@ -199,7 +223,7 @@ export function AnalogClock({
           label that bleeds toward the centre. */}
       <g data-testid="floating-labels-layer">
         {eventLayouts
-          .filter(({ layout }) => layout.fit.didOverflow)
+          .filter(({ isOverflow }) => isOverflow)
           .sort((a, b) => a.event.startAngle - b.event.startAngle)
           .map(({ event, ringOuterRadius, layout }) => {
             const midAngle = (event.startAngle + event.endAngle) / 2;

--- a/src/components/calendar/analog-clock/arc-title-layout.ts
+++ b/src/components/calendar/analog-clock/arc-title-layout.ts
@@ -1,0 +1,58 @@
+/**
+ * Shared layout helper for an event arc's title — keeps EventArc (which
+ * renders the in-arc text) and AnalogClock (which decides when to render a
+ * sibling FloatingLabel for overflows, #311) agreeing on `didOverflow`.
+ *
+ * If these two surfaces ever disagreed, the floating label could render for
+ * an event whose in-arc text actually fit (or fail to render for one that
+ * was truncated), which would manifest as a missing title or a duplicate
+ * title in the production view.
+ */
+import { roundCoord } from "./clock-utils";
+import { type FitTitleResult, fitTitleToArc } from "./fit-title";
+
+/** Minimum arc span (degrees) below which the 2-line wrap is suppressed. */
+export const TWO_LINE_MIN_SPAN_DEGREES = 30;
+
+/** Title baseline sits at this fraction of the arc band, measured from the inner radius. */
+export const TITLE_RADIUS_RATIO = 0.68;
+
+/** Title font size = arcHeight × this ratio (capped). */
+export const TITLE_FONT_SIZE_RATIO = 0.3;
+
+/** Upper bound on title font size, in px. */
+export const TITLE_FONT_SIZE_MAX = 18;
+
+export interface ArcTitleLayout {
+  /** Curved-text baseline radius. */
+  titleRadius: number;
+  /** Resolved title font size in px. */
+  titleFontSize: number;
+  /** Number of lines the title is allowed to occupy on this arc. */
+  maxLines: 1 | 2;
+  /** Result of the word-pack fit — drives both rendering and overflow detection. */
+  fit: FitTitleResult;
+}
+
+export function computeArcTitleLayout(params: {
+  cleanTitle: string;
+  arcSpan: number;
+  innerRadius: number;
+  outerRadius: number;
+}): ArcTitleLayout {
+  const { cleanTitle, arcSpan, innerRadius, outerRadius } = params;
+  const arcHeight = outerRadius - innerRadius;
+  const titleRadius = innerRadius + arcHeight * TITLE_RADIUS_RATIO;
+  const titleFontSize = roundCoord(
+    Math.min(arcHeight * TITLE_FONT_SIZE_RATIO, TITLE_FONT_SIZE_MAX)
+  );
+  const maxLines: 1 | 2 = arcSpan >= TWO_LINE_MIN_SPAN_DEGREES ? 2 : 1;
+  const fit = fitTitleToArc(
+    cleanTitle,
+    arcSpan,
+    titleRadius,
+    titleFontSize,
+    maxLines
+  );
+  return { titleRadius, titleFontSize, maxLines, fit };
+}

--- a/src/components/calendar/analog-clock/clamp-label.ts
+++ b/src/components/calendar/analog-clock/clamp-label.ts
@@ -1,0 +1,33 @@
+/**
+ * Pure helper for the floating off-arc label feature (#311).
+ *
+ * Clamps a label's vertical position so the AnalogClockView grid row height
+ * stays stable regardless of how many overflowing labels exist. The X
+ * coordinate is preserved — the label's angular position on the invisible
+ * outer circle is not adjusted to compensate for the clamp.
+ *
+ * Allowed band: `clockBox.top - 0.10 × clockBox.height` to
+ * `clockBox.bottom + 0.10 × clockBox.height` (inclusive at both ends).
+ */
+
+const VERTICAL_OVERFLOW_RATIO = 0.1;
+
+export interface ClockBox {
+  /** SVG y-coordinate of the top edge of the clock face (incl. arc band). */
+  top: number;
+  /** SVG y-coordinate of the bottom edge of the clock face (incl. arc band). */
+  bottom: number;
+  /** Total clock height used to compute the 10% allowance. */
+  height: number;
+}
+
+export function clampLabelPosition(
+  position: { x: number; y: number },
+  clockBox: ClockBox
+): { x: number; y: number } {
+  const allowance = clockBox.height * VERTICAL_OVERFLOW_RATIO;
+  const upperLimit = clockBox.top - allowance;
+  const lowerLimit = clockBox.bottom + allowance;
+  const clampedY = Math.min(Math.max(position.y, upperLimit), lowerLimit);
+  return { x: position.x, y: clampedY };
+}

--- a/src/components/calendar/analog-clock/event-arc.tsx
+++ b/src/components/calendar/analog-clock/event-arc.tsx
@@ -6,12 +6,9 @@
  * with emoji positioned at the midpoint of the arc.
  */
 import type { KeyboardEvent as ReactKeyboardEvent } from "react";
+import { computeArcTitleLayout } from "./arc-title-layout";
 import { describeArc, polarToCartesian, roundCoord } from "./clock-utils";
-import { fitTitleToArc } from "./fit-title";
 import type { EventArcProps } from "./types";
-
-/** Minimum arc span (degrees) below which 2-line wrap is suppressed. */
-const TWO_LINE_MIN_SPAN_DEGREES = 30;
 
 /**
  * Generate an SVG arc path for textPath (single arc, not a donut).
@@ -50,6 +47,7 @@ export function EventArc({
   cx,
   cy,
   onEventClick,
+  forceHideTitle = false,
 }: EventArcProps) {
   const { id, cleanTitle, color, eventEmoji, startAngle, endAngle } = event;
   const isInteractive = Boolean(onEventClick);
@@ -84,16 +82,15 @@ export function EventArc({
   const midAngle = (startAngle + endAngle) / 2;
   const arcHeight = outerRadius - innerRadius;
 
-  // Place emoji near the inner edge (closer to the clock face) and the
-  // title near the outer edge so they stack radially instead of overlaying.
+  // Place emoji near the inner edge (closer to the clock face); the title
+  // sits at the outer edge so they stack radially instead of overlaying.
   // For arcs on the bottom half of the clock, textPath direction is reversed
   // (so text reads right-side-up); this doesn't affect the radial split.
   const emojiRadius = innerRadius + arcHeight * 0.28;
-  const titleRadius = innerRadius + arcHeight * 0.68;
 
   // Whether we have enough room for different elements
   const showEmoji = arcSpan >= 10;
-  const showTitle = arcSpan >= 20;
+  const showTitle = !forceHideTitle && arcSpan >= 20;
 
   // Text positioning for emoji (centered on arc midpoint, on inner radius)
   const emojiPos = polarToCartesian(cx, cy, emojiRadius, midAngle);
@@ -102,20 +99,16 @@ export function EventArc({
 
   // Font sizing — arcs are now thicker so we can use more of the height
   const emojiFontSize = roundCoord(Math.min(arcHeight * 0.4, 26));
-  const titleFontSize = roundCoord(Math.min(arcHeight * 0.3, 18));
 
-  // Decide between a single curved line and two concentric curved lines based
-  // on the arc's available circumference at titleRadius. Below
-  // TWO_LINE_MIN_SPAN_DEGREES we keep the single-line truncation behavior so
-  // narrow arcs don't end up with 2-char-per-line stubs.
-  const maxLines: 1 | 2 = arcSpan >= TWO_LINE_MIN_SPAN_DEGREES ? 2 : 1;
-  const fit = fitTitleToArc(
+  // Title layout (radius, font size, 1- vs 2-line, fit) is shared with
+  // AnalogClock so the floating-label overflow path (#311) agrees on
+  // didOverflow without recomputing.
+  const { titleRadius, titleFontSize, fit } = computeArcTitleLayout({
     cleanTitle,
     arcSpan,
-    titleRadius,
-    titleFontSize,
-    maxLines
-  );
+    innerRadius,
+    outerRadius,
+  });
 
   // Per-line offset for the 2-line case (per #310 spec). Place the two
   // curved baselines at titleRadius ± lineOffset so their centre-to-centre

--- a/src/components/calendar/analog-clock/event-arc.tsx
+++ b/src/components/calendar/analog-clock/event-arc.tsx
@@ -48,6 +48,7 @@ export function EventArc({
   cy,
   onEventClick,
   forceHideTitle = false,
+  precomputedLayout,
 }: EventArcProps) {
   const { id, cleanTitle, color, eventEmoji, startAngle, endAngle } = event;
   const isInteractive = Boolean(onEventClick);
@@ -102,13 +103,17 @@ export function EventArc({
 
   // Title layout (radius, font size, 1- vs 2-line, fit) is shared with
   // AnalogClock so the floating-label overflow path (#311) agrees on
-  // didOverflow without recomputing.
-  const { titleRadius, titleFontSize, fit } = computeArcTitleLayout({
-    cleanTitle,
-    arcSpan,
-    innerRadius,
-    outerRadius,
-  });
+  // didOverflow without recomputing. When AnalogClock supplies its
+  // precomputed layout, use that verbatim — guarantees the two surfaces
+  // can never disagree even if inputs drift in a future refactor.
+  const { titleRadius, titleFontSize, fit } =
+    precomputedLayout ??
+    computeArcTitleLayout({
+      cleanTitle,
+      arcSpan,
+      innerRadius,
+      outerRadius,
+    });
 
   // Per-line offset for the 2-line case (per #310 spec). Place the two
   // curved baselines at titleRadius ± lineOffset so their centre-to-centre

--- a/src/components/calendar/analog-clock/floating-label.tsx
+++ b/src/components/calendar/analog-clock/floating-label.tsx
@@ -1,0 +1,175 @@
+/**
+ * FloatingLabel — renders an event title outside the clock face when the title
+ * is too long to fit inside its arc, with a thin connector line back to the
+ * arc midpoint. Used by the analog clock's overflow path (#311).
+ *
+ * Pure positioning — no React state. Vertical clamp delegated to
+ * `clampLabelPosition` so the AnalogClockView grid row height stays stable
+ * regardless of how many overflowing labels exist.
+ */
+import type { KeyboardEvent as ReactKeyboardEvent } from "react";
+import { type ClockBox, clampLabelPosition } from "./clamp-label";
+import { polarToCartesian, roundCoord } from "./clock-utils";
+
+const CHAR_WIDTH_RATIO = 0.6;
+const LINE_HEIGHT_RATIO = 1.4;
+const RECT_PADDING_X = 6;
+const RECT_PADDING_Y = 3;
+const CONNECTOR_OPACITY = 0.6;
+const CONNECTOR_STROKE_WIDTH = 1;
+const RECT_BORDER_OPACITY = 0.4;
+const RECT_CORNER_RADIUS = 3;
+const DEFAULT_FONT_SIZE = 14;
+
+export interface FloatingLabelProps {
+  /** Stable id (typically the calendar event id) used for testids and a11y. */
+  id: string;
+  /** Full text to render (typically `cleanTitle`). */
+  text: string;
+  /** Arc midpoint angle in degrees (0° = 12 o'clock, clockwise). */
+  anchorAngle: number;
+  /** Outer radius of the arc — connector line origin. */
+  anchorRadius: number;
+  /**
+   * Radius of the invisible outer circle on which the label centre sits
+   * (before vertical clamping).
+   */
+  labelRadius: number;
+  /** Event color — used for connector stroke and rect border. */
+  color: string;
+  /** Clock centre X. */
+  cx: number;
+  /** Clock centre Y. */
+  cy: number;
+  /** Clock face vertical extents — defines the vertical clamp band. */
+  clockBox: ClockBox;
+  /** Optional font size override. */
+  fontSize?: number;
+  /**
+   * Optional click handler. When provided, the group becomes focusable
+   * role="button" and fires on click and on Enter/Space, mirroring EventArc.
+   */
+  onClick?: (id: string, trigger: SVGGElement) => void;
+}
+
+/**
+ * Find the point on the boundary of an axis-aligned rectangle (centred at
+ * `center` with the given `width`/`height`) along the ray from `center`
+ * toward `toward`. Returns `center` if the two points coincide.
+ */
+function rectEdgeIntersection(
+  center: { x: number; y: number },
+  width: number,
+  height: number,
+  toward: { x: number; y: number }
+): { x: number; y: number } {
+  const dx = toward.x - center.x;
+  const dy = toward.y - center.y;
+  if (dx === 0 && dy === 0) return center;
+  const halfW = width / 2;
+  const halfH = height / 2;
+  const tx = dx === 0 ? Number.POSITIVE_INFINITY : halfW / Math.abs(dx);
+  const ty = dy === 0 ? Number.POSITIVE_INFINITY : halfH / Math.abs(dy);
+  const t = Math.min(tx, ty);
+  return {
+    x: center.x + t * dx,
+    y: center.y + t * dy,
+  };
+}
+
+export function FloatingLabel({
+  id,
+  text,
+  anchorAngle,
+  anchorRadius,
+  labelRadius,
+  color,
+  cx,
+  cy,
+  clockBox,
+  fontSize = DEFAULT_FONT_SIZE,
+  onClick,
+}: FloatingLabelProps) {
+  const isInteractive = Boolean(onClick);
+
+  const anchor = polarToCartesian(cx, cy, anchorRadius, anchorAngle);
+  const idealCentre = polarToCartesian(cx, cy, labelRadius, anchorAngle);
+  const centre = clampLabelPosition(idealCentre, clockBox);
+
+  const textWidth = text.length * fontSize * CHAR_WIDTH_RATIO;
+  const textHeight = fontSize * LINE_HEIGHT_RATIO;
+  const rectWidth = textWidth + RECT_PADDING_X * 2;
+  const rectHeight = textHeight + RECT_PADDING_Y * 2;
+
+  const rectX = centre.x - rectWidth / 2;
+  const rectY = centre.y - rectHeight / 2;
+
+  const connectorEnd = rectEdgeIntersection(
+    centre,
+    rectWidth,
+    rectHeight,
+    anchor
+  );
+
+  const handleKeyDown = (e: ReactKeyboardEvent<SVGGElement>) => {
+    if (!onClick) return;
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      onClick(id, e.currentTarget);
+    }
+  };
+
+  return (
+    <g
+      data-testid={`floating-label-${id}`}
+      role={isInteractive ? "button" : undefined}
+      aria-label={isInteractive ? `Event: ${text}` : undefined}
+      tabIndex={isInteractive ? 0 : undefined}
+      onClick={
+        isInteractive ? (e) => onClick?.(id, e.currentTarget) : undefined
+      }
+      onKeyDown={isInteractive ? handleKeyDown : undefined}
+      className={
+        isInteractive
+          ? "cursor-pointer focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+          : undefined
+      }
+    >
+      <line
+        data-testid={`floating-label-connector-${id}`}
+        x1={roundCoord(anchor.x)}
+        y1={roundCoord(anchor.y)}
+        x2={roundCoord(connectorEnd.x)}
+        y2={roundCoord(connectorEnd.y)}
+        stroke={color}
+        strokeOpacity={CONNECTOR_OPACITY}
+        strokeWidth={CONNECTOR_STROKE_WIDTH}
+      />
+      <rect
+        data-testid={`floating-label-rect-${id}`}
+        x={roundCoord(rectX)}
+        y={roundCoord(rectY)}
+        width={roundCoord(rectWidth)}
+        height={roundCoord(rectHeight)}
+        rx={RECT_CORNER_RADIUS}
+        ry={RECT_CORNER_RADIUS}
+        fill="white"
+        stroke={color}
+        strokeOpacity={RECT_BORDER_OPACITY}
+        strokeWidth={1}
+      />
+      <text
+        data-testid={`floating-label-text-${id}`}
+        x={roundCoord(centre.x)}
+        y={roundCoord(centre.y)}
+        textAnchor="middle"
+        dominantBaseline="central"
+        fontSize={fontSize}
+        fontFamily="system-ui, -apple-system, sans-serif"
+        fill="#1f2937"
+      >
+        {text}
+      </text>
+    </g>
+  );
+}

--- a/src/components/calendar/analog-clock/types.ts
+++ b/src/components/calendar/analog-clock/types.ts
@@ -103,4 +103,13 @@ export interface EventArcProps {
    * still renders so the arc remains visually identifiable.
    */
   forceHideTitle?: boolean;
+  /**
+   * Optional precomputed title layout. When provided, EventArc skips the
+   * internal `computeArcTitleLayout` call and uses this value — keeps the
+   * arc's `fit.lines` decision strictly identical to the one AnalogClock
+   * used to derive `forceHideTitle`, so the two surfaces cannot silently
+   * disagree if the underlying inputs ever drift apart. When omitted,
+   * EventArc still works standalone (e.g. tests, ad-hoc usage).
+   */
+  precomputedLayout?: import("./arc-title-layout").ArcTitleLayout;
 }

--- a/src/components/calendar/analog-clock/types.ts
+++ b/src/components/calendar/analog-clock/types.ts
@@ -96,4 +96,11 @@ export interface EventArcProps {
    * after a modal closes.
    */
   onEventClick?: (eventId: string, trigger: SVGGElement) => void;
+  /**
+   * When true, suppresses in-arc title rendering even if the title would
+   * have fit. Used by AnalogClock for overflowing events whose titles are
+   * promoted to a sibling FloatingLabel (#311). The leading event emoji
+   * still renders so the arc remains visually identifiable.
+   */
+  forceHideTitle?: boolean;
 }


### PR DESCRIPTION
Closes #311.

## Summary

When an event title in the Clock view overflows even the 2-line in-arc budget from #310, render the full title as a floating label outside the clock face with a thin connector line back to the arc midpoint. The arc keeps its colored fill and leading event emoji; the in-arc title is suppressed so the floating label is the sole title surface for that event.

## Approach (TDD, three phases)

1. **`clamp-label.ts`** — pure helper for the vertical clamp band `[clockTop − 0.10×h, clockBottom + 0.10×h]` so the AnalogClockView grid row height stays stable regardless of how many overflowing labels exist. **11 unit tests.**
2. **`floating-label.tsx`** — pure SVG primitive: connector `<line>` + bordered `<rect>` + `<text>`. Uses `clampLabelPosition` and a small `rectEdgeIntersection` helper to anchor the connector on the rect side facing the anchor. Optional `onClick` mirrors `EventArc` so the wiring layer can route into `EventDetailModal`. **17 component tests.**
3. **Wiring** — extracted `arc-title-layout.ts` so `EventArc` and `AnalogClock` agree on `didOverflow` without independent recomputation. `EventArc` gains a `forceHideTitle` prop that suppresses the in-arc title (preserving the leading emoji). `AnalogClock` renders a sibling `floating-labels-layer` for overflowing events; SVG carries `overflow="visible"` (presentation attribute, not inline `style`) so labels can paint outside the clock viewBox. **+8 integration tests + 4 EventArc tests.**

## Spec compliance checklist

- [x] Trigger: `fitTitleToArc(...).didOverflow === true` (and arc is wide enough to render at all)
- [x] Arc in overflow mode: keeps fill, keeps leading event emoji, drops in-arc title
- [x] Label sits on an invisible outer circle at `outerRadius + arcThickness × 0.6`
- [x] Connector at arc midpoint outer-radius, `strokeOpacity=0.6`
- [x] Vertical clamp keeps grid row height stable
- [x] Multiple labels: angular order, no collision avoidance for v1
- [x] Floating label is clickable when `onEventClick` is provided

## Test plan

- [x] `pnpm test` — 2059/2059 vitest tests pass (40 new across this PR)
- [x] `pnpm lint:fix && pnpm format:fix && pnpm check-types` — clean (only pre-existing warnings)
- [x] Playwright spec added at `e2e/analog-clock-floating-labels.spec.ts` exercising the production-style fixture page; **could not run locally** (browser binary download blocked in this session) — relying on CI

## Files

- `src/components/calendar/analog-clock/clamp-label.ts` (new)
- `src/components/calendar/analog-clock/floating-label.tsx` (new)
- `src/components/calendar/analog-clock/arc-title-layout.ts` (new — shared layout helper)
- `src/components/calendar/analog-clock/analog-clock.tsx` (wiring)
- `src/components/calendar/analog-clock/event-arc.tsx` (uses helper, accepts `forceHideTitle`)
- `src/components/calendar/analog-clock/types.ts` (`EventArcProps.forceHideTitle`)
- Tests: `__tests__/clamp-label.test.ts`, `__tests__/floating-label.test.tsx`, `__tests__/event-arc.test.tsx` (+4), `__tests__/analog-clock.test.tsx` (+8)
- `e2e/analog-clock-floating-labels.spec.ts` (new)

https://claude.ai/code/session_019iskjPEeRXWu1K8B22o9qN