### PR TITLE
chore(test): retype Profile fixtures against production types (#280)

### DIFF
--- a/.claude/plans/retype-profile-fixtures-280.md
+++ b/.claude/plans/retype-profile-fixtures-280.md
@@ -1,0 +1,86 @@
+# Retype Profile fixtures (#280)
+
+Tracking issue: https://github.com/BenSeymourODB/next-digital-wall-calendar/issues/280
+
+## Problem
+
+Profile-shaped test fixtures across the codebase are loosely typed (no annotation, or local interface declarations that drift from the canonical types). The canonical fixtures module at `src/app/api/profiles/__tests__/fixtures.ts:9` already calls out:
+
+> Full retype to the generated Prisma `Profile` lives in #280.
+
+There are two canonical `Profile` shapes in the production code, and a fixture's right type depends on what it mocks:
+
+1. **Prisma row** — `import type { Profile } from "@/generated/prisma/client"` — the DB row shape. Used by API route tests that mock `prisma.profile.findFirst/update/...` return values, and by server-side service tests. Includes `pinHash`, `failedPinAttempts`, `pinLockedUntil`, `createdAt: Date`, `updatedAt: Date`, etc.
+2. **UI / API-response** — `import type { Profile } from "@/components/profiles/profile-context"` — the trimmed shape used by client components (no `pinHash`, dates as `string | undefined`). Used by component tests and any test that mocks the `/api/profiles` JSON response.
+
+When a fixture is typed against the production shape, mismatches surface at compile time rather than as silent test drift.
+
+## Scope
+
+### Phase 1 — Canonical fixtures module (high leverage)
+
+`src/app/api/profiles/__tests__/fixtures.ts`:
+
+- Replace the local `Profile`, `ProfileRewardPoints`, `ProfileSettings` interfaces with the generated Prisma types.
+- Adjust `mockAdminProfile.avatar` typing — Prisma's `avatar` field is `Prisma.JsonValue`. Keep the literal object; cast or use `satisfies` so the literal still passes through the JSON shape constraint.
+- Keep field values identical; this is a type-tightening change with zero runtime delta.
+- Delete the "Full retype … lives in #280" comment.
+
+### Phase 2 — UI component fixtures
+
+For each component test using an ad-hoc profile literal, annotate with `import type { Profile } from "@/components/profiles/profile-context"`:
+
+- `src/components/profiles/__tests__/profile-card.test.tsx`
+- `src/components/profiles/__tests__/profile-context.test.tsx`
+- `src/components/profiles/__tests__/profile-grid.test.tsx`
+- `src/components/profiles/__tests__/profile-switcher.test.tsx`
+- `src/components/profiles/__tests__/pin-entry-modal.test.tsx`
+- `src/components/profiles/__tests__/pin-setup-modal.test.tsx`
+- `src/components/profiles/__tests__/pin-settings.test.tsx`
+- `src/components/profiles/__tests__/profile-avatar.test.tsx` (look at what subset its component requires; may be a `Pick<>`)
+- `src/components/profiles/__tests__/profile-form.test.tsx`
+- `src/components/profiles/__tests__/give-points-modal.test.tsx` (already typed — verify)
+- `src/components/tasks/__tests__/profile-scoped-task-list.test.tsx`
+- `src/components/tasks/__tests__/task-assignment-picker.test.tsx` (uses `ProfileInfo` — verify alignment)
+- `src/components/rewards/__tests__/points-context.test.tsx`
+- `src/app/profiles/__tests__/page.test.tsx`
+- `src/app/profiles/[id]/settings/__tests__/page.test.tsx`
+
+Where a test only needs a couple of fields, use `Pick<Profile, …>` rather than forcing the full shape. This documents the test's actual surface area.
+
+### Phase 3 — Prisma-row consumer fixtures
+
+For each API/service test that mocks Prisma directly with an ad-hoc literal, annotate with the generated `Profile` type from `@/generated/prisma/client`. Many already import from `__tests__/fixtures` (covered by Phase 1), but spot-check:
+
+- `src/app/api/profiles/[id]/reset-pin/__tests__/route.test.ts`
+- `src/app/api/profiles/[id]/stats/__tests__/route.test.ts`
+- `src/app/api/profiles/[id]/give-points/__tests__/route.test.ts`
+- `src/app/api/points/award/__tests__/route.test.ts`
+- `src/lib/services/__tests__/admin-verification.test.ts`
+- `src/lib/services/__tests__/task-assignments.test.ts`
+- `src/lib/test-utils/pin-test-helpers.ts` (already partial — `mockPinProfile`)
+
+`pin-test-helpers.ts:mockPinProfile` currently returns an inferred shape. Give it a return type of the generated Prisma `Profile` (so test files using it can rely on full type-safety).
+
+## Out of scope
+
+- No runtime changes. Snapshots untouched.
+- No new tests (the verification IS `pnpm check-types`).
+- E2E test fixtures (`e2e/fixtures/` does not contain profile shapes today — `mock-events.ts`/`google-api-mocks.ts` only).
+- Re-shaping the production `Profile` interfaces themselves.
+
+## Acceptance criteria (from #280)
+
+- [x] All profile fixtures typed against the production `Profile` type
+- [x] `pnpm check-types` passes
+- [x] No runtime test changes (snapshots untouched)
+
+## Verification
+
+```bash
+pnpm check-types
+pnpm test
+pnpm lint:fix && pnpm format:fix
+```
+
+All four must pass. Diff should be type annotations + import reshuffling only — no value changes.

--- a/src/app/api/profiles/__tests__/fixtures.ts
+++ b/src/app/api/profiles/__tests__/fixtures.ts
@@ -1,50 +1,11 @@
 /**
  * Test fixtures for Profile API tests
  */
-import type { Prisma } from "@/generated/prisma/client";
-
-// Define local types for testing (matches Prisma schema). `avatar` is
-// `Prisma.JsonValue` so fixtures pass strict type checks when handed to
-// `vi.mocked(prisma)…mockResolvedValue` calls. Full retype to the
-// generated Prisma `Profile` lives in #280.
-interface Profile {
-  id: string;
-  userId: string;
-  name: string;
-  type: "admin" | "standard";
-  ageGroup: "adult" | "teen" | "child";
-  color: string;
-  avatar: Prisma.JsonValue;
-  pinHash: string | null;
-  pinEnabled: boolean;
-  failedPinAttempts: number;
-  pinLockedUntil: Date | null;
-  isActive: boolean;
-  createdAt: Date;
-  updatedAt: Date;
-}
-
-interface ProfileRewardPoints {
-  id: string;
-  profileId: string;
-  totalPoints: number;
-  currentStreak: number;
-  longestStreak: number;
-  lastActivityDate: Date;
-  updatedAt: Date;
-}
-
-interface ProfileSettings {
-  id: string;
-  profileId: string;
-  defaultTaskListId: string | null;
-  showCompletedTasks: boolean;
-  taskSortOrder: string;
-  theme: string;
-  language: string;
-  enableNotifications: boolean;
-  notificationTime: string | null;
-}
+import type {
+  Profile,
+  ProfileRewardPoints,
+  ProfileSettings,
+} from "@/generated/prisma/client";
 
 export const mockUserId = "test-user-123";
 

--- a/src/app/profiles/[id]/settings/__tests__/page.test.tsx
+++ b/src/app/profiles/[id]/settings/__tests__/page.test.tsx
@@ -1,6 +1,7 @@
 /**
  * Tests for /profiles/[id]/settings page
  */
+import type { Profile } from "@/components/profiles/profile-context";
 import { render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 // Import after mocks
@@ -11,15 +12,15 @@ const mockFetch = vi.fn();
 global.fetch = mockFetch;
 
 // Mock profile data
-const mockAdminProfile = {
+const mockAdminProfile: Profile = {
   id: "profile-admin",
   userId: "user-1",
   name: "Admin User",
-  type: "admin" as const,
-  ageGroup: "adult" as const,
+  type: "admin",
+  ageGroup: "adult",
   color: "#3b82f6",
   avatar: {
-    type: "initials" as const,
+    type: "initials",
     value: "AU",
     backgroundColor: "#3b82f6",
   },
@@ -27,15 +28,15 @@ const mockAdminProfile = {
   isActive: true,
 };
 
-const mockStandardProfile = {
+const mockStandardProfile: Profile = {
   id: "profile-standard",
   userId: "user-1",
   name: "Child User",
-  type: "standard" as const,
-  ageGroup: "child" as const,
+  type: "standard",
+  ageGroup: "child",
   color: "#22c55e",
   avatar: {
-    type: "emoji" as const,
+    type: "emoji",
     value: "👦",
   },
   pinEnabled: false,

--- a/src/app/profiles/__tests__/page.test.tsx
+++ b/src/app/profiles/__tests__/page.test.tsx
@@ -1,6 +1,7 @@
 /**
  * Tests for /profiles page
  */
+import type { Profile } from "@/components/profiles/profile-context";
 import { render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import ProfilesPage from "../page";
@@ -27,15 +28,15 @@ vi.mock("next/navigation", () => ({
 }));
 
 // Mock profile data
-const mockAdminProfile = {
+const mockAdminProfile: Profile = {
   id: "profile-admin",
   userId: "user-1",
   name: "Admin User",
-  type: "admin" as const,
-  ageGroup: "adult" as const,
+  type: "admin",
+  ageGroup: "adult",
   color: "#3b82f6",
   avatar: {
-    type: "initials" as const,
+    type: "initials",
     value: "AU",
     backgroundColor: "#3b82f6",
   },
@@ -43,15 +44,15 @@ const mockAdminProfile = {
   isActive: true,
 };
 
-const mockStandardProfile = {
+const mockStandardProfile: Profile = {
   id: "profile-standard",
   userId: "user-1",
   name: "Child User",
-  type: "standard" as const,
-  ageGroup: "child" as const,
+  type: "standard",
+  ageGroup: "child",
   color: "#22c55e",
   avatar: {
-    type: "emoji" as const,
+    type: "emoji",
     value: "👦",
   },
   pinEnabled: false,

--- a/src/components/profiles/__tests__/pin-entry-modal.test.tsx
+++ b/src/components/profiles/__tests__/pin-entry-modal.test.tsx
@@ -3,18 +3,18 @@
  */
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { PinEntryModal } from "../pin-entry-modal";
+import { PinEntryModal, type PinEntryModalProfile } from "../pin-entry-modal";
 
 // Mock fetch
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
 
 // Sample profile for testing
-const mockProfile = {
+const mockProfile: PinEntryModalProfile = {
   id: "profile-1",
   name: "Test User",
   avatar: {
-    type: "initials" as const,
+    type: "initials",
     value: "TU",
     backgroundColor: "#3b82f6",
   },

--- a/src/components/profiles/__tests__/pin-settings.test.tsx
+++ b/src/components/profiles/__tests__/pin-settings.test.tsx
@@ -3,43 +3,43 @@
  */
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { PinSettings } from "../pin-settings";
+import { PinSettings, type PinSettingsProfile } from "../pin-settings";
 
 // Mock fetch
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
 
 // Mock profiles
-const standardProfileWithoutPin = {
+const standardProfileWithoutPin: PinSettingsProfile = {
   id: "profile-standard-1",
   name: "Child User",
-  type: "standard" as const,
+  type: "standard",
   pinEnabled: false,
   color: "#22c55e",
-  avatar: { type: "emoji" as const, value: "👦" },
+  avatar: { type: "emoji", value: "👦" },
 };
 
-const standardProfileWithPin = {
+const standardProfileWithPin: PinSettingsProfile = {
   id: "profile-standard-2",
   name: "Teen User",
-  type: "standard" as const,
+  type: "standard",
   pinEnabled: true,
   color: "#a855f7",
   avatar: {
-    type: "initials" as const,
+    type: "initials",
     value: "TU",
     backgroundColor: "#a855f7",
   },
 };
 
-const adminProfile = {
+const adminProfile: PinSettingsProfile = {
   id: "profile-admin-1",
   name: "Admin User",
-  type: "admin" as const,
+  type: "admin",
   pinEnabled: true,
   color: "#3b82f6",
   avatar: {
-    type: "initials" as const,
+    type: "initials",
     value: "AU",
     backgroundColor: "#3b82f6",
   },

--- a/src/components/profiles/__tests__/pin-setup-modal.test.tsx
+++ b/src/components/profiles/__tests__/pin-setup-modal.test.tsx
@@ -3,14 +3,14 @@
  */
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { PinSetupModal } from "../pin-setup-modal";
+import { PinSetupModal, type PinSetupModalProfile } from "../pin-setup-modal";
 
 // Mock fetch
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
 
 // Sample profile for testing
-const mockProfile = {
+const mockProfile: PinSetupModalProfile = {
   id: "profile-1",
   name: "Test User",
   pinEnabled: false,

--- a/src/components/profiles/__tests__/profile-avatar.test.tsx
+++ b/src/components/profiles/__tests__/profile-avatar.test.tsx
@@ -4,14 +4,21 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { ProfileAvatar } from "../profile-avatar";
+import type { Profile } from "../profile-context";
+
+// ProfileAvatar consumes a narrow subset of Profile (name + color + avatar);
+// the `id` is retained here for clarity since fixtures historically include it.
+type ProfileAvatarFixture = Pick<Profile, "name" | "color" | "avatar"> & {
+  id: string;
+};
 
 // Mock profile data
-const mockProfile = {
+const mockProfile: ProfileAvatarFixture = {
   id: "profile-1",
   name: "Test User",
   color: "#3b82f6",
   avatar: {
-    type: "initials" as const,
+    type: "initials",
     value: "TU",
     backgroundColor: "#3b82f6",
   },
@@ -33,10 +40,10 @@ describe("ProfileAvatar", () => {
     });
 
     it("falls back to profile color if avatar backgroundColor not set", () => {
-      const profileWithoutBgColor = {
+      const profileWithoutBgColor: ProfileAvatarFixture = {
         ...mockProfile,
         avatar: {
-          type: "initials" as const,
+          type: "initials",
           value: "TU",
         },
       };
@@ -52,10 +59,10 @@ describe("ProfileAvatar", () => {
 
   describe("emoji avatar type", () => {
     it("renders emoji correctly", () => {
-      const emojiProfile = {
+      const emojiProfile: ProfileAvatarFixture = {
         ...mockProfile,
         avatar: {
-          type: "emoji" as const,
+          type: "emoji",
           value: "👦",
         },
       };
@@ -68,10 +75,10 @@ describe("ProfileAvatar", () => {
 
   describe("photo avatar type", () => {
     it("renders image with correct src", () => {
-      const photoProfile = {
+      const photoProfile: ProfileAvatarFixture = {
         ...mockProfile,
         avatar: {
-          type: "photo" as const,
+          type: "photo",
           value: "https://example.com/avatar.jpg",
         },
       };

--- a/src/components/profiles/__tests__/profile-avatar.test.tsx
+++ b/src/components/profiles/__tests__/profile-avatar.test.tsx
@@ -6,15 +6,11 @@ import { describe, expect, it } from "vitest";
 import { ProfileAvatar } from "../profile-avatar";
 import type { Profile } from "../profile-context";
 
-// ProfileAvatar consumes a narrow subset of Profile (name + color + avatar);
-// the `id` is retained here for clarity since fixtures historically include it.
-type ProfileAvatarFixture = Pick<Profile, "name" | "color" | "avatar"> & {
-  id: string;
-};
+// ProfileAvatar's prop type is the narrow subset { name, color, avatar }.
+type ProfileAvatarFixture = Pick<Profile, "name" | "color" | "avatar">;
 
 // Mock profile data
 const mockProfile: ProfileAvatarFixture = {
-  id: "profile-1",
   name: "Test User",
   color: "#3b82f6",
   avatar: {

--- a/src/components/profiles/__tests__/profile-card.test.tsx
+++ b/src/components/profiles/__tests__/profile-card.test.tsx
@@ -5,21 +5,22 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ProfileCard, ProfileCardSkeleton } from "../profile-card";
+import type { Profile } from "../profile-context";
 
 // Mock fetch for stats API
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
 
 // Mock profile data
-const mockProfile = {
+const mockProfile: Profile = {
   id: "profile-1",
   userId: "user-1",
   name: "Test User",
-  type: "standard" as const,
-  ageGroup: "adult" as const,
+  type: "standard",
+  ageGroup: "adult",
   color: "#3b82f6",
   avatar: {
-    type: "initials" as const,
+    type: "initials",
     value: "TU",
     backgroundColor: "#3b82f6",
   },
@@ -27,13 +28,13 @@ const mockProfile = {
   isActive: true,
 };
 
-const mockAdminProfile = {
+const mockAdminProfile: Profile = {
   ...mockProfile,
   id: "profile-admin",
   name: "Admin User",
-  type: "admin" as const,
+  type: "admin",
   avatar: {
-    type: "initials" as const,
+    type: "initials",
     value: "AU",
     backgroundColor: "#3b82f6",
   },

--- a/src/components/profiles/__tests__/profile-context.test.tsx
+++ b/src/components/profiles/__tests__/profile-context.test.tsx
@@ -274,8 +274,10 @@ describe("ProfileContext", () => {
         expect(result.current.allProfiles).toHaveLength(2);
       });
 
-      // Add a new profile to the response
-      const updatedProfiles = [
+      // Add a new profile to the response. The appended fragment is a
+      // deliberately partial Profile — the test only checks `allProfiles`
+      // length after refresh, so a minimal shape exercises the path.
+      const updatedProfiles: Array<Profile | Partial<Profile>> = [
         ...mockProfiles,
         {
           id: "profile-new",

--- a/src/components/profiles/__tests__/profile-context.test.tsx
+++ b/src/components/profiles/__tests__/profile-context.test.tsx
@@ -4,7 +4,7 @@
 import { type ReactNode } from "react";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { ProfileProvider, useProfile } from "../profile-context";
+import { type Profile, ProfileProvider, useProfile } from "../profile-context";
 
 // Mock fetch
 const mockFetch = vi.fn();
@@ -28,7 +28,7 @@ vi.stubGlobal("localStorage", {
 });
 
 // Mock profiles data
-const mockProfiles = [
+const mockProfiles: Profile[] = [
   {
     id: "profile-admin-1",
     userId: "user-1",

--- a/src/components/profiles/__tests__/profile-grid.test.tsx
+++ b/src/components/profiles/__tests__/profile-grid.test.tsx
@@ -3,6 +3,7 @@
  */
 import { render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Profile } from "../profile-context";
 import { ProfileGrid, ProfileGridSkeleton } from "../profile-grid";
 
 // Mock fetch for stats API
@@ -10,16 +11,16 @@ const mockFetch = vi.fn();
 global.fetch = mockFetch;
 
 // Mock profile data
-const mockProfiles = [
+const mockProfiles: Profile[] = [
   {
     id: "profile-1",
     userId: "user-1",
     name: "Admin User",
-    type: "admin" as const,
-    ageGroup: "adult" as const,
+    type: "admin",
+    ageGroup: "adult",
     color: "#3b82f6",
     avatar: {
-      type: "initials" as const,
+      type: "initials",
       value: "AU",
       backgroundColor: "#3b82f6",
     },
@@ -30,11 +31,11 @@ const mockProfiles = [
     id: "profile-2",
     userId: "user-1",
     name: "Child User",
-    type: "standard" as const,
-    ageGroup: "child" as const,
+    type: "standard",
+    ageGroup: "child",
     color: "#22c55e",
     avatar: {
-      type: "emoji" as const,
+      type: "emoji",
       value: "👦",
     },
     pinEnabled: false,
@@ -44,11 +45,11 @@ const mockProfiles = [
     id: "profile-3",
     userId: "user-1",
     name: "Teen User",
-    type: "standard" as const,
-    ageGroup: "teen" as const,
+    type: "standard",
+    ageGroup: "teen",
     color: "#a855f7",
     avatar: {
-      type: "initials" as const,
+      type: "initials",
       value: "TU",
       backgroundColor: "#a855f7",
     },

--- a/src/components/profiles/__tests__/profile-switcher.test.tsx
+++ b/src/components/profiles/__tests__/profile-switcher.test.tsx
@@ -4,7 +4,7 @@
 import { type ReactNode } from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { ProfileProvider } from "../profile-context";
+import { type Profile, ProfileProvider } from "../profile-context";
 import { ProfileSwitcher } from "../profile-switcher";
 
 // Mock fetch
@@ -29,7 +29,7 @@ vi.stubGlobal("localStorage", {
 });
 
 // Mock profiles data
-const mockProfiles = [
+const mockProfiles: Profile[] = [
   {
     id: "profile-admin-1",
     userId: "user-1",

--- a/src/components/tasks/__tests__/profile-scoped-task-list.test.tsx
+++ b/src/components/tasks/__tests__/profile-scoped-task-list.test.tsx
@@ -3,6 +3,7 @@
  * surrounding ProfileContext into a TaskList's per-profile filter.
  */
 import {
+  type Profile,
   ProfileProvider,
   useProfile,
 } from "@/components/profiles/profile-context";
@@ -21,7 +22,7 @@ vi.mock("../task-list", () => ({
 
 const mockTaskList = vi.mocked(TaskList);
 
-const mockProfiles = [
+const mockProfiles: Profile[] = [
   {
     id: "profile-admin-1",
     userId: "user-1",

--- a/src/lib/test-utils/pin-test-helpers.ts
+++ b/src/lib/test-utils/pin-test-helpers.ts
@@ -9,6 +9,7 @@
  * because Vitest hoists them. This module provides the type casts and
  * setup helpers that come after the mocks.
  */
+import type { Profile } from "@/generated/prisma/client";
 import type { prisma } from "@/lib/db";
 import bcrypt from "bcrypt";
 import { vi } from "vitest";
@@ -33,20 +34,14 @@ export function castPinPrisma(prismaMock: typeof prisma): MockPinPrisma {
 /**
  * Create a mock profile object with PIN-related fields.
  */
-export function mockPinProfile(overrides: {
-  id: string;
-  pinEnabled?: boolean;
-  pinHash?: string | null;
-  failedPinAttempts?: number;
-  pinLockedUntil?: Date | null;
-  type?: "admin" | "standard" | "child";
-  [key: string]: unknown;
-}) {
+export function mockPinProfile(
+  overrides: Partial<Profile> & Pick<Profile, "id">
+): Profile {
   return {
     userId: "user-1",
     name: "Test Profile",
-    type: "standard" as const,
-    ageGroup: "adult" as const,
+    type: "standard",
+    ageGroup: "adult",
     color: "#3b82f6",
     avatar: { type: "initials", value: "TP", backgroundColor: "#3b82f6" },
     pinEnabled: false,


### PR DESCRIPTION
## Summary

- Retypes the canonical fixtures module `src/app/api/profiles/__tests__/fixtures.ts` against the generated Prisma `Profile`/`ProfileRewardPoints`/`ProfileSettings` types — closes the "Full retype … lives in #280" TODO that was sitting in that file.
- Adds type annotations to 11 component/page test fixtures so they're pinned to the production shape (UI `Profile` from `profile-context.tsx`, or each component's own narrowed prop type where the component exposes one).
- Retypes `src/lib/test-utils/pin-test-helpers.ts:mockPinProfile` to take `Partial<Profile> & Pick<Profile, "id">` and return `Profile`, so any future caller picks up the full Prisma row type.

## Plan

Linked plan: `.claude/plans/retype-profile-fixtures-280.md`
Project: https://github.com/users/BenSeymourODB/projects/1

## Rationale

Two production `Profile` shapes coexist; each fixture should pin to the one its consumer actually uses:

- **Prisma row** (`@/generated/prisma/client`) — API/service tests that mock `prisma.profile.*` return values. Includes `pinHash`, `failedPinAttempts`, `pinLockedUntil`, `Date` timestamps, etc.
- **UI / API-response** (`@/components/profiles/profile-context`) — component tests consuming the trimmed `/api/profiles` JSON shape.
- **Component-owned narrow prop types** (`PinEntryModalProfile`, `PinSetupModalProfile`, `PinSettingsProfile`) — PIN modal tests whose components already export the exact shape they accept.
- **`Pick<Profile, ...>`** for `ProfileAvatar`, whose prop type is an inline anonymous subset.

## Test plan

- [x] `pnpm check-types` clean (no errors)
- [x] `pnpm test` — 2019/2019 tests pass across 131 files
- [x] `pnpm lint:fix && pnpm format:fix` clean
- [x] Pre-commit hook (Husky + lint-staged) passed cleanly
- [x] Net diff is type annotations + import reshuffling only — no runtime test changes, no snapshot updates

## Notes

- `src/components/profiles/__tests__/give-points-modal.test.tsx` was already typed against `Profile` and did not need changes.
- `src/components/tasks/__tests__/task-assignment-picker.test.tsx` was already typed against the exported `ProfileInfo` and did not need changes.
- Local `Profile`/`ProfileRewardPoints`/`ProfileSettings` interface declarations are deleted from `fixtures.ts` — they were a transitional measure flagged as "lives in #280" right in the file.

Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThwHbfHHg2zATbcWZkLAje)_