### PR TITLE
feat(profile-settings): persist TaskSection values to ProfileSettings (#334)

### DIFF
--- a/.claude/plans/persist-task-section-profile-settings-334.md
+++ b/.claude/plans/persist-task-section-profile-settings-334.md
@@ -1,0 +1,97 @@
+# Persist TaskSection values to ProfileSettings (#334)
+
+Issue: https://github.com/BenSeymourODB/next-digital-wall-calendar/issues/334
+
+## Goal
+
+`SettingsForm` currently holds Tasks settings (`taskSortOrder`, `showCompletedTasks`) in a sibling `useState` that is never PUT anywhere. The fields already exist in the database on the `ProfileSettings` model. Wire them up so they:
+
+- persist across reloads
+- are per-profile (so different family members can have different defaults)
+- can be read by the future `TasksSettingsPanel` (#333) from the same source
+
+## Architecture decision: dedicated `/api/profiles/[id]/settings` endpoint
+
+Issue offers two options — extending `/api/settings` PUT, or a dedicated profile-scoped endpoint. The issue notes the rest of `ProfileSettings` (`theme`, `language`, `enableNotifications`, `notificationTime`, `defaultTaskListId`) needs the same treatment, so a dedicated endpoint is cleaner.
+
+Route: `src/app/api/profiles/[id]/settings/route.ts`
+
+- `GET /api/profiles/[id]/settings` — returns the `ProfileSettings` row for that profile, upserting defaults if missing. Ownership check: profile.userId must equal session.user.id.
+- `PUT /api/profiles/[id]/settings` — partial update, same ownership check, field-level validation.
+
+Why not extend the existing `/api/profiles/[id]` PATCH? Because mixing profile metadata (name, avatar, color) with settings creates a fat endpoint and forces clients to fetch + send the whole record. The settings endpoint is what `TasksSettingsPanel` will hit directly.
+
+## Validation rules (PUT)
+
+- `taskSortOrder` — string ∈ {`dueDate`, `title`, `priority`, `createdAt`}
+- `showCompletedTasks` — boolean
+- `theme` — string ∈ {`light`, `dark`, `auto`, `system`} (matches existing `/api/settings` rules)
+- `language` — non-empty string (light validation; locale list is future work)
+- `enableNotifications` — boolean
+- `notificationTime` — string matching `HH:MM` or null
+- `defaultTaskListId` — string or null
+
+This issue's acceptance criteria only require the first two; the rest are validated defensively so the same endpoint can serve `TasksSettingsPanel` later without a schema rewrite.
+
+## Client wiring (`SettingsForm`)
+
+The component is server-rendered with `initialSettings`. Active profile is client-only (`useProfile()` from `ProfileContext`, backed by localStorage).
+
+Pattern:
+
+1. On mount (or when `activeProfile.id` changes), fetch `/api/profiles/<id>/settings` and seed local state.
+2. Render `TaskSection` only once profile settings are loaded; before that, render the section with the loaded-but-not-yet-overridden defaults from `defaultValues`. (Keeps the section visible during the brief fetch; avoids flicker on stale values.)
+3. `onChange` does an optimistic update + PUT; on failure, toast and rollback.
+
+Disable interactions / show "no profile" state if `activeProfile` is null (e.g. before profiles load, or if the user has no profiles). The existing `SettingsForm` always renders, so the simplest UX is to leave TaskSection mounted with the in-memory defaults — interaction PUTs only fire once a profile exists.
+
+## Test plan
+
+### Phase 1 — API route (integration tests, then implementation)
+
+`src/app/api/profiles/[id]/settings/__tests__/route.test.ts`
+
+GET:
+
+- returns 401 when no session
+- returns 404 when profile not found / not owned by user
+- returns existing settings
+- upserts defaults when settings row is missing
+- returns 500 on DB error
+
+PUT:
+
+- returns 401 when no session
+- returns 404 when profile not found / not owned by user
+- partial update of `taskSortOrder` persists
+- partial update of `showCompletedTasks` persists
+- rejects invalid `taskSortOrder` (400)
+- rejects non-boolean `showCompletedTasks` (400)
+- rejects invalid `theme` (400)
+- rejects non-`HH:MM` `notificationTime` (400)
+- accepts `notificationTime = null`
+- returns 500 on DB error
+
+### Phase 2 — `SettingsForm` wiring
+
+Add `src/components/settings/__tests__/settings-form.test.tsx` covering:
+
+- Fetches profile settings from `/api/profiles/<activeProfileId>/settings` on mount (mock `useProfile` + `fetch`)
+- Initial render shows fallback defaults (`dueDate`, `false`) when fetch is pending
+- After fetch resolves, TaskSection reflects fetched values
+- Toggling `Show completed tasks` PUTs the new value
+- Failed PUT rolls back the optimistic update and toasts an error
+- Switching active profile re-fetches and updates the displayed values
+
+Existing `task-section.test.tsx` continues to pass — the component contract is unchanged.
+
+### Verification
+
+- `pnpm lint:fix && pnpm format:fix && pnpm check-types && pnpm test`
+- Manual smoke (dev server): toggle, reload, verify persistence. (Requires database; if no DB available in remote env, document in PR.)
+
+## Out of scope
+
+- `TasksSettingsPanel` (#333) — sibling sub-issue; the endpoint is ready for it but the UI is not built here.
+- Wiring `theme`, `language`, `enableNotifications`, `notificationTime`, `defaultTaskListId` into UI surfaces — endpoint accepts them, no UI uses them yet (covered by #328 cluster).
+- Persisting per-profile settings via `User.activeProfileId` server-side — active profile remains a client-side concept; the endpoint is explicit about which profile is being read/written.

--- a/src/app/api/profiles/[id]/settings/__tests__/route.test.ts
+++ b/src/app/api/profiles/[id]/settings/__tests__/route.test.ts
@@ -94,7 +94,7 @@ describe("/api/profiles/[id]/settings", () => {
       });
     });
 
-    it("returns existing settings for an owned profile", async () => {
+    it("returns existing settings for an owned profile (upsert update branch)", async () => {
       vi.mocked(getSession).mockResolvedValue(mockSession);
       mockPrisma.profile.findFirst.mockResolvedValue({ id: profileId });
       mockPrisma.profileSettings.upsert.mockResolvedValue(mockProfileSettings);
@@ -113,6 +113,67 @@ describe("/api/profiles/[id]/settings", () => {
         where: { profileId },
         create: { profileId },
         update: {},
+      });
+    });
+
+    it("creates defaults when settings row is missing (upsert create branch)", async () => {
+      vi.mocked(getSession).mockResolvedValue(mockSession);
+      mockPrisma.profile.findFirst.mockResolvedValue({ id: profileId });
+      // Simulate the upsert's create branch returning a fresh defaults row.
+      const freshDefaults = {
+        ...mockProfileSettings,
+        id: "settings-fresh",
+        taskSortOrder: "dueDate",
+        showCompletedTasks: false,
+        theme: "light",
+        language: "en",
+        enableNotifications: false,
+        notificationTime: null,
+        defaultTaskListId: null,
+      };
+      mockPrisma.profileSettings.upsert.mockResolvedValue(freshDefaults);
+
+      const request = createMockRequest(`/api/profiles/${profileId}/settings`);
+      const response = await GET(request, {
+        params: createParams(profileId),
+      });
+      const { status, data } =
+        await parseResponse<typeof freshDefaults>(response);
+
+      expect(status).toBe(200);
+      expect(data.taskSortOrder).toBe("dueDate");
+      expect(data.showCompletedTasks).toBe(false);
+      // The upsert call shape proves the create branch will be taken when no
+      // row exists — Prisma chooses between create/update based on `where`.
+      expect(mockPrisma.profileSettings.upsert).toHaveBeenCalledWith({
+        where: { profileId },
+        create: { profileId },
+        update: {},
+      });
+    });
+
+    it("returns 404 for a soft-deleted (isActive: false) profile", async () => {
+      vi.mocked(getSession).mockResolvedValue(mockSession);
+      // findFirst returns null because the where clause requires
+      // `isActive: true` — a soft-deleted profile is intentionally
+      // inaccessible. See comment on assertProfileOwnership.
+      mockPrisma.profile.findFirst.mockResolvedValue(null);
+
+      const request = createMockRequest(`/api/profiles/${profileId}/settings`);
+      const response = await GET(request, {
+        params: createParams(profileId),
+      });
+      const { status, data } = await parseResponse<ApiErrorResponse>(response);
+
+      expect(status).toBe(404);
+      expect(data.error).toBe("Profile not found");
+      expect(mockPrisma.profile.findFirst).toHaveBeenCalledWith({
+        where: {
+          id: profileId,
+          userId: mockUserId,
+          isActive: true,
+        },
+        select: { id: true },
       });
     });
 
@@ -360,6 +421,42 @@ describe("/api/profiles/[id]/settings", () => {
         await parseResponse<typeof mockProfileSettings>(response);
 
       expect(status).toBe(200);
+    });
+
+    it("rejects an empty body (no valid fields to update)", async () => {
+      vi.mocked(getSession).mockResolvedValue(mockSession);
+      mockPrisma.profile.findFirst.mockResolvedValue({ id: profileId });
+
+      const request = createMockRequest(`/api/profiles/${profileId}/settings`, {
+        method: "PUT",
+        body: {},
+      });
+      const response = await PUT(request, {
+        params: createParams(profileId),
+      });
+      const { status, data } = await parseResponse<ApiErrorResponse>(response);
+
+      expect(status).toBe(400);
+      expect(data.error).toContain("No valid fields");
+      expect(mockPrisma.profileSettings.upsert).not.toHaveBeenCalled();
+    });
+
+    it("rejects a body containing only unknown fields (no valid fields to update)", async () => {
+      vi.mocked(getSession).mockResolvedValue(mockSession);
+      mockPrisma.profile.findFirst.mockResolvedValue({ id: profileId });
+
+      const request = createMockRequest(`/api/profiles/${profileId}/settings`, {
+        method: "PUT",
+        body: { bogus: "field", id: "evil" },
+      });
+      const response = await PUT(request, {
+        params: createParams(profileId),
+      });
+      const { status, data } = await parseResponse<ApiErrorResponse>(response);
+
+      expect(status).toBe(400);
+      expect(data.error).toContain("No valid fields");
+      expect(mockPrisma.profileSettings.upsert).not.toHaveBeenCalled();
     });
 
     it("ignores unknown fields (does not persist them)", async () => {

--- a/src/app/api/profiles/[id]/settings/__tests__/route.test.ts
+++ b/src/app/api/profiles/[id]/settings/__tests__/route.test.ts
@@ -1,0 +1,407 @@
+/**
+ * Integration tests for /api/profiles/[id]/settings routes
+ * Following TDD - tests are written before implementation
+ */
+import { getSession } from "@/lib/auth";
+import { mockSession } from "@/lib/auth/__tests__/fixtures";
+import { prisma } from "@/lib/db";
+import {
+  type ApiErrorResponse,
+  createMockRequest,
+  createParams,
+  parseResponse,
+} from "@/lib/test-utils/api-test-helpers";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  mockAdminProfile,
+  mockProfileSettings,
+  mockUserId,
+} from "../../../__tests__/fixtures";
+import { GET, PUT } from "../route";
+
+vi.mock("@/lib/auth", () => ({
+  getSession: vi.fn(),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    error: vi.fn(),
+    log: vi.fn(),
+    event: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    profile: {
+      findFirst: vi.fn(),
+    },
+    profileSettings: {
+      upsert: vi.fn(),
+    },
+  },
+}));
+
+const mockPrisma = prisma as unknown as {
+  profile: {
+    findFirst: ReturnType<typeof vi.fn>;
+  };
+  profileSettings: {
+    upsert: ReturnType<typeof vi.fn>;
+  };
+};
+
+const profileId = mockAdminProfile.id;
+
+describe("/api/profiles/[id]/settings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("GET", () => {
+    it("returns 401 when no session", async () => {
+      vi.mocked(getSession).mockResolvedValue(null);
+
+      const request = createMockRequest(`/api/profiles/${profileId}/settings`);
+      const response = await GET(request, {
+        params: createParams(profileId),
+      });
+      const { status, data } = await parseResponse<ApiErrorResponse>(response);
+
+      expect(status).toBe(401);
+      expect(data.error).toBe("Unauthorized");
+    });
+
+    it("returns 404 when profile not owned by user", async () => {
+      vi.mocked(getSession).mockResolvedValue(mockSession);
+      mockPrisma.profile.findFirst.mockResolvedValue(null);
+
+      const request = createMockRequest(`/api/profiles/${profileId}/settings`);
+      const response = await GET(request, {
+        params: createParams(profileId),
+      });
+      const { status, data } = await parseResponse<ApiErrorResponse>(response);
+
+      expect(status).toBe(404);
+      expect(data.error).toBe("Profile not found");
+      expect(mockPrisma.profile.findFirst).toHaveBeenCalledWith({
+        where: {
+          id: profileId,
+          userId: mockUserId,
+          isActive: true,
+        },
+        select: { id: true },
+      });
+    });
+
+    it("returns existing settings for an owned profile", async () => {
+      vi.mocked(getSession).mockResolvedValue(mockSession);
+      mockPrisma.profile.findFirst.mockResolvedValue({ id: profileId });
+      mockPrisma.profileSettings.upsert.mockResolvedValue(mockProfileSettings);
+
+      const request = createMockRequest(`/api/profiles/${profileId}/settings`);
+      const response = await GET(request, {
+        params: createParams(profileId),
+      });
+      const { status, data } =
+        await parseResponse<typeof mockProfileSettings>(response);
+
+      expect(status).toBe(200);
+      expect(data.taskSortOrder).toBe("dueDate");
+      expect(data.showCompletedTasks).toBe(false);
+      expect(mockPrisma.profileSettings.upsert).toHaveBeenCalledWith({
+        where: { profileId },
+        create: { profileId },
+        update: {},
+      });
+    });
+
+    it("returns 500 on database error", async () => {
+      vi.mocked(getSession).mockResolvedValue(mockSession);
+      mockPrisma.profile.findFirst.mockRejectedValue(
+        new Error("Database error")
+      );
+
+      const request = createMockRequest(`/api/profiles/${profileId}/settings`);
+      const response = await GET(request, {
+        params: createParams(profileId),
+      });
+      const { status, data } = await parseResponse<ApiErrorResponse>(response);
+
+      expect(status).toBe(500);
+      expect(data.error).toBe("Failed to fetch profile settings");
+    });
+  });
+
+  describe("PUT", () => {
+    it("returns 401 when no session", async () => {
+      vi.mocked(getSession).mockResolvedValue(null);
+
+      const request = createMockRequest(`/api/profiles/${profileId}/settings`, {
+        method: "PUT",
+        body: { taskSortOrder: "title" },
+      });
+      const response = await PUT(request, {
+        params: createParams(profileId),
+      });
+      const { status, data } = await parseResponse<ApiErrorResponse>(response);
+
+      expect(status).toBe(401);
+      expect(data.error).toBe("Unauthorized");
+    });
+
+    it("returns 404 when profile not owned by user", async () => {
+      vi.mocked(getSession).mockResolvedValue(mockSession);
+      mockPrisma.profile.findFirst.mockResolvedValue(null);
+
+      const request = createMockRequest(`/api/profiles/${profileId}/settings`, {
+        method: "PUT",
+        body: { taskSortOrder: "title" },
+      });
+      const response = await PUT(request, {
+        params: createParams(profileId),
+      });
+      const { status, data } = await parseResponse<ApiErrorResponse>(response);
+
+      expect(status).toBe(404);
+      expect(data.error).toBe("Profile not found");
+    });
+
+    it("updates taskSortOrder successfully", async () => {
+      vi.mocked(getSession).mockResolvedValue(mockSession);
+      mockPrisma.profile.findFirst.mockResolvedValue({ id: profileId });
+      const updated = { ...mockProfileSettings, taskSortOrder: "title" };
+      mockPrisma.profileSettings.upsert.mockResolvedValue(updated);
+
+      const request = createMockRequest(`/api/profiles/${profileId}/settings`, {
+        method: "PUT",
+        body: { taskSortOrder: "title" },
+      });
+      const response = await PUT(request, {
+        params: createParams(profileId),
+      });
+      const { status, data } =
+        await parseResponse<typeof mockProfileSettings>(response);
+
+      expect(status).toBe(200);
+      expect(data.taskSortOrder).toBe("title");
+      expect(mockPrisma.profileSettings.upsert).toHaveBeenCalledWith({
+        where: { profileId },
+        create: { profileId, taskSortOrder: "title" },
+        update: { taskSortOrder: "title" },
+      });
+    });
+
+    it("updates showCompletedTasks successfully", async () => {
+      vi.mocked(getSession).mockResolvedValue(mockSession);
+      mockPrisma.profile.findFirst.mockResolvedValue({ id: profileId });
+      const updated = { ...mockProfileSettings, showCompletedTasks: true };
+      mockPrisma.profileSettings.upsert.mockResolvedValue(updated);
+
+      const request = createMockRequest(`/api/profiles/${profileId}/settings`, {
+        method: "PUT",
+        body: { showCompletedTasks: true },
+      });
+      const response = await PUT(request, {
+        params: createParams(profileId),
+      });
+      const { status, data } =
+        await parseResponse<typeof mockProfileSettings>(response);
+
+      expect(status).toBe(200);
+      expect(data.showCompletedTasks).toBe(true);
+    });
+
+    it("rejects invalid taskSortOrder", async () => {
+      vi.mocked(getSession).mockResolvedValue(mockSession);
+      mockPrisma.profile.findFirst.mockResolvedValue({ id: profileId });
+
+      const request = createMockRequest(`/api/profiles/${profileId}/settings`, {
+        method: "PUT",
+        body: { taskSortOrder: "nope" },
+      });
+      const response = await PUT(request, {
+        params: createParams(profileId),
+      });
+      const { status, data } = await parseResponse<ApiErrorResponse>(response);
+
+      expect(status).toBe(400);
+      expect(data.error).toContain("taskSortOrder");
+      expect(mockPrisma.profileSettings.upsert).not.toHaveBeenCalled();
+    });
+
+    it("rejects non-boolean showCompletedTasks", async () => {
+      vi.mocked(getSession).mockResolvedValue(mockSession);
+      mockPrisma.profile.findFirst.mockResolvedValue({ id: profileId });
+
+      const request = createMockRequest(`/api/profiles/${profileId}/settings`, {
+        method: "PUT",
+        body: { showCompletedTasks: "yes" },
+      });
+      const response = await PUT(request, {
+        params: createParams(profileId),
+      });
+      const { status, data } = await parseResponse<ApiErrorResponse>(response);
+
+      expect(status).toBe(400);
+      expect(data.error).toContain("showCompletedTasks");
+    });
+
+    it("rejects invalid theme", async () => {
+      vi.mocked(getSession).mockResolvedValue(mockSession);
+      mockPrisma.profile.findFirst.mockResolvedValue({ id: profileId });
+
+      const request = createMockRequest(`/api/profiles/${profileId}/settings`, {
+        method: "PUT",
+        body: { theme: "neon" },
+      });
+      const response = await PUT(request, {
+        params: createParams(profileId),
+      });
+      const { status, data } = await parseResponse<ApiErrorResponse>(response);
+
+      expect(status).toBe(400);
+      expect(data.error).toContain("theme");
+    });
+
+    it("rejects invalid notificationTime", async () => {
+      vi.mocked(getSession).mockResolvedValue(mockSession);
+      mockPrisma.profile.findFirst.mockResolvedValue({ id: profileId });
+
+      const request = createMockRequest(`/api/profiles/${profileId}/settings`, {
+        method: "PUT",
+        body: { notificationTime: "25:99" },
+      });
+      const response = await PUT(request, {
+        params: createParams(profileId),
+      });
+      const { status, data } = await parseResponse<ApiErrorResponse>(response);
+
+      expect(status).toBe(400);
+      expect(data.error).toContain("notificationTime");
+    });
+
+    it("accepts null notificationTime", async () => {
+      vi.mocked(getSession).mockResolvedValue(mockSession);
+      mockPrisma.profile.findFirst.mockResolvedValue({ id: profileId });
+      const updated = { ...mockProfileSettings, notificationTime: null };
+      mockPrisma.profileSettings.upsert.mockResolvedValue(updated);
+
+      const request = createMockRequest(`/api/profiles/${profileId}/settings`, {
+        method: "PUT",
+        body: { notificationTime: null },
+      });
+      const response = await PUT(request, {
+        params: createParams(profileId),
+      });
+      const { status, data } =
+        await parseResponse<typeof mockProfileSettings>(response);
+
+      expect(status).toBe(200);
+      expect(data.notificationTime).toBeNull();
+    });
+
+    it("accepts valid notificationTime (HH:MM)", async () => {
+      vi.mocked(getSession).mockResolvedValue(mockSession);
+      mockPrisma.profile.findFirst.mockResolvedValue({ id: profileId });
+      const updated = {
+        ...mockProfileSettings,
+        notificationTime: "08:30",
+        enableNotifications: true,
+      };
+      mockPrisma.profileSettings.upsert.mockResolvedValue(updated);
+
+      const request = createMockRequest(`/api/profiles/${profileId}/settings`, {
+        method: "PUT",
+        body: { notificationTime: "08:30", enableNotifications: true },
+      });
+      const response = await PUT(request, {
+        params: createParams(profileId),
+      });
+      const { status, data } =
+        await parseResponse<typeof mockProfileSettings>(response);
+
+      expect(status).toBe(200);
+      expect(data.notificationTime).toBe("08:30");
+      expect(data.enableNotifications).toBe(true);
+    });
+
+    it("rejects empty language", async () => {
+      vi.mocked(getSession).mockResolvedValue(mockSession);
+      mockPrisma.profile.findFirst.mockResolvedValue({ id: profileId });
+
+      const request = createMockRequest(`/api/profiles/${profileId}/settings`, {
+        method: "PUT",
+        body: { language: "" },
+      });
+      const response = await PUT(request, {
+        params: createParams(profileId),
+      });
+      const { status, data } = await parseResponse<ApiErrorResponse>(response);
+
+      expect(status).toBe(400);
+      expect(data.error).toContain("language");
+    });
+
+    it("accepts defaultTaskListId set to null", async () => {
+      vi.mocked(getSession).mockResolvedValue(mockSession);
+      mockPrisma.profile.findFirst.mockResolvedValue({ id: profileId });
+      const updated = { ...mockProfileSettings, defaultTaskListId: null };
+      mockPrisma.profileSettings.upsert.mockResolvedValue(updated);
+
+      const request = createMockRequest(`/api/profiles/${profileId}/settings`, {
+        method: "PUT",
+        body: { defaultTaskListId: null },
+      });
+      const response = await PUT(request, {
+        params: createParams(profileId),
+      });
+      const { status } =
+        await parseResponse<typeof mockProfileSettings>(response);
+
+      expect(status).toBe(200);
+    });
+
+    it("ignores unknown fields (does not persist them)", async () => {
+      vi.mocked(getSession).mockResolvedValue(mockSession);
+      mockPrisma.profile.findFirst.mockResolvedValue({ id: profileId });
+      mockPrisma.profileSettings.upsert.mockResolvedValue(mockProfileSettings);
+
+      const request = createMockRequest(`/api/profiles/${profileId}/settings`, {
+        method: "PUT",
+        body: { taskSortOrder: "title", bogus: "field", id: "evil" },
+      });
+      const response = await PUT(request, {
+        params: createParams(profileId),
+      });
+
+      expect(response.status).toBe(200);
+      const call = mockPrisma.profileSettings.upsert.mock.calls[0][0];
+      expect(call.update).toEqual({ taskSortOrder: "title" });
+      expect(call.create).toEqual({
+        profileId,
+        taskSortOrder: "title",
+      });
+    });
+
+    it("returns 500 on database error", async () => {
+      vi.mocked(getSession).mockResolvedValue(mockSession);
+      mockPrisma.profile.findFirst.mockResolvedValue({ id: profileId });
+      mockPrisma.profileSettings.upsert.mockRejectedValue(
+        new Error("Database error")
+      );
+
+      const request = createMockRequest(`/api/profiles/${profileId}/settings`, {
+        method: "PUT",
+        body: { taskSortOrder: "title" },
+      });
+      const response = await PUT(request, {
+        params: createParams(profileId),
+      });
+      const { status, data } = await parseResponse<ApiErrorResponse>(response);
+
+      expect(status).toBe(500);
+      expect(data.error).toBe("Failed to update profile settings");
+    });
+  });
+});

--- a/src/app/api/profiles/[id]/settings/route.ts
+++ b/src/app/api/profiles/[id]/settings/route.ts
@@ -1,0 +1,182 @@
+/**
+ * API routes for profile-scoped settings.
+ *
+ * GET  /api/profiles/[id]/settings — fetch the ProfileSettings row for a
+ *                                    profile owned by the authenticated user,
+ *                                    upserting defaults when absent.
+ * PUT  /api/profiles/[id]/settings — partial update of the same row.
+ *
+ * Active profile is a client-side concept (see ProfileContext). This endpoint
+ * is explicit about which profile is being addressed so it can also serve
+ * `TasksSettingsPanel` (#333) without coupling to server-side active state.
+ */
+import {
+  ApiError,
+  requireUserSession,
+  withApiHandler,
+} from "@/lib/api/handler";
+import { prisma } from "@/lib/db";
+import { logger } from "@/lib/logger";
+import { NextRequest, NextResponse } from "next/server";
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+const VALID_TASK_SORT_ORDERS = ["dueDate", "title", "priority", "createdAt"];
+const VALID_THEMES = ["light", "dark", "auto", "system"];
+const NOTIFICATION_TIME_RE = /^([01]\d|2[0-3]):[0-5]\d$/;
+
+type SettingsUpdate = {
+  taskSortOrder?: string;
+  showCompletedTasks?: boolean;
+  theme?: string;
+  language?: string;
+  enableNotifications?: boolean;
+  notificationTime?: string | null;
+  defaultTaskListId?: string | null;
+};
+
+function validateAndExtract(body: Record<string, unknown>): SettingsUpdate {
+  const update: SettingsUpdate = {};
+
+  if (body.taskSortOrder !== undefined) {
+    if (
+      typeof body.taskSortOrder !== "string" ||
+      !VALID_TASK_SORT_ORDERS.includes(body.taskSortOrder)
+    ) {
+      throw new ApiError(
+        `Invalid taskSortOrder. Must be one of: ${VALID_TASK_SORT_ORDERS.join(", ")}`,
+        400
+      );
+    }
+    update.taskSortOrder = body.taskSortOrder;
+  }
+
+  if (body.showCompletedTasks !== undefined) {
+    if (typeof body.showCompletedTasks !== "boolean") {
+      throw new ApiError("showCompletedTasks must be a boolean", 400);
+    }
+    update.showCompletedTasks = body.showCompletedTasks;
+  }
+
+  if (body.theme !== undefined) {
+    if (typeof body.theme !== "string" || !VALID_THEMES.includes(body.theme)) {
+      throw new ApiError(
+        `Invalid theme. Must be one of: ${VALID_THEMES.join(", ")}`,
+        400
+      );
+    }
+    update.theme = body.theme;
+  }
+
+  if (body.language !== undefined) {
+    if (typeof body.language !== "string" || body.language.length === 0) {
+      throw new ApiError("language must be a non-empty string", 400);
+    }
+    update.language = body.language;
+  }
+
+  if (body.enableNotifications !== undefined) {
+    if (typeof body.enableNotifications !== "boolean") {
+      throw new ApiError("enableNotifications must be a boolean", 400);
+    }
+    update.enableNotifications = body.enableNotifications;
+  }
+
+  if (body.notificationTime !== undefined) {
+    if (body.notificationTime === null) {
+      update.notificationTime = null;
+    } else if (
+      typeof body.notificationTime !== "string" ||
+      !NOTIFICATION_TIME_RE.test(body.notificationTime)
+    ) {
+      throw new ApiError("notificationTime must be HH:MM or null", 400);
+    } else {
+      update.notificationTime = body.notificationTime;
+    }
+  }
+
+  if (body.defaultTaskListId !== undefined) {
+    if (
+      body.defaultTaskListId !== null &&
+      typeof body.defaultTaskListId !== "string"
+    ) {
+      throw new ApiError("defaultTaskListId must be a string or null", 400);
+    }
+    update.defaultTaskListId = body.defaultTaskListId as string | null;
+  }
+
+  return update;
+}
+
+async function assertProfileOwnership(
+  profileId: string,
+  userId: string
+): Promise<void> {
+  const profile = await prisma.profile.findFirst({
+    where: {
+      id: profileId,
+      userId,
+      isActive: true,
+    },
+    select: { id: true },
+  });
+
+  if (!profile) {
+    throw new ApiError("Profile not found", 404);
+  }
+}
+
+export const GET = withApiHandler(
+  {
+    endpoint: "/api/profiles/[id]/settings",
+    method: "GET",
+    errorMessage: "Failed to fetch profile settings",
+  },
+  async (_request: NextRequest, { params }: RouteParams) => {
+    const session = await requireUserSession();
+    const { id: profileId } = await params;
+
+    await assertProfileOwnership(profileId, session.user.id);
+
+    const settings = await prisma.profileSettings.upsert({
+      where: { profileId },
+      create: { profileId },
+      update: {},
+    });
+
+    return NextResponse.json(settings);
+  }
+);
+
+export const PUT = withApiHandler(
+  {
+    endpoint: "/api/profiles/[id]/settings",
+    method: "PUT",
+    errorMessage: "Failed to update profile settings",
+  },
+  async (request: NextRequest, { params }: RouteParams) => {
+    const session = await requireUserSession();
+    const { id: profileId } = await params;
+
+    await assertProfileOwnership(profileId, session.user.id);
+
+    const body = (await request.json()) as Record<string, unknown>;
+    const update = validateAndExtract(body);
+
+    const settings = await prisma.profileSettings.upsert({
+      where: { profileId },
+      create: { profileId, ...update },
+      update,
+    });
+
+    logger.event("ProfileSettingsUpdated", {
+      profileId,
+      userId: session.user.id,
+      fields: Object.keys(update).join(","),
+    });
+
+    return NextResponse.json(settings);
+  }
+);

--- a/src/app/api/profiles/[id]/settings/route.ts
+++ b/src/app/api/profiles/[id]/settings/route.ts
@@ -110,6 +110,15 @@ function validateAndExtract(body: Record<string, unknown>): SettingsUpdate {
   return update;
 }
 
+// Settings on soft-deleted profiles are intentionally inaccessible: the
+// profile is no longer addressable from the UI (filtered out of
+// `/api/profiles`), and `ProfileSettings` is cascade-deleted with the
+// profile, so any soft-deleted profile that still has a settings row is
+// in a transient state we shouldn't expose. Matches the
+// `isActive: true` filter on every sibling sub-route (reset-pin,
+// set-pin, stats, give-points). The parent `PATCH /api/profiles/[id]`
+// deliberately omits it so admins can rename/reactivate a soft-deleted
+// profile — a different use case.
 async function assertProfileOwnership(
   profileId: string,
   userId: string
@@ -146,6 +155,12 @@ export const GET = withApiHandler(
       update: {},
     });
 
+    logger.log("ProfileSettingsFetched", {
+      profileId,
+      userId: session.user.id,
+      endpoint: "/api/profiles/[id]/settings",
+    });
+
     return NextResponse.json(settings);
   }
 );
@@ -164,6 +179,10 @@ export const PUT = withApiHandler(
 
     const body = (await request.json()) as Record<string, unknown>;
     const update = validateAndExtract(body);
+
+    if (Object.keys(update).length === 0) {
+      throw new ApiError("No valid fields to update", 400);
+    }
 
     const settings = await prisma.profileSettings.upsert({
       where: { profileId },

--- a/src/components/settings/__tests__/settings-form.test.tsx
+++ b/src/components/settings/__tests__/settings-form.test.tsx
@@ -1,0 +1,288 @@
+/**
+ * Tests for SettingsForm — focused on the profile-scoped Tasks settings wiring
+ * added for #334. The form is server-rendered with `initialSettings` (UserSettings),
+ * but Tasks settings live on `ProfileSettings` and must be fetched client-side
+ * for the active profile.
+ */
+import { useProfile } from "@/components/profiles/profile-context";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { toast } from "sonner";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SettingsForm } from "../settings-form";
+
+vi.mock("@/components/profiles/profile-context", () => ({
+  useProfile: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/scheduler/schedule-storage", () => ({
+  loadScheduleConfig: vi.fn(() => ({ transition: undefined })),
+  saveScheduleConfig: vi.fn(),
+}));
+
+const baseInitialSettings = {
+  theme: "light",
+  timeFormat: "12h",
+  dateFormat: "MM/DD/YYYY",
+  defaultZoomLevel: 1,
+  rewardSystemEnabled: false,
+  defaultTaskPoints: 10,
+  showPointsOnCompletion: true,
+  schedulerIntervalSeconds: 10,
+  schedulerPauseOnInteractionSeconds: 30,
+  calendarRefreshIntervalMinutes: 15,
+  calendarFetchMonthsAhead: 6,
+  calendarFetchMonthsBehind: 1,
+  calendarMaxEventsPerDay: 3,
+};
+
+const baseUser = {
+  name: "Test User",
+  email: "test@example.com",
+  image: null,
+};
+
+const ACTIVE_PROFILE_ID = "profile-active-1";
+
+function mockActiveProfile(id: string | null) {
+  vi.mocked(useProfile).mockReturnValue({
+    activeProfile: id
+      ? {
+          id,
+          userId: "user-1",
+          name: "Active",
+          type: "admin",
+          ageGroup: "adult",
+          color: "#3b82f6",
+          avatar: { type: "initials", value: "A" },
+          pinEnabled: false,
+          isActive: true,
+        }
+      : null,
+    allProfiles: [],
+    viewMode: "profile",
+    isAdmin: true,
+    isLoading: false,
+    setActiveProfile: vi.fn(),
+    setViewMode: vi.fn(),
+    refreshProfiles: vi.fn(),
+  });
+}
+
+function renderSettings() {
+  return render(
+    <SettingsForm
+      user={baseUser}
+      createdAt="2024-01-01T00:00:00Z"
+      providers={["google"]}
+      initialSettings={baseInitialSettings}
+    />
+  );
+}
+
+describe("SettingsForm — Tasks settings wiring (#334)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockActiveProfile(ACTIVE_PROFILE_ID);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("fetches profile settings for the active profile on mount", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        taskSortOrder: "title",
+        showCompletedTasks: true,
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderSettings();
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        `/api/profiles/${ACTIVE_PROFILE_ID}/settings`
+      );
+    });
+  });
+
+  it("renders fetched showCompletedTasks value once load resolves", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          taskSortOrder: "title",
+          showCompletedTasks: true,
+        }),
+      })
+    );
+
+    renderSettings();
+
+    const switchEl = await screen.findByRole("switch", {
+      name: /show completed tasks/i,
+    });
+    await waitFor(() =>
+      expect(switchEl).toHaveAttribute("data-state", "checked")
+    );
+  });
+
+  it("does not fetch when no active profile is available", () => {
+    mockActiveProfile(null);
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderSettings();
+
+    const profileSettingsFetch = fetchMock.mock.calls.find(
+      (call) => typeof call[0] === "string" && call[0].includes("/settings")
+    );
+    expect(profileSettingsFetch).toBeUndefined();
+  });
+
+  it("PUTs to the active profile's settings endpoint when showCompletedTasks toggles", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi
+      .fn()
+      // GET on mount
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          taskSortOrder: "dueDate",
+          showCompletedTasks: false,
+        }),
+      })
+      // PUT on toggle
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          taskSortOrder: "dueDate",
+          showCompletedTasks: true,
+        }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderSettings();
+
+    const switchEl = await screen.findByRole("switch", {
+      name: /show completed tasks/i,
+    });
+
+    await waitFor(() =>
+      expect(switchEl).toHaveAttribute("data-state", "unchecked")
+    );
+
+    await user.click(switchEl);
+
+    await waitFor(() => {
+      const putCall = fetchMock.mock.calls.find((call) => {
+        const url = call[0] as string;
+        const init = call[1] as RequestInit | undefined;
+        return (
+          url === `/api/profiles/${ACTIVE_PROFILE_ID}/settings` &&
+          init?.method === "PUT"
+        );
+      });
+      expect(putCall).toBeDefined();
+      const body = JSON.parse((putCall![1] as RequestInit).body as string) as {
+        showCompletedTasks: boolean;
+      };
+      expect(body.showCompletedTasks).toBe(true);
+    });
+
+    expect(switchEl).toHaveAttribute("data-state", "checked");
+  });
+
+  it("rolls back optimistic toggle and toasts on PUT failure", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          taskSortOrder: "dueDate",
+          showCompletedTasks: false,
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({ error: "boom" }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderSettings();
+
+    const switchEl = await screen.findByRole("switch", {
+      name: /show completed tasks/i,
+    });
+    await waitFor(() =>
+      expect(switchEl).toHaveAttribute("data-state", "unchecked")
+    );
+
+    await user.click(switchEl);
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalled();
+    });
+    expect(switchEl).toHaveAttribute("data-state", "unchecked");
+  });
+
+  it("re-fetches and updates display when the active profile changes", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          taskSortOrder: "dueDate",
+          showCompletedTasks: false,
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          taskSortOrder: "title",
+          showCompletedTasks: true,
+        }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { rerender } = renderSettings();
+
+    const switchEl = await screen.findByRole("switch", {
+      name: /show completed tasks/i,
+    });
+    await waitFor(() =>
+      expect(switchEl).toHaveAttribute("data-state", "unchecked")
+    );
+
+    mockActiveProfile("profile-other-2");
+    rerender(
+      <SettingsForm
+        user={baseUser}
+        createdAt="2024-01-01T00:00:00Z"
+        providers={["google"]}
+        initialSettings={baseInitialSettings}
+      />
+    );
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/profiles/profile-other-2/settings"
+      );
+    });
+    await waitFor(() =>
+      expect(switchEl).toHaveAttribute("data-state", "checked")
+    );
+  });
+});

--- a/src/components/settings/__tests__/settings-form.test.tsx
+++ b/src/components/settings/__tests__/settings-form.test.tsx
@@ -5,7 +5,7 @@
  * for the active profile.
  */
 import { useProfile } from "@/components/profiles/profile-context";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { toast } from "sonner";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -138,17 +138,54 @@ describe("SettingsForm — Tasks settings wiring (#334)", () => {
     );
   });
 
-  it("does not fetch when no active profile is available", () => {
+  it("does not fetch when no active profile is available", async () => {
     mockActiveProfile(null);
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
 
     renderSettings();
 
+    // Wait for effects to settle — if the no-active-profile guard were
+    // removed, fetch would be called asynchronously and a synchronous
+    // assertion would miss it.
+    await act(async () => {
+      await Promise.resolve();
+    });
+
     const profileSettingsFetch = fetchMock.mock.calls.find(
       (call) => typeof call[0] === "string" && call[0].includes("/settings")
     );
     expect(profileSettingsFetch).toBeUndefined();
+  });
+
+  it("shows fallback defaults (unchecked) while the fetch is still pending", async () => {
+    let resolveFetch: ((value: unknown) => void) | undefined;
+    const pendingFetch = new Promise((resolve) => {
+      resolveFetch = resolve;
+    });
+    vi.stubGlobal("fetch", vi.fn().mockReturnValue(pendingFetch));
+
+    renderSettings();
+
+    const switchEl = await screen.findByRole("switch", {
+      name: /show completed tasks/i,
+    });
+
+    // Settings would say `showCompletedTasks: true`, but the promise hasn't
+    // resolved, so the component must still show the unchecked default.
+    expect(switchEl).toHaveAttribute("data-state", "unchecked");
+
+    // Resolve so the cleanup effect doesn't leak.
+    resolveFetch?.({
+      ok: true,
+      json: async () => ({
+        taskSortOrder: "dueDate",
+        showCompletedTasks: true,
+      }),
+    });
+    await waitFor(() =>
+      expect(switchEl).toHaveAttribute("data-state", "checked")
+    );
   });
 
   it("PUTs to the active profile's settings endpoint when showCompletedTasks toggles", async () => {
@@ -202,6 +239,59 @@ describe("SettingsForm — Tasks settings wiring (#334)", () => {
     });
 
     expect(switchEl).toHaveAttribute("data-state", "checked");
+  });
+
+  it("PUTs the new taskSortOrder when the sort-order Select changes", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          taskSortOrder: "dueDate",
+          showCompletedTasks: false,
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          taskSortOrder: "priority",
+          showCompletedTasks: false,
+        }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderSettings();
+
+    // Wait until the GET resolves and the section is fully wired.
+    await screen.findByRole("switch", { name: /show completed tasks/i });
+
+    // SettingsForm has several Select dropdowns (timeFormat, dateFormat,
+    // taskSortOrder, …) — the only one initialised to "Due Date" is the
+    // task-sort-order one.
+    const combobox = screen
+      .getAllByRole("combobox")
+      .find((el) => /due date/i.test(el.textContent ?? ""));
+    expect(combobox).toBeDefined();
+    await user.click(combobox!);
+    const option = await screen.findByRole("option", { name: /priority/i });
+    await user.click(option);
+
+    await waitFor(() => {
+      const putCall = fetchMock.mock.calls.find((call) => {
+        const url = call[0] as string;
+        const init = call[1] as RequestInit | undefined;
+        return (
+          url === `/api/profiles/${ACTIVE_PROFILE_ID}/settings` &&
+          init?.method === "PUT"
+        );
+      });
+      expect(putCall).toBeDefined();
+      const body = JSON.parse((putCall![1] as RequestInit).body as string) as {
+        taskSortOrder: string;
+      };
+      expect(body.taskSortOrder).toBe("priority");
+    });
   });
 
   it("rolls back optimistic toggle and toasts on PUT failure", async () => {

--- a/src/components/settings/settings-form.tsx
+++ b/src/components/settings/settings-form.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useProfile } from "@/components/profiles/profile-context";
 import type { TransitionConfig } from "@/components/scheduler/types";
 import { DEFAULT_TRANSITION_CONFIG } from "@/lib/scheduler/schedule-config";
 import {
@@ -16,6 +17,16 @@ import { RewardSection } from "./reward-section";
 import { SchedulerSection } from "./scheduler-section";
 import { TaskSection } from "./task-section";
 import { TransitionSection } from "./transition-section";
+
+interface ProfileTaskSettings {
+  taskSortOrder: string;
+  showCompletedTasks: boolean;
+}
+
+const DEFAULT_TASK_SETTINGS: ProfileTaskSettings = {
+  taskSortOrder: "dueDate",
+  showCompletedTasks: false,
+};
 
 interface UserSettingsData {
   theme: string;
@@ -50,11 +61,13 @@ export function SettingsForm({
   providers,
   initialSettings,
 }: SettingsFormProps) {
+  const { activeProfile } = useProfile();
+  const activeProfileId = activeProfile?.id ?? null;
+
   const [settings, setSettings] = useState<UserSettingsData>(initialSettings);
-  const [taskSettings, setTaskSettings] = useState({
-    taskSortOrder: "dueDate",
-    showCompletedTasks: false,
-  });
+  const [taskSettings, setTaskSettings] = useState<ProfileTaskSettings>(
+    DEFAULT_TASK_SETTINGS
+  );
   const [transitionConfig, setTransitionConfig] = useState<TransitionConfig>(
     () => DEFAULT_TRANSITION_CONFIG
   );
@@ -64,6 +77,37 @@ export function SettingsForm({
     const config = loadScheduleConfig();
     setTransitionConfig(config.transition ?? DEFAULT_TRANSITION_CONFIG);
   }, []);
+
+  // Load profile-scoped task settings whenever the active profile changes.
+  useEffect(() => {
+    if (!activeProfileId) return;
+    let cancelled = false;
+
+    const load = async () => {
+      try {
+        const response = await fetch(
+          `/api/profiles/${activeProfileId}/settings`
+        );
+        if (!response.ok) return;
+        const data = (await response.json()) as Partial<ProfileTaskSettings>;
+        if (cancelled) return;
+        setTaskSettings({
+          taskSortOrder:
+            data.taskSortOrder ?? DEFAULT_TASK_SETTINGS.taskSortOrder,
+          showCompletedTasks:
+            data.showCompletedTasks ?? DEFAULT_TASK_SETTINGS.showCompletedTasks,
+        });
+      } catch {
+        // Leave defaults in place on network failure; toast is reserved for
+        // user-initiated changes.
+      }
+    };
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [activeProfileId]);
 
   const updateSettings = async (partial: Partial<UserSettingsData>) => {
     const updated = { ...settings, ...partial };
@@ -109,6 +153,35 @@ export function SettingsForm({
 
   const handleDeleteAllData = async () => {
     await handleDeleteAccount();
+  };
+
+  const updateTaskSettings = async (partial: Partial<ProfileTaskSettings>) => {
+    if (!activeProfileId) {
+      toast.error("No active profile — task settings cannot be saved");
+      return;
+    }
+
+    const previous = taskSettings;
+    const next = { ...previous, ...partial };
+    setTaskSettings(next);
+
+    try {
+      const response = await fetch(
+        `/api/profiles/${activeProfileId}/settings`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(partial),
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error("Failed to update task settings");
+      }
+    } catch {
+      toast.error("Failed to save task settings");
+      setTaskSettings(previous);
+    }
   };
 
   return (
@@ -164,12 +237,7 @@ export function SettingsForm({
         onChange={updateSettings}
       />
 
-      <TaskSection
-        values={taskSettings}
-        onChange={(partial) =>
-          setTaskSettings((prev) => ({ ...prev, ...partial }))
-        }
-      />
+      <TaskSection values={taskSettings} onChange={updateTaskSettings} />
 
       <PrivacySection
         permissions={["Google Calendar (read)", "Google Tasks (read/write)"]}


### PR DESCRIPTION
## Summary

- New `/api/profiles/[id]/settings` GET + PUT — profile-scoped, ownership-checked, validates every accepted `ProfileSettings` field.
- `SettingsForm` now fetches profile-scoped task settings on mount (and on profile switch) and PUTs changes back, replacing the orphan `useState` that was never persisted.
- Optimistic update + rollback + toast on failure.

## Plan

Linked plan: `.claude/plans/persist-task-section-profile-settings-334.md`
Project: https://github.com/users/BenSeymourODB/projects/1

## Approach

The issue offered two options; this PR adds a dedicated `/api/profiles/[id]/settings` endpoint rather than extending `/api/settings`. Rationale:

- `ProfileSettings` is per-profile, not per-user, so it doesn't belong on the user-level endpoint.
- The same endpoint will serve `TasksSettingsPanel` (#333) without forcing it to send the whole profile record.
- The endpoint validates the rest of `ProfileSettings` (`theme`, `language`, `enableNotifications`, `notificationTime`, `defaultTaskListId`) so it's ready for #328 follow-ups without a rewrite.

The active profile remains a client-only concept — the endpoint is explicit about which profile is being addressed, which avoids coupling to server-side `User.activeProfileId`.

## Acceptance criteria

- [x] Active profile's `taskSortOrder` and `showCompletedTasks` persist across reloads (covered by the GET + PUT integration tests and `SettingsForm` mount-fetch test)
- [x] Different profiles see different values after profile switch (covered by `re-fetches and updates display when the active profile changes` test)
- [x] API integration test (18 tests)
- [x] No regression in existing `UserSettings` PUT path (untouched, 2043 / 2043 tests still pass)
- [ ] `TasksSettingsPanel` reflects changes from `TaskSection` immediately — deferred until #333 builds the panel; the endpoint and component contract are ready for it.

## Test plan

- [x] `pnpm test` — 2043 / 2043 (133 files)
- [x] `pnpm check-types` — clean
- [x] `pnpm lint:fix` — no new warnings or errors
- [ ] Manual dev-server smoke (toggle, reload, profile-switch) — requires a real DB / OAuth, **deferred** to the merge-readiness check on a local dev box.

## What's deliberately out of scope

- `TasksSettingsPanel` (#333) — sibling sub-issue.
- Wiring `theme`, `language`, `enableNotifications`, `notificationTime`, `defaultTaskListId` into UI surfaces — the endpoint accepts them, but no UI uses them yet (covered by the #328 cluster).
- Promoting `User.activeProfileId` to a server-side source of truth — out of scope for this issue.

Closes #334

🤖 Generated with [Claude Code](https://claude.com/claude-code)
