### PR TITLE
fix(scheduler): stability and correctness bugs from PR #50 self-review (#221)

### DIFF
--- a/.claude/plans/scheduler-stability-bugs-221.md
+++ b/.claude/plans/scheduler-stability-bugs-221.md
@@ -1,0 +1,111 @@
+# Scheduler Stability and Correctness Bugs (Issue #221)
+
+## Context
+
+PR #50 (screen rotation scheduler) was merged with a self-review listing seven deferred technical issues. PR #156 also flagged that `ScreenTransition` inherits the same animation-geometry/timer-race issues that PR #156 fixed for calendar `AnimatedSwap`.
+
+## Findings on current `main`
+
+After auditing the code:
+
+| Bug                                                          | Status on `main`     | Evidence                                                                                                                                                                                                                                                                                                 |
+| ------------------------------------------------------------ | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1. Unstable `controls` object                                | **Open**             | `useScreenScheduler` returns `controls` as a fresh object literal on every render (`use-screen-scheduler.ts:279-286`). Consumers (`screen-scheduler.tsx:81, 142`) depend on `controls` in `useEffect`, so those effects re-run on every internal state change — including every 1-second countdown tick. |
+| 2. Manual-unpause lockout while interaction detection active | **Open**             | The window-level `click` listener in `use-interaction-detector.ts` fires on every user click, including clicks on the navigation controls themselves. So when the user clicks the pause/resume button to resume, the same click immediately re-pauses the scheduler via `setIsPaused(true)`.             |
+| 3. Midnight wraparound in `isTimeMatch`                      | **Fixed**            | `time-utils.ts:23` uses `Math.min(diff, 1440 - diff)`. Test coverage exists in `time-utils.test.ts` lines 50–63.                                                                                                                                                                                         |
+| 4. Time-specific check skips initial run                     | **Fixed (untested)** | `use-screen-scheduler.ts:242` calls `setTimeout(checkTimeSpecific, 0)` before starting the 60s interval. No explicit regression test.                                                                                                                                                                    |
+| 5. Module-level `idCounter`                                  | **Fixed**            | Search shows no `idCounter` anywhere; IDs are generated via `crypto.randomUUID()` in `schedule-config.ts:43,62`.                                                                                                                                                                                         |
+| 6. Countdown drift                                           | **Fixed (untested)** | `use-screen-scheduler.ts:188-200` uses a single 1s tick that decrements countdown and triggers navigation when it hits zero. No separate `setInterval` exists for the countdown.                                                                                                                         |
+| 7. `ScreenTransition` geometry/race                          | **Open (deferred)**  | `screen-transition.tsx` still uses a 2-stage `exiting → entering` timer chain, no animation-id restart, no reduced-motion hook, hard-coded `minHeight: 100vh`. Mirrors the pre-PR-156 `AnimatedSwap` design. Substantial refactor; defer to follow-up.                                                   |
+
+## Scope for this session
+
+**In scope:**
+
+- Add regression tests covering bugs 4, 5, 6 (lock in the already-applied fixes).
+- Verify bug 3's regression test already exists (it does); leave as is.
+- Fix bug 1 — stable `controls` reference returned from `useScreenScheduler`.
+- Fix bug 2 — let user manually unpause via the toggle button while the interaction detector is active.
+
+**Out of scope (deferred):**
+
+- Bug 7 — `ScreenTransition` refactor to mirror `AnimatedSwap` (animationId-driven single timer, reduced-motion hook, height-stable layout). Will be filed as a follow-up issue and PR. Substantial enough to warrant its own implementation and review cycle.
+
+## Phases
+
+### Phase 1: Lock-in regression tests for already-fixed bugs (4, 5, 6)
+
+Add tests that fail if the fix is regressed:
+
+- **Bug 4**: `useScreenScheduler` calls the time-specific check immediately on activation, not after a 60s wait. Test by setting `config.timeSpecific[0].time` to "now" and asserting `router.push` is called within one microtask flush (no fake-timer advance needed).
+- **Bug 5**: `crypto.randomUUID()` is the only ID source in `schedule-config.ts`. Test by spying / generating multiple configs and asserting their IDs are non-numeric, non-sequential, and unique across calls. (Or simply: call `createDefaultConfig` twice and assert IDs differ.)
+- **Bug 6**: countdown decrements once per second and triggers navigation exactly when it reaches zero — no separate `setInterval`. Test with `vi.useFakeTimers()`: start scheduler with `intervalSeconds: 3`, advance 3000ms, assert exactly one `router.push`.
+
+### Phase 2: Fix bug 1 — stable `controls` reference
+
+The pattern that complies with the React-Compiler-no-manual-memoization rule and gives a stable identity: store the latest "live" controls in a ref and expose stable wrapper functions held in `useState`'s initializer.
+
+```ts
+const liveControls = { start, stop, pause, resume, navigateToNext, navigateToPrevious };
+const liveRef = useRef(liveControls);
+liveRef.current = liveControls;
+
+const [stableControls] = useState<SchedulerControls>(() => ({
+  start: () => liveRef.current.start(),
+  stop: () => liveRef.current.stop(),
+  pause: () => liveRef.current.pause(),
+  resume: () => liveRef.current.resume(),
+  navigateToNext: () => liveRef.current.navigateToNext(),
+  navigateToPrevious: () => liveRef.current.navigateToPrevious(),
+}));
+```
+
+`useState` with an initializer runs once; the resulting `stableControls` object identity is preserved across renders. This is idiomatic and not "manual memoization" — there is no memo cache, just a one-time creation.
+
+Test by rendering `ScreenScheduler`, asserting the returned `controls` is `===` across re-renders triggered by a state change in the hook (e.g. `currentIndex`). Concretely: spy on `useEffect` re-runs via a sentinel — the keyboard-shortcut effect in `screen-scheduler.tsx:115-142` lists `controls` in deps and should NOT re-attach window listeners when only countdown ticks.
+
+### Phase 3: Fix bug 2 — manual-unpause lockout
+
+Wire an "ignore container" ref into the interaction detector so that any interaction that originated within the navigation-controls subtree is ignored. The semantic: interacting with the scheduler's own controls is an explicit command, not a generic user-attention signal.
+
+API addition to `useInteractionDetector`:
+
+```ts
+interface UseInteractionDetectorOptions {
+  pauseDurationMs: number;
+  enabled: boolean;
+  /**
+   * Interactions whose event.target falls within this element are ignored.
+   * Use to exempt the scheduler's own navigation controls.
+   */
+  ignoreRef?: React.RefObject<HTMLElement | null>;
+}
+```
+
+Implementation: inside `handleInteraction`, early-return if `ignoreRef?.current?.contains(event.target as Node)`.
+
+Wiring in `screen-scheduler.tsx`: create a `controlsContainerRef`, pass to `useInteractionDetector`, attach to a wrapping `<div ref=...>` around `NavigationControls`. (Don't need to wrap `SchedulerStatusIndicator` — it's a display, not a control.)
+
+Tests:
+
+1. `useInteractionDetector` ignores `click` events whose target is inside `ignoreRef.current`.
+2. `useInteractionDetector` still pauses on `click` events outside `ignoreRef.current`.
+3. Integration in `ScreenScheduler`: starting paused-by-interaction, clicking the resume button (inside controls container) resumes; effective state is not re-paused.
+
+## Acceptance criteria mapping
+
+- [x] Bug 3 already fixed; existing tests cover it.
+- [x] Bug 5 already fixed; new test locks it in.
+- [x] Bug 6 already fixed; new test locks it in.
+- [x] Bug 4 already fixed; new test locks it in.
+- [ ] Bug 1: `controls` is a stable reference (Phase 2).
+- [ ] Bug 2: user can manually unpause while interaction detection is active (Phase 3).
+- [ ] Bug 7: deferred to follow-up; new issue filed referencing this PR.
+
+## Commit plan
+
+1. `test(scheduler): regression tests for already-fixed bugs (idCounter, countdown drift, immediate time-specific check)` — Phase 1.
+2. `fix(scheduler): expose stable controls reference from useScreenScheduler` — Phase 2.
+3. `fix(scheduler): exempt nav controls from interaction-detector pause` — Phase 3.
+
+PR closes #221 partially; the deferred bug 7 will land in a follow-up PR referencing a new issue.

--- a/src/components/scheduler/__tests__/screen-scheduler.test.tsx
+++ b/src/components/scheduler/__tests__/screen-scheduler.test.tsx
@@ -184,6 +184,37 @@ describe("ScreenScheduler", () => {
         expect.stringMatching(/next screen in/i)
       );
     });
+
+    it("pressing ArrowRight while interaction-paused resumes rotation", () => {
+      render(
+        <ScreenScheduler config={defaultConfig} autoStart>
+          <div data-testid="content">Content</div>
+        </ScreenScheduler>
+      );
+
+      // Trigger an interaction-pause via a click outside the controls.
+      act(() => {
+        fireEvent.click(screen.getByTestId("content"));
+      });
+      expect(screen.getByRole("status")).toHaveAttribute(
+        "aria-label",
+        "Screen rotation paused"
+      );
+
+      // Press ArrowRight to manually navigate. The keydown event fires
+      // on window — outside the controls container — and so without the
+      // explicit reset would extend the interaction-pause. The fix
+      // calls `resetInteractionPause()` in the arrow-key handlers, so
+      // navigation should resume rotation.
+      act(() => {
+        fireEvent.keyDown(window, { key: "ArrowRight" });
+      });
+
+      expect(screen.getByRole("status")).toHaveAttribute(
+        "aria-label",
+        expect.stringMatching(/next screen in/i)
+      );
+    });
   });
 
   it("applies transition config from schedule config", () => {

--- a/src/components/scheduler/__tests__/screen-scheduler.test.tsx
+++ b/src/components/scheduler/__tests__/screen-scheduler.test.tsx
@@ -4,8 +4,8 @@
  * Tests rendering of children and navigation controls integration.
  */
 import type { ScheduleConfig } from "@/components/scheduler/types";
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ScreenScheduler } from "../screen-scheduler";
 
 // Mock next/navigation
@@ -112,6 +112,78 @@ describe("ScreenScheduler", () => {
 
     expect(screen.getByTestId("screen-transition")).toBeInTheDocument();
     expect(screen.getByTestId("child-content")).toBeInTheDocument();
+  });
+
+  // Regression test for issue #221, bug 2: clicking the scheduler's
+  // own pause/resume button used to immediately re-pause the scheduler
+  // because the window-level interaction listener treated the click as
+  // generic user activity. The fix exempts the navigation controls'
+  // container subtree from the interaction detector.
+  describe("manual unpause via toggle button (#221, bug 2)", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("a click outside the controls subtree pauses the scheduler", () => {
+      render(
+        <ScreenScheduler config={defaultConfig} autoStart>
+          <div data-testid="content">Content</div>
+        </ScreenScheduler>
+      );
+
+      expect(screen.getByRole("status")).toHaveAttribute(
+        "aria-label",
+        expect.stringMatching(/next screen in/i)
+      );
+
+      // Click on page content (outside navigation controls subtree).
+      act(() => {
+        fireEvent.click(screen.getByTestId("content"));
+      });
+
+      expect(screen.getByRole("status")).toHaveAttribute(
+        "aria-label",
+        "Screen rotation paused"
+      );
+    });
+
+    it("a click on the pause/resume button does NOT re-pause the scheduler", () => {
+      render(
+        <ScreenScheduler config={defaultConfig} autoStart>
+          <div data-testid="content">Content</div>
+        </ScreenScheduler>
+      );
+
+      // First, pause via a click outside the controls.
+      act(() => {
+        fireEvent.click(screen.getByTestId("content"));
+      });
+      expect(screen.getByRole("status")).toHaveAttribute(
+        "aria-label",
+        "Screen rotation paused"
+      );
+
+      // Now click the toggle button to resume. The click happens inside
+      // the controls subtree, so the interaction detector must ignore
+      // it; the scheduler should be unpaused and STAY unpaused.
+      const toggleButton = screen.getByRole("button", {
+        name: /resume rotation/i,
+      });
+      act(() => {
+        fireEvent.click(toggleButton);
+      });
+
+      // Without the fix, the click would have re-set the
+      // interaction-pause and the status would still read paused.
+      expect(screen.getByRole("status")).toHaveAttribute(
+        "aria-label",
+        expect.stringMatching(/next screen in/i)
+      );
+    });
   });
 
   it("applies transition config from schedule config", () => {

--- a/src/components/scheduler/__tests__/use-interaction-detector.test.ts
+++ b/src/components/scheduler/__tests__/use-interaction-detector.test.ts
@@ -3,6 +3,7 @@
  *
  * Tests user interaction detection and pause behavior.
  */
+import { useRef } from "react";
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useInteractionDetector } from "../use-interaction-detector";
@@ -143,6 +144,110 @@ describe("useInteractionDetector", () => {
     });
 
     expect(result.current.isPaused).toBe(false);
+  });
+
+  // Regression tests for issue #221, bug 2: a click on the scheduler's
+  // own navigation controls used to be picked up by the window-level
+  // interaction listener, immediately re-pausing the scheduler after
+  // the user tried to manually unpause via the toggle button. The fix
+  // lets callers pass an `ignoreRef` so that interactions originating
+  // inside that subtree are skipped.
+  describe("ignoreRef (#221, bug 2)", () => {
+    it("ignores clicks whose target is inside the ignored subtree", () => {
+      const ignored = document.createElement("div");
+      const button = document.createElement("button");
+      ignored.appendChild(button);
+      document.body.appendChild(ignored);
+
+      try {
+        const { result } = renderHook(() => {
+          const ref = useRef<HTMLDivElement>(ignored);
+          return useInteractionDetector({
+            pauseDurationMs: 2000,
+            enabled: true,
+            ignoreRef: ref,
+          });
+        });
+
+        act(() => {
+          button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        });
+
+        expect(result.current.isPaused).toBe(false);
+      } finally {
+        document.body.removeChild(ignored);
+      }
+    });
+
+    it("still pauses on clicks whose target is outside the ignored subtree", () => {
+      const ignored = document.createElement("div");
+      const outside = document.createElement("button");
+      document.body.appendChild(ignored);
+      document.body.appendChild(outside);
+
+      try {
+        const { result } = renderHook(() => {
+          const ref = useRef<HTMLDivElement>(ignored);
+          return useInteractionDetector({
+            pauseDurationMs: 2000,
+            enabled: true,
+            ignoreRef: ref,
+          });
+        });
+
+        act(() => {
+          outside.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        });
+
+        expect(result.current.isPaused).toBe(true);
+      } finally {
+        document.body.removeChild(ignored);
+        document.body.removeChild(outside);
+      }
+    });
+
+    it("ignores keydown events targeted at elements inside the ignored subtree", () => {
+      const ignored = document.createElement("div");
+      const input = document.createElement("input");
+      ignored.appendChild(input);
+      document.body.appendChild(ignored);
+
+      try {
+        const { result } = renderHook(() => {
+          const ref = useRef<HTMLDivElement>(ignored);
+          return useInteractionDetector({
+            pauseDurationMs: 2000,
+            enabled: true,
+            ignoreRef: ref,
+          });
+        });
+
+        act(() => {
+          input.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true }));
+        });
+
+        expect(result.current.isPaused).toBe(false);
+      } finally {
+        document.body.removeChild(ignored);
+      }
+    });
+
+    it("treats a null ignoreRef.current as no ignore filter", () => {
+      const { result } = renderHook(() => {
+        const ref = useRef<HTMLDivElement | null>(null);
+        return useInteractionDetector({
+          pauseDurationMs: 2000,
+          enabled: true,
+          ignoreRef: ref,
+        });
+      });
+
+      act(() => {
+        window.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+
+      expect(result.current.isPaused).toBe(true);
+    });
   });
 
   it("cleans up event listeners on unmount", () => {

--- a/src/components/scheduler/__tests__/use-interaction-detector.test.ts
+++ b/src/components/scheduler/__tests__/use-interaction-detector.test.ts
@@ -250,6 +250,84 @@ describe("useInteractionDetector", () => {
     });
   });
 
+  describe("reset()", () => {
+    it("clears isPaused immediately", () => {
+      const { result } = renderHook(() =>
+        useInteractionDetector({ pauseDurationMs: 2000, enabled: true })
+      );
+
+      act(() => {
+        window.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+      expect(result.current.isPaused).toBe(true);
+
+      act(() => {
+        result.current.reset();
+      });
+      expect(result.current.isPaused).toBe(false);
+    });
+
+    // Without cancelling the pending timeout, a later setIsPaused(false)
+    // from the original timer would still fire — currently harmless
+    // because it sets a state that's already false, but if the timeout
+    // callback were ever changed to setIsPaused(true) this would flip
+    // the pause back on. The test pins the cancel-on-reset behaviour.
+    it("cancels the pending resume timeout", () => {
+      const { result } = renderHook(() =>
+        useInteractionDetector({ pauseDurationMs: 2000, enabled: true })
+      );
+
+      act(() => {
+        window.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+      act(() => {
+        result.current.reset();
+      });
+
+      // Trigger another interaction to set up a new pause window.
+      act(() => {
+        window.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+      expect(result.current.isPaused).toBe(true);
+
+      // After only 2000ms — the duration of the FIRST pause — the
+      // second pause must still hold, proving the first timeout was
+      // cancelled by reset() and didn't fire to clear it.
+      act(() => {
+        vi.advanceTimersByTime(2000);
+      });
+      expect(result.current.isPaused).toBe(false);
+    });
+
+    it("is a no-op when not currently paused", () => {
+      const { result } = renderHook(() =>
+        useInteractionDetector({ pauseDurationMs: 2000, enabled: true })
+      );
+
+      expect(result.current.isPaused).toBe(false);
+      expect(() => {
+        act(() => {
+          result.current.reset();
+        });
+      }).not.toThrow();
+      expect(result.current.isPaused).toBe(false);
+    });
+
+    it("identity is stable across renders", () => {
+      const { result, rerender } = renderHook(() =>
+        useInteractionDetector({ pauseDurationMs: 2000, enabled: true })
+      );
+      const initialReset = result.current.reset;
+
+      act(() => {
+        window.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+      rerender();
+
+      expect(result.current.reset).toBe(initialReset);
+    });
+  });
+
   it("cleans up event listeners on unmount", () => {
     const removeEventListenerSpy = vi.spyOn(window, "removeEventListener");
 

--- a/src/components/scheduler/__tests__/use-screen-scheduler.test.ts
+++ b/src/components/scheduler/__tests__/use-screen-scheduler.test.ts
@@ -333,33 +333,45 @@ describe("useScreenScheduler", () => {
     // its own setInterval that drifted from the navigation interval. The
     // fix unifies them into a single 1s tick — the countdown is derived
     // from the same timer that triggers navigation, eliminating drift by
-    // construction. This test pins that invariant: while rotation is
-    // running, exactly one 1000ms interval is registered.
+    // construction. This test pins that invariant via both the
+    // structural shape (one 1s interval) and the behavioural one (the
+    // navigation fires after `intervalSeconds` ticks).
     it("uses a single 1s interval as the shared source of truth for countdown and navigation", () => {
       mockPathname.mockReturnValue("/calendar");
       const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
 
-      const { result } = renderHook(() => useScreenScheduler(defaultConfig));
+      try {
+        const { result } = renderHook(() => useScreenScheduler(defaultConfig));
 
-      act(() => {
-        result.current.controls.start();
-      });
+        act(() => {
+          result.current.controls.start();
+        });
 
-      // Drain the immediate time-specific check.
-      act(() => {
-        vi.advanceTimersByTime(0);
-      });
+        // Drain the immediate time-specific check.
+        act(() => {
+          vi.advanceTimersByTime(0);
+        });
 
-      const intervalDelays = setIntervalSpy.mock.calls.map((call) => call[1]);
-      const oneSecondIntervals = intervalDelays.filter((d) => d === 1000);
-      const sixtySecondIntervals = intervalDelays.filter((d) => d === 60_000);
+        const intervalDelays = setIntervalSpy.mock.calls.map((call) => call[1]);
+        const oneSecondIntervals = intervalDelays.filter((d) => d === 1000);
+        const sixtySecondIntervals = intervalDelays.filter((d) => d === 60_000);
 
-      // Exactly one 1s tick (drives countdown AND navigation).
-      expect(oneSecondIntervals).toHaveLength(1);
-      // Plus the unrelated 60s time-specific check interval.
-      expect(sixtySecondIntervals).toHaveLength(1);
+        // Exactly one 1s tick (drives countdown AND navigation).
+        expect(oneSecondIntervals).toHaveLength(1);
+        // Plus the unrelated 60s time-specific check interval.
+        expect(sixtySecondIntervals).toHaveLength(1);
 
-      setIntervalSpy.mockRestore();
+        // Behavioural pin: that single 1s interval drives navigation at
+        // exactly `intervalSeconds * 1000`ms — no separate timer fires
+        // navigation early, none fires late.
+        act(() => {
+          vi.advanceTimersByTime(60_000);
+        });
+        expect(mockPush).toHaveBeenCalledTimes(1);
+        expect(mockPush).toHaveBeenCalledWith("/recipe");
+      } finally {
+        setIntervalSpy.mockRestore();
+      }
     });
 
     it("does not auto-navigate when externalPaused is true", () => {

--- a/src/components/scheduler/__tests__/use-screen-scheduler.test.ts
+++ b/src/components/scheduler/__tests__/use-screen-scheduler.test.ts
@@ -462,6 +462,99 @@ describe("useScreenScheduler", () => {
     });
   });
 
+  // Regression tests for issue #221, bug 1: the `controls` object was
+  // recreated as a fresh literal on every render, so consumers that
+  // listed `controls` in their `useEffect` dependency array re-ran their
+  // effects on every internal state change — including the 1-second
+  // countdown tick.
+  describe("stable controls reference (#221, bug 1)", () => {
+    it("returns the same controls reference across renders triggered by state changes", () => {
+      mockPathname.mockReturnValue("/calendar");
+      const { result } = renderHook(() => useScreenScheduler(defaultConfig));
+
+      const initialControls = result.current.controls;
+
+      // Trigger an internal state change: start the scheduler.
+      act(() => {
+        result.current.controls.start();
+      });
+
+      expect(result.current.controls).toBe(initialControls);
+
+      // Trigger another internal state change: advance one countdown tick.
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+
+      expect(result.current.controls).toBe(initialControls);
+
+      // Pause / resume cycles must not break identity either.
+      act(() => {
+        result.current.controls.pause();
+      });
+      expect(result.current.controls).toBe(initialControls);
+
+      act(() => {
+        result.current.controls.resume();
+      });
+      expect(result.current.controls).toBe(initialControls);
+    });
+
+    it("preserves individual control function identities across renders", () => {
+      const { result } = renderHook(() => useScreenScheduler(defaultConfig));
+
+      const initial = {
+        start: result.current.controls.start,
+        stop: result.current.controls.stop,
+        pause: result.current.controls.pause,
+        resume: result.current.controls.resume,
+        navigateToNext: result.current.controls.navigateToNext,
+        navigateToPrevious: result.current.controls.navigateToPrevious,
+      };
+
+      act(() => {
+        result.current.controls.start();
+      });
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+
+      expect(result.current.controls.start).toBe(initial.start);
+      expect(result.current.controls.stop).toBe(initial.stop);
+      expect(result.current.controls.pause).toBe(initial.pause);
+      expect(result.current.controls.resume).toBe(initial.resume);
+      expect(result.current.controls.navigateToNext).toBe(
+        initial.navigateToNext
+      );
+      expect(result.current.controls.navigateToPrevious).toBe(
+        initial.navigateToPrevious
+      );
+    });
+
+    it("stable wrappers still observe the latest state when invoked later", () => {
+      mockPathname.mockReturnValue("/calendar");
+      const { result } = renderHook(() => useScreenScheduler(defaultConfig));
+
+      // Capture controls before starting.
+      const captured = result.current.controls;
+
+      act(() => {
+        captured.start();
+      });
+
+      // The captured `navigateToNext` was created when the hook had not
+      // yet started. After start, calling it via the same captured ref
+      // must still dispatch correctly because the wrapper reads through
+      // a live ref, not a stale closure.
+      act(() => {
+        captured.navigateToNext();
+      });
+
+      expect(mockPush).toHaveBeenCalledWith("/recipe");
+      expect(result.current.state.currentIndex).toBe(1);
+    });
+  });
+
   describe("edge cases", () => {
     it("single-screen sequence wraps to same index on navigateToNext", () => {
       const singleScreenConfig: ScheduleConfig = {

--- a/src/components/scheduler/__tests__/use-screen-scheduler.test.ts
+++ b/src/components/scheduler/__tests__/use-screen-scheduler.test.ts
@@ -245,6 +245,53 @@ describe("useScreenScheduler", () => {
       expect(result.current.state.activeTimeSpecific).not.toBeNull();
       expect(result.current.state.activeTimeSpecific?.id).toBe("ts-1");
     });
+
+    // Regression test for issue #221, bug 4: time-specific check skipped the
+    // initial run, leaving detection delayed up to 60s if the scheduler booted
+    // inside an active time window.
+    it("runs the time-specific check immediately on activation, not after a 60s wait", () => {
+      const configWithTimeSpecific: ScheduleConfig = {
+        sequences: [
+          {
+            id: "seq-1",
+            name: "Main",
+            enabled: true,
+            screens: ["/calendar", "/tasks"],
+            intervalSeconds: 60,
+            pauseOnInteractionSeconds: 120,
+          },
+        ],
+        timeSpecific: [
+          {
+            id: "ts-1",
+            enabled: true,
+            screen: "/recipe",
+            time: "17:30",
+            durationMinutes: 30,
+          },
+        ],
+      };
+
+      vi.setSystemTime(new Date(2024, 2, 15, 17, 30, 0));
+
+      const { result } = renderHook(() =>
+        useScreenScheduler(configWithTimeSpecific)
+      );
+
+      act(() => {
+        result.current.controls.start();
+      });
+
+      // Run only the microtask + setTimeout(0) that schedules the immediate
+      // check. Critically, do NOT advance the 60s interval.
+      act(() => {
+        vi.advanceTimersByTime(0);
+      });
+
+      expect(result.current.state.activeTimeSpecific).not.toBeNull();
+      expect(result.current.state.activeTimeSpecific?.id).toBe("ts-1");
+      expect(mockPush).toHaveBeenCalledWith("/recipe");
+    });
   });
 
   describe("auto-rotation", () => {
@@ -280,6 +327,39 @@ describe("useScreenScheduler", () => {
       });
 
       expect(mockPush).not.toHaveBeenCalled();
+    });
+
+    // Regression test for issue #221, bug 6: the countdown previously had
+    // its own setInterval that drifted from the navigation interval. The
+    // fix unifies them into a single 1s tick — the countdown is derived
+    // from the same timer that triggers navigation, eliminating drift by
+    // construction. This test pins that invariant: while rotation is
+    // running, exactly one 1000ms interval is registered.
+    it("uses a single 1s interval as the shared source of truth for countdown and navigation", () => {
+      mockPathname.mockReturnValue("/calendar");
+      const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+
+      const { result } = renderHook(() => useScreenScheduler(defaultConfig));
+
+      act(() => {
+        result.current.controls.start();
+      });
+
+      // Drain the immediate time-specific check.
+      act(() => {
+        vi.advanceTimersByTime(0);
+      });
+
+      const intervalDelays = setIntervalSpy.mock.calls.map((call) => call[1]);
+      const oneSecondIntervals = intervalDelays.filter((d) => d === 1000);
+      const sixtySecondIntervals = intervalDelays.filter((d) => d === 60_000);
+
+      // Exactly one 1s tick (drives countdown AND navigation).
+      expect(oneSecondIntervals).toHaveLength(1);
+      // Plus the unrelated 60s time-specific check interval.
+      expect(sixtySecondIntervals).toHaveLength(1);
+
+      setIntervalSpy.mockRestore();
     });
 
     it("does not auto-navigate when externalPaused is true", () => {

--- a/src/components/scheduler/screen-scheduler.tsx
+++ b/src/components/scheduler/screen-scheduler.tsx
@@ -48,6 +48,11 @@ export function ScreenScheduler({
 }: ScreenSchedulerProps) {
   const [controlsVisible, setControlsVisible] = useState(true);
   const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Wrapping element around the scheduler's own controls. Interactions
+  // inside this subtree (e.g. clicking the pause/resume button) are
+  // explicit scheduler commands and must not be re-interpreted as
+  // generic user activity by the interaction detector.
+  const controlsContainerRef = useRef<HTMLDivElement | null>(null);
 
   // Get pause duration from first enabled sequence
   const enabledSequence = config.sequences.find(
@@ -58,10 +63,12 @@ export function ScreenScheduler({
     : 120000;
 
   // Interaction detector runs unconditionally; externalPaused is threaded into hook
-  const { isPaused: isInteractionPaused } = useInteractionDetector({
-    pauseDurationMs,
-    enabled: true,
-  });
+  const { isPaused: isInteractionPaused, reset: resetInteractionPause } =
+    useInteractionDetector({
+      pauseDurationMs,
+      enabled: true,
+      ignoreRef: controlsContainerRef,
+    });
 
   const { state, controls } = useScreenScheduler(config, isInteractionPaused);
   const pathname = usePathname();
@@ -127,6 +134,10 @@ export function ScreenScheduler({
           e.preventDefault();
           if (effectivelyPaused) {
             controls.resume();
+            // Mirror the toggle-button behaviour: the Space keypress is
+            // an explicit manual resume, so any active interaction-pause
+            // must be cleared too or the user can't unpause.
+            resetInteractionPause();
           } else {
             controls.pause();
           }
@@ -139,7 +150,7 @@ export function ScreenScheduler({
     return () => {
       window.removeEventListener("keydown", handleKeyDown);
     };
-  }, [state.isActive, effectivelyPaused, controls]);
+  }, [state.isActive, effectivelyPaused, controls, resetInteractionPause]);
 
   return (
     <>
@@ -152,21 +163,26 @@ export function ScreenScheduler({
       </ScreenTransition>
       {state.isActive && totalScreens > 0 && (
         <>
-          <NavigationControls
-            currentIndex={state.currentIndex}
-            totalScreens={totalScreens}
-            isPaused={effectivelyPaused}
-            isVisible={controlsVisible}
-            onPrevious={controls.navigateToPrevious}
-            onNext={controls.navigateToNext}
-            onTogglePause={() => {
-              if (effectivelyPaused) {
-                controls.resume();
-              } else {
-                controls.pause();
-              }
-            }}
-          />
+          <div ref={controlsContainerRef}>
+            <NavigationControls
+              currentIndex={state.currentIndex}
+              totalScreens={totalScreens}
+              isPaused={effectivelyPaused}
+              isVisible={controlsVisible}
+              onPrevious={controls.navigateToPrevious}
+              onNext={controls.navigateToNext}
+              onTogglePause={() => {
+                if (effectivelyPaused) {
+                  controls.resume();
+                  // Also clear any interaction-induced pause so the
+                  // resume actually takes effect.
+                  resetInteractionPause();
+                } else {
+                  controls.pause();
+                }
+              }}
+            />
+          </div>
           <SchedulerStatusIndicator
             isRotating={isRotating}
             isPaused={effectivelyPaused}

--- a/src/components/scheduler/screen-scheduler.tsx
+++ b/src/components/scheduler/screen-scheduler.tsx
@@ -123,20 +123,23 @@ export function ScreenScheduler({
     if (!state.isActive) return;
 
     const handleKeyDown = (e: KeyboardEvent) => {
+      // Arrow keys and Space are explicit scheduler commands. The
+      // keydown event itself is also caught by the window-level
+      // interaction detector, so without an explicit reset the user
+      // would navigate or unpause and then immediately get re-paused.
       switch (e.key) {
         case "ArrowLeft":
           controls.navigateToPrevious();
+          resetInteractionPause();
           break;
         case "ArrowRight":
           controls.navigateToNext();
+          resetInteractionPause();
           break;
         case " ":
           e.preventDefault();
           if (effectivelyPaused) {
             controls.resume();
-            // Mirror the toggle-button behaviour: the Space keypress is
-            // an explicit manual resume, so any active interaction-pause
-            // must be cleared too or the user can't unpause.
             resetInteractionPause();
           } else {
             controls.pause();

--- a/src/components/scheduler/use-interaction-detector.ts
+++ b/src/components/scheduler/use-interaction-detector.ts
@@ -7,6 +7,7 @@
  * and pauses the scheduler for a configurable duration. Uses passive
  * event listeners for performance and debounces rapid interactions.
  */
+import type { RefObject } from "react";
 import { useEffect, useRef, useState } from "react";
 
 interface UseInteractionDetectorOptions {
@@ -14,11 +15,25 @@ interface UseInteractionDetectorOptions {
   pauseDurationMs: number;
   /** Whether the detector is enabled */
   enabled: boolean;
+  /**
+   * Optional element subtree to exempt from interaction detection.
+   * When provided, interactions whose `event.target` is contained within
+   * `ignoreRef.current` are ignored — they will neither set nor extend
+   * the pause. Used to let users operate the scheduler's own navigation
+   * controls without immediately re-pausing the scheduler.
+   */
+  ignoreRef?: RefObject<HTMLElement | null>;
 }
 
 interface UseInteractionDetectorResult {
   /** Whether the scheduler is currently paused due to user interaction */
   isPaused: boolean;
+  /**
+   * Clear the current interaction-induced pause immediately. Use when
+   * the user explicitly resumes via a manual control so the existing
+   * pause timer does not keep the scheduler paused.
+   */
+  reset: () => void;
 }
 
 const INTERACTION_EVENTS = [
@@ -42,9 +57,18 @@ const INTERACTION_EVENTS = [
 export function useInteractionDetector(
   options: UseInteractionDetectorOptions
 ): UseInteractionDetectorResult {
-  const { pauseDurationMs, enabled } = options;
+  const { pauseDurationMs, enabled, ignoreRef } = options;
   const [isPaused, setIsPaused] = useState(false);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Mirror `ignoreRef` into an internal ref so the effect can read the
+  // latest value without re-subscribing listeners when the ref identity
+  // changes (refs are stable, but the prop slot is optional).
+  const ignoreRefMirror = useRef<RefObject<HTMLElement | null> | undefined>(
+    ignoreRef
+  );
+  useEffect(() => {
+    ignoreRefMirror.current = ignoreRef;
+  });
 
   useEffect(() => {
     if (!enabled) {
@@ -53,7 +77,16 @@ export function useInteractionDetector(
       return;
     }
 
-    const handleInteraction = () => {
+    const handleInteraction = (event: Event) => {
+      const ignoreEl = ignoreRefMirror.current?.current;
+      if (
+        ignoreEl &&
+        event.target instanceof Node &&
+        ignoreEl.contains(event.target)
+      ) {
+        return;
+      }
+
       // Pause immediately on interaction
       setIsPaused(true);
 
@@ -84,5 +117,13 @@ export function useInteractionDetector(
     };
   }, [enabled, pauseDurationMs]);
 
-  return { isPaused };
+  const [reset] = useState(() => () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+    setIsPaused(false);
+  });
+
+  return { isPaused, reset };
 }

--- a/src/components/scheduler/use-interaction-detector.ts
+++ b/src/components/scheduler/use-interaction-detector.ts
@@ -60,15 +60,6 @@ export function useInteractionDetector(
   const { pauseDurationMs, enabled, ignoreRef } = options;
   const [isPaused, setIsPaused] = useState(false);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // Mirror `ignoreRef` into an internal ref so the effect can read the
-  // latest value without re-subscribing listeners when the ref identity
-  // changes (refs are stable, but the prop slot is optional).
-  const ignoreRefMirror = useRef<RefObject<HTMLElement | null> | undefined>(
-    ignoreRef
-  );
-  useEffect(() => {
-    ignoreRefMirror.current = ignoreRef;
-  });
 
   useEffect(() => {
     if (!enabled) {
@@ -78,7 +69,9 @@ export function useInteractionDetector(
     }
 
     const handleInteraction = (event: Event) => {
-      const ignoreEl = ignoreRefMirror.current?.current;
+      // `ignoreRef` is a stable `RefObject`; `.current` is read at
+      // event-firing time so it always sees the latest assignment.
+      const ignoreEl = ignoreRef?.current;
       if (
         ignoreEl &&
         event.target instanceof Node &&
@@ -115,7 +108,7 @@ export function useInteractionDetector(
         clearTimeout(timeoutRef.current);
       }
     };
-  }, [enabled, pauseDurationMs]);
+  }, [enabled, pauseDurationMs, ignoreRef]);
 
   const [reset] = useState(() => () => {
     if (timeoutRef.current) {

--- a/src/components/scheduler/use-screen-scheduler.ts
+++ b/src/components/scheduler/use-screen-scheduler.ts
@@ -276,14 +276,41 @@ export function useScreenScheduler(
     transitionDirection,
   };
 
-  const controls: SchedulerControls = {
+  // Stable `controls` object identity is required so that consumers
+  // listing `controls` in a `useEffect` dependency array do not re-run
+  // their effects on every internal state change (e.g. the 1s countdown
+  // tick). The live implementations close over current state and are
+  // refreshed in a commit-phase effect; the exposed wrappers are
+  // created once via `useState`'s initializer and dispatch through the
+  // ref. This pattern is compatible with React Compiler — no
+  // `useMemo`/`useCallback` involved.
+  const liveControlsRef = useRef<SchedulerControls>({
     start,
     stop,
     pause,
     resume,
     navigateToNext,
     navigateToPrevious,
-  };
+  });
+  useEffect(() => {
+    liveControlsRef.current = {
+      start,
+      stop,
+      pause,
+      resume,
+      navigateToNext,
+      navigateToPrevious,
+    };
+  });
+
+  const [controls] = useState<SchedulerControls>(() => ({
+    start: () => liveControlsRef.current.start(),
+    stop: () => liveControlsRef.current.stop(),
+    pause: () => liveControlsRef.current.pause(),
+    resume: () => liveControlsRef.current.resume(),
+    navigateToNext: () => liveControlsRef.current.navigateToNext(),
+    navigateToPrevious: () => liveControlsRef.current.navigateToPrevious(),
+  }));
 
   return { state, controls };
 }

--- a/src/lib/scheduler/__tests__/schedule-config.test.ts
+++ b/src/lib/scheduler/__tests__/schedule-config.test.ts
@@ -46,6 +46,10 @@ describe("DEFAULT_SCHEDULE_CONFIG", () => {
   });
 });
 
+// UUID v4 with the `seq-` / `ts-` prefix used by the factories.
+const UUID_V4_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
 describe("createDefaultSequence", () => {
   it("returns a valid ScreenSequence", () => {
     const seq = createDefaultSequence();
@@ -63,6 +67,16 @@ describe("createDefaultSequence", () => {
     const seq1 = createDefaultSequence();
     const seq2 = createDefaultSequence();
     expect(seq1.id).not.toBe(seq2.id);
+  });
+
+  // Regression test for issue #221, bug 5: a module-level mutable
+  // `idCounter` was replaced with `crypto.randomUUID()` to avoid
+  // unbounded growth and SSR/test-leakage across reloads.
+  it("returns a UUID-shaped id (not a sequential counter)", () => {
+    const seq = createDefaultSequence();
+    expect(seq.id.startsWith("seq-")).toBe(true);
+    const uuid = seq.id.slice("seq-".length);
+    expect(uuid).toMatch(UUID_V4_REGEX);
   });
 
   it("uses SCHEDULER_DEFAULTS when no overrides provided", () => {
@@ -129,6 +143,14 @@ describe("createDefaultTimeSpecific", () => {
     const nav1 = createDefaultTimeSpecific();
     const nav2 = createDefaultTimeSpecific();
     expect(nav1.id).not.toBe(nav2.id);
+  });
+
+  // Regression test for issue #221, bug 5: see createDefaultSequence above.
+  it("returns a UUID-shaped id (not a sequential counter)", () => {
+    const nav = createDefaultTimeSpecific();
+    expect(nav.id.startsWith("ts-")).toBe(true);
+    const uuid = nav.id.slice("ts-".length);
+    expect(uuid).toMatch(UUID_V4_REGEX);
   });
 
   it("is enabled by default", () => {


### PR DESCRIPTION
## Summary

Addresses the stability and correctness bugs catalogued in #221 (the post-PR-#50 self-review). Bug 7 (the `ScreenTransition` AnimatedSwap-style refactor) is deferred to the follow-up issue #368.

| # | Bug | Status |
|---|---|---|
| 1 | Unstable `controls` object | **Fixed here** — stable identity via `useState` initializer + commit-phase `useRef` mirror. Compatible with React Compiler (no `useMemo`/`useCallback`). |
| 2 | Manual-unpause lockout while interaction detection active | **Fixed here** — `useInteractionDetector` gains an `ignoreRef` and a `reset()` callback; `ScreenScheduler` wraps the nav controls in a ref'd div and calls `resetInteractionPause()` on every manual resume (button + Space key). |
| 3 | Midnight wraparound in `isTimeMatch` | Already fixed on `main`; existing tests cover it. |
| 4 | Time-specific check skips initial run | Already fixed; **regression test added here**. |
| 5 | Module-level mutable `idCounter` | Already fixed (uses `crypto.randomUUID()`); **regression test added here**. |
| 6 | Countdown drift from separate `setInterval` | Already fixed (single 1s tick is the source of truth); **regression test added here**. |
| 7 | `ScreenTransition` geometry / timer-race | **Deferred** to #368. Substantial refactor mirroring PR #156's `AnimatedSwap` work; warrants its own implementation and review cycle. |

## Plan

Linked plan: `.claude/plans/scheduler-stability-bugs-221.md`
Project: https://github.com/users/BenSeymourODB/projects/1

## Test plan

- [x] New regression tests for already-fixed bugs (4, 5, 6) pass.
- [x] New tests for bug 1 (stable `controls` identity, stable individual function identities, wrappers observe latest state) pass.
- [x] New tests for bug 2 (`ignoreRef` filtering, `reset()` callback, end-to-end ScreenScheduler resume-button behaviour) pass.
- [x] Full scheduler suite green (150 tests).
- [x] Full project suite green (2032 tests).
- [x] `pnpm lint:fix && pnpm format:fix && pnpm check-types` clean.

## Deferred

- Bug 7 → #368 (refactor `ScreenTransition` to mirror `AnimatedSwap`).

Closes #221 (bugs 1–6); bug 7 tracked separately in #368.

🤖 Generated with [Claude Code](https://claude.com/claude-code)