### PR TITLE
fix(settings): rollback only updated keys to preserve concurrent PUTs (#363)

### DIFF
--- a/src/components/settings/__tests__/settings-form.test.tsx
+++ b/src/components/settings/__tests__/settings-form.test.tsx
@@ -363,3 +363,156 @@ describe("SettingsForm — Tasks settings wiring (#334)", () => {
     );
   });
 });
+
+/**
+ * Tests for SettingsForm optimistic-update rollback semantics (#363).
+ *
+ * The rollback path must restore the pre-call value of *only* the fields
+ * being updated, read from the truly-current state via the functional
+ * setter — not a stale closure of the entire settings object. Without
+ * this, an overlapping successful PUT to a different key loses its
+ * optimistic state when an earlier PUT to a different key fails.
+ */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("SettingsForm — updateSettings rollback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockActiveProfile(ACTIVE_PROFILE_ID);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("rolls back to the pre-call value when a single PUT fails", async () => {
+    const user = userEvent.setup();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url: string) => {
+        if (typeof url === "string" && url.startsWith("/api/profiles/")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              taskSortOrder: "dueDate",
+              showCompletedTasks: false,
+            }),
+          } as unknown as Response);
+        }
+        return Promise.resolve({ ok: false } as Response);
+      })
+    );
+
+    renderSettings();
+
+    const lightRadio = screen.getByLabelText(/^light$/i);
+    const darkRadio = screen.getByLabelText(/^dark$/i);
+    expect(lightRadio).toBeChecked();
+
+    await user.click(darkRadio);
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Failed to save settings");
+    });
+
+    expect(lightRadio).toBeChecked();
+    expect(darkRadio).not.toBeChecked();
+  });
+
+  it("preserves a concurrent successful PUT when an earlier PUT fails", async () => {
+    const user = userEvent.setup();
+    const first = deferred<Response>();
+    const second = deferred<Response>();
+    let userSettingsCallIndex = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url: string) => {
+        // The profile-settings GET fires on mount; let it resolve immediately
+        // so the form is fully wired before we click. Only the two /api/settings
+        // PUTs are the ones under test.
+        if (typeof url === "string" && url.startsWith("/api/profiles/")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              taskSortOrder: "dueDate",
+              showCompletedTasks: false,
+            }),
+          } as unknown as Response);
+        }
+        userSettingsCallIndex += 1;
+        return userSettingsCallIndex === 1 ? first.promise : second.promise;
+      })
+    );
+
+    renderSettings();
+
+    const lightRadio = screen.getByLabelText(/^light$/i);
+    const darkRadio = screen.getByLabelText(/^dark$/i);
+    const twelveHourRadio = screen.getByLabelText(/12-hour/i);
+    const twentyFourHourRadio = screen.getByLabelText(/24-hour/i);
+
+    await user.click(darkRadio);
+    await user.click(twentyFourHourRadio);
+
+    expect(darkRadio).toBeChecked();
+    expect(twentyFourHourRadio).toBeChecked();
+
+    second.resolve({ ok: true } as Response);
+    first.reject(new Error("network failure"));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Failed to save settings");
+    });
+
+    // Theme reverts (its PUT failed)…
+    expect(lightRadio).toBeChecked();
+    expect(darkRadio).not.toBeChecked();
+    // …but the time-format change must NOT be wiped by the failed theme PUT's
+    // rollback — its own PUT succeeded.
+    expect(twentyFourHourRadio).toBeChecked();
+    expect(twelveHourRadio).not.toBeChecked();
+  });
+
+  it("does not roll back when the PUT succeeds", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn((url: string) => {
+      if (typeof url === "string" && url.startsWith("/api/profiles/")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            taskSortOrder: "dueDate",
+            showCompletedTasks: false,
+          }),
+        } as unknown as Response);
+      }
+      return Promise.resolve({ ok: true } as Response);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderSettings();
+
+    const darkRadio = screen.getByLabelText(/^dark$/i);
+    await user.click(darkRadio);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/settings",
+        expect.objectContaining({
+          method: "PUT",
+          body: JSON.stringify({ theme: "dark" }),
+        })
+      );
+    });
+
+    expect(darkRadio).toBeChecked();
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/settings/settings-form.tsx
+++ b/src/components/settings/settings-form.tsx
@@ -123,6 +123,9 @@ export function SettingsForm({
     // to other keys is preserved (#363).
     let previousPartial: Partial<UserSettingsData> | undefined;
     setSettings((curr) => {
+      // The cast is sound because `Object.keys(partial)` is bounded by
+      // `partial`'s `Partial<UserSettingsData>` type — no extraneous keys
+      // can enter the snapshot.
       previousPartial = Object.fromEntries(
         (Object.keys(partial) as Array<keyof UserSettingsData>).map((key) => [
           key,

--- a/src/components/settings/settings-form.tsx
+++ b/src/components/settings/settings-form.tsx
@@ -117,8 +117,20 @@ export function SettingsForm({
   }, [activeProfileId]);
 
   const updateSettings = async (partial: Partial<UserSettingsData>) => {
-    const updated = { ...settings, ...partial };
-    setSettings(updated);
+    // Capture the pre-call value of *only* the keys we're about to overwrite,
+    // read from the functional setter's current state (not a stale closure).
+    // On rollback, merge those keys back so any concurrent successful PUT
+    // to other keys is preserved (#363).
+    let previousPartial: Partial<UserSettingsData> | undefined;
+    setSettings((curr) => {
+      previousPartial = Object.fromEntries(
+        (Object.keys(partial) as Array<keyof UserSettingsData>).map((key) => [
+          key,
+          curr[key],
+        ])
+      ) as Partial<UserSettingsData>;
+      return { ...curr, ...partial };
+    });
 
     try {
       const response = await fetch("/api/settings", {
@@ -137,7 +149,10 @@ export function SettingsForm({
       emitUserSettingsChange(partial);
     } catch {
       toast.error("Failed to save settings");
-      setSettings(settings);
+      const revert = previousPartial;
+      if (revert) {
+        setSettings((curr) => ({ ...curr, ...revert }));
+      }
     }
   };
 


### PR DESCRIPTION
## Summary

- Replace closure-snapshot rollback in `SettingsForm.updateSettings` with a partial-key revert sourced from the truly-current state via the functional setter — so an overlapping successful PUT to a different field is no longer wiped out when an earlier PUT fails.
- New `settings-form.test.tsx` reproduces the bug (theme PUT fails while timeFormat PUT succeeds) and pins the fix.
- Scoped: `updateTaskSettings` is introduced by PR #362 (not yet on `main`) and has the same shape — best fixed inside #362's review or as an immediate follow-up after it lands.

## Plan

No prior plan in `.claude/plans/`. Issue body laid out the repro and acceptance criteria; this PR implements the *partial-merge* variant of the proposed fix so the second acceptance criterion (concurrent successful PUT preserved) actually holds — the literal "snapshot the whole settings object" variant from the issue still wipes the concurrent change.

Project: https://github.com/users/BenSeymourODB/projects/1

## Test plan

- [x] `pnpm test:run src/components/settings/__tests__/settings-form.test.tsx` — three new specs cover: single-PUT rollback, overlapping-PUTs preservation (the bug under fix), and the no-rollback-on-success sanity check.
- [x] `pnpm test:run` — full suite, 2022 tests passing.
- [x] `pnpm lint:fix && pnpm format:fix && pnpm check-types` — clean.

## Notes for the reviewer

- Project board `Status` could not be flipped from this session (no GraphQL/projects MCP tool available); please update manually if you rely on board state.
- A follow-up issue (or a quick PR-#362 review comment) should apply the same `setSettings((curr) => { previousPartial = ...; return ... })` pattern to `updateTaskSettings` when it lands.

Closes #363

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014eSrseECt2QtEyWXFhZxta)_