### PR TITLE
feat(auth): automate OAuth token-key rotation with dual-read cipher (#215)

### DIFF
--- a/.claude/plans/token-key-rotation-215.md
+++ b/.claude/plans/token-key-rotation-215.md
@@ -1,0 +1,182 @@
+# Plan — feat(auth): automate OAuth token-key rotation (#215)
+
+## Goal
+
+PR #158 ("encrypt OAuth tokens at rest") introduced a v1 envelope but
+explicitly deferred operational tooling for key rotation. The
+`docs/auth-token-encryption.md` runbook today tells operators that a
+rotation forces every user to re-login — fine for a single-family
+deployment but not a defensible posture for the broader self-host
+audience.
+
+This issue adds:
+
+1. **Dual-read decryption** so an active key and a previous key are
+   both accepted for reads during a rotation window. Encryption always
+   uses the active key.
+2. **A rotation CLI** (`scripts/rotate-token-encryption-key.mjs`) that
+   walks the `Account` table in batches, decrypts each token with the
+   active-or-previous key, and re-encrypts it under the active key.
+3. **Documentation** in `docs/auth-token-encryption.md` covering the
+   rolling-rotation runbook.
+
+## Out of scope (deferred)
+
+- A full live integration test against a seeded Postgres instance. The
+  CLI's rotation logic will be unit-tested by extracting the pure
+  re-encrypt step into a testable function and feeding it fake rows;
+  the Prisma I/O wiring stays thin.
+- Multiple previous keys (a single `TOKEN_ENCRYPTION_KEY_PREVIOUS` is
+  enough for the one-at-a-time rotation pattern; expanding to a list
+  is trivial later if needed).
+- A new envelope version. The issue body suggested "bumping the
+  version byte" on rotation, but a pure key rotation under the same
+  AES-256-GCM algorithm does not need it — the version byte stays
+  reserved for algorithm/scheme changes, which keeps the rotation
+  scriptidempotent (running it twice produces identical envelope
+  shapes).
+
+## Design
+
+### Dual-read in `src/lib/crypto/token-cipher.ts`
+
+Today `resolveKey()` returns a single `Buffer`. After this change it
+becomes `resolveKeys()` and returns:
+
+```ts
+type ResolvedKeys = {
+  active: Buffer;
+  previous: Buffer | null;
+};
+```
+
+`encryptToken` reads `active` only. `decryptToken`:
+
+1. Attempts AES-GCM decrypt with `active`.
+2. On any decryption error (auth-tag mismatch is the expected one
+   immediately after a rotation), and only if `previous` is non-null,
+   re-tries with `previous`.
+3. If both fail, throws the original error — operators see
+   `RefreshTokenDecryptFailed` exactly as before for terminal cases.
+
+`TOKEN_ENCRYPTION_KEY_PREVIOUS` is a new env var with identical
+parsing rules to `TOKEN_ENCRYPTION_KEY` (base64 or base64url, 32 bytes,
+fatal if malformed). If unset, behaviour is unchanged — single-key
+read.
+
+The module's cache key already incorporates the source string; extend
+it to include the previous key so a `vi.stubEnv` flip across tests is
+reflected.
+
+### CLI in `scripts/rotate-token-encryption-key.mjs`
+
+Mirrors `scripts/check-migration-naming.mjs` style: ESM, JSDoc types,
+a pure exported helper plus a thin `main()` that wires CLI flags and
+Prisma.
+
+```
+Usage:
+  node scripts/rotate-token-encryption-key.mjs [--dry-run] [--batch-size=N]
+
+Required env:
+  TOKEN_ENCRYPTION_KEY            New (active) key (base64, 32 bytes)
+  TOKEN_ENCRYPTION_KEY_PREVIOUS   Previous key (base64, 32 bytes)
+  DATABASE_URL                    Standard Prisma URL
+```
+
+Behaviour:
+
+- Refuses to run when either key env is missing — that's exactly the
+  scenario the dual-read protects against, but the CLI cannot rotate
+  without both.
+- Refuses to run when the two keys decode to the same 32 bytes —
+  prevents an accidental no-op that would still bill a full table
+  scan.
+- Iterates `Account` rows that have at least one non-null token
+  column, in `--batch-size` chunks ordered by `id`. For each row,
+  decrypts each non-null token (legacy plaintext passes through
+  unchanged), then re-encrypts under the active key. Updates the row
+  inside a per-batch `prisma.$transaction` so a failure on any row in
+  the batch rolls the batch back.
+- In `--dry-run`, every step except the final `update()` runs;
+  decryption failures still surface so an operator can spot tampered
+  rows before the real run.
+- Prints a single-line progress log every batch and a final summary.
+  Exits non-zero on any failure.
+
+Extracted pure helper:
+
+```ts
+/**
+ * Pure re-encrypt step for one Account row. Returns the partial
+ * update payload (only changed columns) or null if nothing needs
+ * writing.
+ */
+function reencryptAccountRow(row, { encryptToken, decryptToken }) { ... }
+```
+
+Tests for this helper cover:
+
+- All three fields present, all encrypted → returns three new
+  envelopes that decrypt back to the original plaintext.
+- A null field stays null.
+- A legacy plaintext field (no `v1:` prefix) stays as-is (not
+  re-encrypted from plaintext — the next session refresh handles
+  that).
+- A row with no encrypted fields at all returns null (no update
+  needed).
+
+### Documentation
+
+`docs/auth-token-encryption.md` — replace the "Rotating the key" stub
+with:
+
+1. The rolling-rotation runbook (deploy new + old keys, run the CLI,
+   drop the old key, redeploy).
+2. The dual-read contract (which envelope formats decrypt with which
+   key).
+3. A reminder that the previous-key env var must be unset after the
+   rotation completes — otherwise an attacker who later compromises
+   the now-retired key can still decrypt fresh tokens.
+
+## Test strategy (TDD)
+
+1. **Cipher (red)**: add tests in
+   `src/lib/crypto/__tests__/token-cipher.test.ts` for:
+   - decrypt with previous key after active rotates
+   - decrypt rejects when neither active nor previous matches
+   - previous key absent → single-key behaviour preserved (regression
+     guard)
+   - encrypt always uses active key (write doesn't fall back)
+     Make them pass by introducing `TOKEN_ENCRYPTION_KEY_PREVIOUS`
+     plumbing.
+2. **CLI helper (red)**: new
+   `scripts/__tests__/rotate-token-encryption-key.test.ts` with
+   fixture rows.
+3. **Green**: implement cipher changes + CLI helper.
+4. **Refactor + docs**: tidy CLI `main()`, update runbook.
+5. **Validate**: `pnpm lint:fix && pnpm format:fix && pnpm check-types && pnpm test`.
+
+## Risk register
+
+- **Cache stickiness**: forgetting to invalidate the module-level
+  cache on previous-key change would corrupt subsequent tests. The
+  existing `loadCipher()` helper already calls `vi.resetModules`, so
+  new tests inherit that. Production servers reboot on env change so
+  the in-process cache is moot there.
+- **Atomicity vs throughput**: per-row transactions are slow but
+  safe; per-batch transactions are fast but a single-row failure
+  rolls back N rows. The CLI picks per-batch. The decryption step is
+  side-effect-free, so the failure mode is "we re-process a batch on
+  the next CLI invocation", which is idempotent.
+- **Empty-string plaintext**: the cipher round-trips `""` correctly
+  (test exists), so the re-encrypt step preserves the distinction
+  between `null` and `""`.
+
+## File list
+
+- `src/lib/crypto/token-cipher.ts` — extend resolution + decrypt
+- `src/lib/crypto/__tests__/token-cipher.test.ts` — add dual-read tests
+- `scripts/rotate-token-encryption-key.mjs` — new
+- `scripts/__tests__/rotate-token-encryption-key.test.ts` — new
+- `docs/auth-token-encryption.md` — runbook update

--- a/docs/auth-token-encryption.md
+++ b/docs/auth-token-encryption.md
@@ -167,9 +167,11 @@ envelopes.
    `Account.id` and counted in the final summary; the CLI exits
    non-zero so an automation can detect partial completion.
 
-   Re-running the CLI is safe — it is idempotent (rows already
-   encrypted under the active key get fresh IVs but the same
-   plaintext).
+   Re-running the CLI is safe — rows already encrypted under the
+   active key get a fresh IV but the same plaintext. Note that a
+   rerun **always restarts from the beginning of the table** — the
+   page cursor lives only in process memory, so a crashed run is not
+   resumable from where it left off.
 
 4. **Verify and retire the previous key.** Confirm the CLI summary
    shows `failed=0`. Unset `TOKEN_ENCRYPTION_KEY_PREVIOUS` and

--- a/docs/auth-token-encryption.md
+++ b/docs/auth-token-encryption.md
@@ -116,17 +116,73 @@ between dev and staging) you should set `TOKEN_ENCRYPTION_KEY` explicitly.
 
 ### Rotating the key
 
-Rotating `TOKEN_ENCRYPTION_KEY` invalidates every currently stored token
-envelope. The next time each user's session refreshes, decryption of their
-refresh token fails, the session callback hits the `RefreshTokenError`
-branch, and the user is prompted to sign in again.
+The cipher supports a **rolling rotation window** so a key change does
+not force every user to re-login. During the window the active key
+(used for writes) and the previous key (read-only fallback) are both
+configured; a CLI walks the `Account` table and re-encrypts every
+stored envelope under the active key; once the table is clean the
+previous key is dropped.
 
-In-place rotation with re-encryption would need a migration script that
-decrypts with the old key and re-encrypts with the new one. That tooling is
-**not** in place yet — open a follow-up issue if you need it.
+#### Env-var contract
 
-For now, rotation is a forced re-login for all users. Budget that when
-planning a rotation.
+- `TOKEN_ENCRYPTION_KEY` — always the **active** key. All new writes
+  go through this one.
+- `TOKEN_ENCRYPTION_KEY_PREVIOUS` — optional. When set,
+  `decryptToken` will fall back to it if the active key fails to
+  decrypt an envelope (typical immediately after a rotation: the row
+  was written under the old key, but the new key is now active).
+
+Both follow the same parsing rules (base64 or base64url, 32 bytes,
+fatal on malformed input). Leave `TOKEN_ENCRYPTION_KEY_PREVIOUS` unset
+in steady state — keeping a retired key plumbed in means anyone who
+later compromises the retired key can still read your current
+envelopes.
+
+#### Runbook
+
+1. **Generate the new key.**
+
+   ```bash
+   openssl rand -base64 32
+   ```
+
+2. **Deploy both keys.** Set `TOKEN_ENCRYPTION_KEY` to the new value
+   and `TOKEN_ENCRYPTION_KEY_PREVIOUS` to the existing one. Redeploy.
+   The app continues to serve traffic — writes go out under the new
+   key; reads of existing rows transparently fall back to the
+   previous one. There is no forced re-login.
+
+3. **Run the rotation CLI** from a host with `DATABASE_URL` and both
+   key env vars set:
+
+   ```bash
+   pnpm tsx scripts/rotate-token-encryption-key.mjs --dry-run
+   pnpm tsx scripts/rotate-token-encryption-key.mjs
+   ```
+
+   The CLI walks `Account` in batches (default 100) and re-encrypts
+   every encrypted token column. Legacy plaintext rows are skipped
+   (the next session refresh writes them as v1 envelopes naturally).
+   On any per-row decryption failure the row is logged with its
+   `Account.id` and counted in the final summary; the CLI exits
+   non-zero so an automation can detect partial completion.
+
+   Re-running the CLI is safe — it is idempotent (rows already
+   encrypted under the active key get fresh IVs but the same
+   plaintext).
+
+4. **Verify and retire the previous key.** Confirm the CLI summary
+   shows `failed=0`. Unset `TOKEN_ENCRYPTION_KEY_PREVIOUS` and
+   redeploy. The cipher is back to single-key mode.
+
+#### What if a row fails to decrypt?
+
+A row whose tokens decrypt under neither key is either tampered or
+was written under a third key that was never in
+`TOKEN_ENCRYPTION_KEY_PREVIOUS`. The CLI surfaces the failure in its
+summary and continues with the rest of the table. The affected user
+will be prompted to sign in again on their next token refresh — the
+same `RefreshTokenError` path that has always handled this case.
 
 ### Suspected key compromise
 
@@ -146,7 +202,9 @@ the key, which lives on the application server.
 
 ## Code references
 
-- `src/lib/crypto/token-cipher.ts` — cipher implementation
+- `src/lib/crypto/token-cipher.ts` — cipher implementation (dual-read)
 - `src/lib/crypto/__tests__/token-cipher.test.ts` — cipher tests
+- `scripts/rotate-token-encryption-key.mjs` — rotation CLI
+- `scripts/__tests__/rotate-token-encryption-key.test.ts` — CLI helper tests
 - `src/lib/auth/auth.ts` — `events.linkAccount` + session refresh
 - `src/lib/auth/helpers.ts` — `getAccessToken` / `getGoogleAccount`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1165,11 +1165,6 @@ packages:
     peerDependencies:
       tslib: '>= 1.0.0'
 
-  '@microsoft/applicationinsights-cfgsync-js@3.3.11':
-    resolution: {integrity: sha512-HdBc/ldMZpqGtzAFDs49o82wTdKRX2B0BzmjgS+D4MrS7CLth4MxLHJHOpmTI2bmc/S4T8n32LlFkaQCvWb9ig==}
-    peerDependencies:
-      tslib: '>= 1.0.0'
-
   '@microsoft/applicationinsights-cfgsync-js@3.4.1':
     resolution: {integrity: sha512-ifNgSIisKM/rZoLdpzS6sIQqBBRNXXAhiazZizwoP2MLdK93Z8JcPNi6eXkKPhW0Fi3SuoUivCaM7GgAMgVEFw==}
     peerDependencies:
@@ -2996,6 +2991,9 @@ packages:
 
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
@@ -5808,10 +5806,6 @@ packages:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
-  tinyglobby@0.2.17:
-    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
-    engines: {node: '>=12.0.0'}
-
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
@@ -7232,7 +7226,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.20.1':
     dependencies:
-      ajv: 6.15.0
+      ajv: 6.12.6
       content-type: 1.0.5
       cors: 2.8.5
       cross-spawn: 7.0.6
@@ -9103,6 +9097,13 @@ snapshots:
   agent-base@7.1.4: {}
 
   ajv@6.12.6:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
+  ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
@@ -12205,11 +12206,6 @@ snapshots:
   tinyexec@1.0.4: {}
 
   tinyglobby@0.2.15:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-
-  tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4

--- a/scripts/__tests__/rotate-token-encryption-key.test.ts
+++ b/scripts/__tests__/rotate-token-encryption-key.test.ts
@@ -1,0 +1,202 @@
+import { randomBytes } from "node:crypto";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Tests for the rotate-token-encryption-key CLI helper (#215).
+ *
+ * Covers the pure `reencryptAccountTokens` step: given an Account row and a
+ * cipher API, return the partial update payload that re-encrypts every
+ * encrypted token field under the active key. Null / plaintext / no-op rows
+ * are handled without touching the database.
+ *
+ * The Prisma I/O wiring in `main()` is deliberately not unit-tested — its
+ * contract is exercised by the runbook integration step in
+ * `docs/auth-token-encryption.md` (deferred to a follow-up issue for a full
+ * seeded-DB harness).
+ */
+
+const OLD_KEY = randomBytes(32).toString("base64");
+const NEW_KEY = randomBytes(32).toString("base64");
+
+async function loadCipher() {
+  vi.resetModules();
+  return await import("../../src/lib/crypto/token-cipher");
+}
+
+async function loadHelper() {
+  vi.resetModules();
+  return await import("../rotate-token-encryption-key.mjs");
+}
+
+describe("reencryptAccountTokens", () => {
+  beforeEach(() => {
+    vi.stubEnv("NODE_ENV", "test");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns null when every token column is null", async () => {
+    vi.stubEnv("TOKEN_ENCRYPTION_KEY", NEW_KEY);
+    vi.stubEnv("TOKEN_ENCRYPTION_KEY_PREVIOUS", OLD_KEY);
+    const cipher = await loadCipher();
+    const { reencryptAccountTokens } = await loadHelper();
+
+    const update = reencryptAccountTokens(
+      {
+        id: "acct-null",
+        access_token: null,
+        refresh_token: null,
+        id_token: null,
+      },
+      cipher
+    );
+
+    expect(update).toBeNull();
+  });
+
+  it("re-encrypts an envelope written under the previous key under the active key", async () => {
+    // Step 1: write a row using the OLD key as ACTIVE (no previous).
+    vi.stubEnv("TOKEN_ENCRYPTION_KEY", OLD_KEY);
+    vi.stubEnv("TOKEN_ENCRYPTION_KEY_PREVIOUS", "");
+    const writer = await loadCipher();
+    const oldAccess = writer.encryptToken("access-plaintext")!;
+    const oldRefresh = writer.encryptToken("refresh-plaintext")!;
+    const oldId = writer.encryptToken("id-plaintext")!;
+
+    // Step 2: rotation window — NEW key is ACTIVE, OLD is PREVIOUS.
+    vi.stubEnv("TOKEN_ENCRYPTION_KEY", NEW_KEY);
+    vi.stubEnv("TOKEN_ENCRYPTION_KEY_PREVIOUS", OLD_KEY);
+    const cipher = await loadCipher();
+    const { reencryptAccountTokens } = await loadHelper();
+
+    const update = reencryptAccountTokens(
+      {
+        id: "acct-rotated",
+        access_token: oldAccess,
+        refresh_token: oldRefresh,
+        id_token: oldId,
+      },
+      cipher
+    );
+
+    expect(update).not.toBeNull();
+    expect(update?.access_token).not.toBe(oldAccess);
+    expect(update?.refresh_token).not.toBe(oldRefresh);
+    expect(update?.id_token).not.toBe(oldId);
+    expect(update?.access_token?.startsWith("v1:")).toBe(true);
+
+    // Step 3: drop the PREVIOUS key — the re-encrypted envelopes must
+    // still decrypt because they're under the NEW (active) key.
+    vi.stubEnv("TOKEN_ENCRYPTION_KEY", NEW_KEY);
+    vi.stubEnv("TOKEN_ENCRYPTION_KEY_PREVIOUS", "");
+    const postRotation = await loadCipher();
+    expect(postRotation.decryptToken(update!.access_token!)).toBe(
+      "access-plaintext"
+    );
+    expect(postRotation.decryptToken(update!.refresh_token!)).toBe(
+      "refresh-plaintext"
+    );
+    expect(postRotation.decryptToken(update!.id_token!)).toBe("id-plaintext");
+  });
+
+  it("preserves legacy plaintext token columns unchanged", async () => {
+    // Plaintext entries are not re-encrypted by the CLI — the next
+    // session refresh writes them as v1 envelopes naturally. Touching
+    // them here would corrupt rows whose tokens were never encrypted.
+    vi.stubEnv("TOKEN_ENCRYPTION_KEY", NEW_KEY);
+    vi.stubEnv("TOKEN_ENCRYPTION_KEY_PREVIOUS", OLD_KEY);
+    const cipher = await loadCipher();
+    const { reencryptAccountTokens } = await loadHelper();
+
+    const update = reencryptAccountTokens(
+      {
+        id: "acct-legacy",
+        access_token: "ya29.legacy-plaintext-access",
+        refresh_token: null,
+        id_token: null,
+      },
+      cipher
+    );
+
+    expect(update).toBeNull();
+  });
+
+  it("re-encrypts only the encrypted columns and leaves legacy plaintext alone", async () => {
+    vi.stubEnv("TOKEN_ENCRYPTION_KEY", OLD_KEY);
+    vi.stubEnv("TOKEN_ENCRYPTION_KEY_PREVIOUS", "");
+    const writer = await loadCipher();
+    const oldEnvelope = writer.encryptToken("access-plaintext")!;
+
+    vi.stubEnv("TOKEN_ENCRYPTION_KEY", NEW_KEY);
+    vi.stubEnv("TOKEN_ENCRYPTION_KEY_PREVIOUS", OLD_KEY);
+    const cipher = await loadCipher();
+    const { reencryptAccountTokens } = await loadHelper();
+
+    const update = reencryptAccountTokens(
+      {
+        id: "acct-mixed",
+        access_token: oldEnvelope,
+        refresh_token: "legacy-refresh-plaintext",
+        id_token: null,
+      },
+      cipher
+    );
+
+    // Only access_token is in the update payload.
+    expect(update).not.toBeNull();
+    expect(update?.access_token).toBeDefined();
+    expect(update?.refresh_token).toBeUndefined();
+    expect(update?.id_token).toBeUndefined();
+  });
+
+  it("is idempotent on a row already encrypted under the active key", async () => {
+    // The CLI is safe to re-run after a partial failure: a row whose
+    // tokens are already under the active key still gets re-written,
+    // but the new envelope decrypts to the same plaintext (new IV, same
+    // key — the on-disk shape changes but the secret value is
+    // preserved).
+    vi.stubEnv("TOKEN_ENCRYPTION_KEY", NEW_KEY);
+    vi.stubEnv("TOKEN_ENCRYPTION_KEY_PREVIOUS", OLD_KEY);
+    const cipher = await loadCipher();
+    const { reencryptAccountTokens } = await loadHelper();
+
+    const original = cipher.encryptToken("already-rotated")!;
+    const update = reencryptAccountTokens(
+      {
+        id: "acct-idempotent",
+        access_token: original,
+        refresh_token: null,
+        id_token: null,
+      },
+      cipher
+    );
+
+    expect(update).not.toBeNull();
+    expect(update?.access_token).not.toBe(original); // new IV
+    expect(cipher.decryptToken(update!.access_token!)).toBe("already-rotated");
+  });
+
+  it("rejects a tampered envelope by throwing — caller surfaces the failure", async () => {
+    // Tampered ciphertext fails GCM auth on both keys; the CLI must
+    // bubble the error so the row sticks out in the failure summary
+    // instead of silently disappearing.
+    vi.stubEnv("TOKEN_ENCRYPTION_KEY", NEW_KEY);
+    vi.stubEnv("TOKEN_ENCRYPTION_KEY_PREVIOUS", OLD_KEY);
+    const cipher = await loadCipher();
+    const { reencryptAccountTokens } = await loadHelper();
+
+    expect(() =>
+      reencryptAccountTokens(
+        {
+          id: "acct-tampered",
+          access_token: "v1:AAAA:BBBB:CCCC",
+          refresh_token: null,
+          id_token: null,
+        },
+        cipher
+      )
+    ).toThrow();
+  });
+});

--- a/scripts/__tests__/rotate-token-encryption-key.test.ts
+++ b/scripts/__tests__/rotate-token-encryption-key.test.ts
@@ -66,6 +66,9 @@ describe("reencryptAccountTokens", () => {
     const oldId = writer.encryptToken("id-plaintext")!;
 
     // Step 2: rotation window — NEW key is ACTIVE, OLD is PREVIOUS.
+    // `loadHelper()` resets modules again; the `cipher` reference is
+    // already imported so subsequent calls keep the dual-key env
+    // snapshot that was active when the cipher module was loaded.
     vi.stubEnv("TOKEN_ENCRYPTION_KEY", NEW_KEY);
     vi.stubEnv("TOKEN_ENCRYPTION_KEY_PREVIOUS", OLD_KEY);
     const cipher = await loadCipher();
@@ -156,7 +159,10 @@ describe("reencryptAccountTokens", () => {
     // tokens are already under the active key still gets re-written,
     // but the new envelope decrypts to the same plaintext (new IV, same
     // key — the on-disk shape changes but the secret value is
-    // preserved).
+    // preserved). This test exercises only the active-key path; the
+    // dual-read fallback is covered by the "re-encrypts an envelope
+    // written under the previous key" test above and the cipher's own
+    // suite.
     vi.stubEnv("TOKEN_ENCRYPTION_KEY", NEW_KEY);
     vi.stubEnv("TOKEN_ENCRYPTION_KEY_PREVIOUS", OLD_KEY);
     const cipher = await loadCipher();

--- a/scripts/rotate-token-encryption-key.mjs
+++ b/scripts/rotate-token-encryption-key.mjs
@@ -1,0 +1,273 @@
+#!/usr/bin/env node
+// In-place re-encryption of OAuth tokens after a TOKEN_ENCRYPTION_KEY
+// rotation (#215). Reads the active and previous keys from env, walks
+// the Account table in batches, decrypts each non-null token (dual-read
+// in the cipher tries the active key first then the previous one), and
+// re-encrypts under the active key. Legacy plaintext tokens are left
+// alone — the next session refresh writes them as v1 envelopes
+// naturally.
+//
+// Usage:
+//   node scripts/rotate-token-encryption-key.mjs [--dry-run] [--batch-size=N]
+//
+// Required env:
+//   TOKEN_ENCRYPTION_KEY            New (active) key, base64, 32 bytes
+//   TOKEN_ENCRYPTION_KEY_PREVIOUS   Previous key, base64, 32 bytes
+//   DATABASE_URL                    Prisma connection string
+//
+// See docs/auth-token-encryption.md for the full runbook.
+import process from "node:process";
+
+/**
+ * @typedef {{
+ *   id: string;
+ *   access_token: string | null;
+ *   refresh_token: string | null;
+ *   id_token: string | null;
+ * }} AccountTokenRow
+ */
+
+/**
+ * @typedef {{
+ *   encryptToken: (s: string | null | undefined) => string | null;
+ *   decryptToken: (s: string | null | undefined) => string | null;
+ *   isEncrypted: (s: string | null | undefined) => boolean;
+ * }} CipherApi
+ */
+
+/** Fields the rotation considers. Mirrors the Prisma Account model. */
+const TOKEN_FIELDS = /** @type {const} */ ([
+  "access_token",
+  "refresh_token",
+  "id_token",
+]);
+
+/**
+ * Pure re-encrypt step: given an Account row and a cipher API, return
+ * the partial update payload that re-encrypts every encrypted token
+ * column under the active key. Legacy plaintext fields are not
+ * touched. Null fields are not touched.
+ *
+ * Returns `null` when nothing in the row needs writing (a legacy-only
+ * row or a row with no token columns at all).
+ *
+ * Throws if a non-null encrypted field cannot be decrypted with either
+ * key — the caller should surface the failure rather than silently
+ * skip the row.
+ *
+ * @param {AccountTokenRow} row
+ * @param {CipherApi} cipher
+ * @returns {Partial<Record<typeof TOKEN_FIELDS[number], string>> | null}
+ */
+export function reencryptAccountTokens(row, cipher) {
+  /** @type {Partial<Record<typeof TOKEN_FIELDS[number], string>>} */
+  const update = {};
+  let dirty = false;
+
+  for (const field of TOKEN_FIELDS) {
+    const value = row[field];
+    if (value == null) continue;
+    if (!cipher.isEncrypted(value)) continue;
+
+    const plaintext = cipher.decryptToken(value);
+    if (plaintext == null) {
+      // decryptToken only returns null on null input — we already
+      // guarded above. Defensive: bail out if Node's typings ever
+      // narrow differently in future.
+      continue;
+    }
+    const reencrypted = cipher.encryptToken(plaintext);
+    if (reencrypted == null) {
+      throw new Error(
+        `encryptToken returned null for a non-null plaintext (row ${row.id}, field ${field})`
+      );
+    }
+    update[field] = reencrypted;
+    dirty = true;
+  }
+
+  return dirty ? update : null;
+}
+
+/**
+ * Parse a CLI `--flag=value` / `--flag value` pair into a flat record.
+ *
+ * @param {string[]} argv
+ * @returns {{ dryRun: boolean; batchSize: number }}
+ */
+export function parseArgs(argv) {
+  let dryRun = false;
+  let batchSize = 100;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--dry-run") {
+      dryRun = true;
+      continue;
+    }
+    if (arg.startsWith("--batch-size=")) {
+      batchSize = Number(arg.slice("--batch-size=".length));
+      continue;
+    }
+    if (arg === "--batch-size") {
+      batchSize = Number(argv[++i]);
+      continue;
+    }
+    if (arg === "--help" || arg === "-h") {
+      printUsageAndExit(0);
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (!Number.isInteger(batchSize) || batchSize < 1 || batchSize > 10000) {
+    throw new Error(
+      `--batch-size must be a positive integer ≤ 10000 (got ${batchSize})`
+    );
+  }
+
+  return { dryRun, batchSize };
+}
+
+function printUsageAndExit(code) {
+  const out = code === 0 ? process.stdout : process.stderr;
+  out.write(
+    "Usage: node scripts/rotate-token-encryption-key.mjs [--dry-run] [--batch-size=N]\n" +
+      "\n" +
+      "Required env:\n" +
+      "  TOKEN_ENCRYPTION_KEY            New (active) key (base64, 32 bytes)\n" +
+      "  TOKEN_ENCRYPTION_KEY_PREVIOUS   Previous key (base64, 32 bytes)\n" +
+      "  DATABASE_URL                    Prisma connection string\n"
+  );
+  process.exit(code);
+}
+
+/**
+ * Refuse to run unless the operator has both keys set AND they are
+ * actually different — both signals that a rotation is in progress.
+ * Defers the actual decode validation to the cipher (`encryptToken` /
+ * `decryptToken` calls trip the env validators on first use), so the
+ * error messages from this script and from runtime stay consistent.
+ */
+function assertRotationEnv() {
+  const active = process.env.TOKEN_ENCRYPTION_KEY;
+  const previous = process.env.TOKEN_ENCRYPTION_KEY_PREVIOUS;
+
+  if (!active || active.length === 0) {
+    throw new Error(
+      "TOKEN_ENCRYPTION_KEY is required (the new / active key for re-encryption)."
+    );
+  }
+  if (!previous || previous.length === 0) {
+    throw new Error(
+      "TOKEN_ENCRYPTION_KEY_PREVIOUS is required (the old key being rotated out)."
+    );
+  }
+  if (active.trim() === previous.trim()) {
+    throw new Error(
+      "TOKEN_ENCRYPTION_KEY and TOKEN_ENCRYPTION_KEY_PREVIOUS are identical — nothing to rotate."
+    );
+  }
+}
+
+/**
+ * Entry point. Wires Prisma + cipher and walks the table.
+ *
+ * Extracted so the unit tests can exercise the pure helpers (the
+ * `reencryptAccountTokens` / `parseArgs` exports) without booting
+ * Prisma.
+ *
+ * @param {string[]} argv
+ */
+export async function main(argv) {
+  const { dryRun, batchSize } = parseArgs(argv);
+  assertRotationEnv();
+
+  // Lazy-imported so `import("../rotate-token-encryption-key.mjs")` in
+  // tests doesn't pull in Prisma's heavy native bindings.
+  const cipher = await import("../src/lib/crypto/token-cipher.ts");
+  const { PrismaClient } = await import("../src/generated/prisma/client.js");
+  const prisma = new PrismaClient();
+
+  const startedAt = Date.now();
+  let scanned = 0;
+  let rotated = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  try {
+    /** @type {string | null} */
+    let cursor = null;
+    for (;;) {
+      const batch = await prisma.account.findMany({
+        where: {
+          OR: [
+            { access_token: { not: null } },
+            { refresh_token: { not: null } },
+            { id_token: { not: null } },
+          ],
+        },
+        select: {
+          id: true,
+          access_token: true,
+          refresh_token: true,
+          id_token: true,
+        },
+        orderBy: { id: "asc" },
+        take: batchSize,
+        ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+      });
+
+      if (batch.length === 0) break;
+
+      const updates = [];
+      for (const row of batch) {
+        scanned++;
+        try {
+          const update = reencryptAccountTokens(row, cipher);
+          if (!update) {
+            skipped++;
+            continue;
+          }
+          updates.push({ id: row.id, data: update });
+        } catch (err) {
+          failed++;
+          process.stderr.write(
+            `[rotate] account ${row.id} failed: ${err instanceof Error ? err.message : String(err)}\n`
+          );
+        }
+      }
+
+      if (!dryRun && updates.length > 0) {
+        await prisma.$transaction(
+          updates.map((u) =>
+            prisma.account.update({ where: { id: u.id }, data: u.data })
+          )
+        );
+      }
+      rotated += updates.length;
+      cursor = batch[batch.length - 1].id;
+
+      process.stdout.write(
+        `[rotate] scanned=${scanned} rotated=${rotated} skipped=${skipped} failed=${failed}\n`
+      );
+    }
+  } finally {
+    await prisma.$disconnect();
+  }
+
+  const elapsedMs = Date.now() - startedAt;
+  process.stdout.write(
+    `[rotate] done in ${elapsedMs}ms — scanned=${scanned} rotated=${rotated} skipped=${skipped} failed=${failed}${dryRun ? " (dry-run)" : ""}\n`
+  );
+  if (failed > 0) process.exit(1);
+}
+
+// Run only when invoked directly (not when imported by tests).
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main(process.argv.slice(2)).catch((err) => {
+    process.stderr.write(
+      `[rotate] fatal: ${err instanceof Error ? err.message : String(err)}\n`
+    );
+    process.exit(1);
+  });
+}

--- a/scripts/rotate-token-encryption-key.mjs
+++ b/scripts/rotate-token-encryption-key.mjs
@@ -237,12 +237,24 @@ export async function main(argv) {
         }
       }
 
+      // Advance counters and the page cursor only after the batch
+      // transaction commits. A throw from `$transaction` aborts the
+      // run (caller restarts from the beginning of the table); the
+      // `rotated` count must never reflect rows that weren't written.
       if (!dryRun && updates.length > 0) {
-        await prisma.$transaction(
-          updates.map((u) =>
-            prisma.account.update({ where: { id: u.id }, data: u.data })
-          )
-        );
+        try {
+          await prisma.$transaction(
+            updates.map((u) =>
+              prisma.account.update({ where: { id: u.id }, data: u.data })
+            )
+          );
+        } catch (err) {
+          failed += updates.length;
+          process.stderr.write(
+            `[rotate] batch transaction failed (${updates.length} rows rolled back): ${err instanceof Error ? err.message : String(err)}\n`
+          );
+          break;
+        }
       }
       rotated += updates.length;
       cursor = batch[batch.length - 1].id;

--- a/src/lib/crypto/__tests__/token-cipher.test.ts
+++ b/src/lib/crypto/__tests__/token-cipher.test.ts
@@ -252,4 +252,109 @@ describe("token-cipher", () => {
       warnSpy.mockRestore();
     });
   });
+
+  // Issue #215 — dual-read decryption keyed on the envelope contents lets us
+  // run a rolling key rotation: encrypt under the new (active) key, but still
+  // decrypt tokens that were written under the previous key until the CLI
+  // re-encrypts every row.
+  describe("dual-read with TOKEN_ENCRYPTION_KEY_PREVIOUS", () => {
+    it("decrypts an envelope written under the previous key after the active key rotates", async () => {
+      // Step 1: encrypt under what will become the "previous" key.
+      const oldKey = randomBytes(32).toString("base64");
+      vi.stubEnv("TOKEN_ENCRYPTION_KEY", oldKey);
+      vi.stubEnv("TOKEN_ENCRYPTION_KEY_PREVIOUS", "");
+      const { encryptToken } = await loadCipher();
+      const envelope = encryptToken("rotation-secret");
+      expect(envelope).not.toBeNull();
+
+      // Step 2: simulate a rotation — flip env so the old key becomes
+      // PREVIOUS and a fresh key is ACTIVE. Reload the module so the
+      // resolver sees the new env.
+      const newKey = randomBytes(32).toString("base64");
+      vi.stubEnv("TOKEN_ENCRYPTION_KEY", newKey);
+      vi.stubEnv("TOKEN_ENCRYPTION_KEY_PREVIOUS", oldKey);
+      const { decryptToken } = await loadCipher();
+
+      // The old envelope must still decrypt to the original plaintext.
+      expect(decryptToken(envelope)).toBe("rotation-secret");
+    });
+
+    it("encrypts under the active key only — re-encrypted envelopes do not decrypt with the previous key", async () => {
+      const oldKey = randomBytes(32).toString("base64");
+      const newKey = randomBytes(32).toString("base64");
+      vi.stubEnv("TOKEN_ENCRYPTION_KEY", newKey);
+      vi.stubEnv("TOKEN_ENCRYPTION_KEY_PREVIOUS", oldKey);
+      const { encryptToken } = await loadCipher();
+      const envelope = encryptToken("written-after-rotation");
+      expect(envelope).not.toBeNull();
+
+      // If we re-load the module with only the old key as ACTIVE
+      // (and no previous), the envelope must NOT decrypt — proving
+      // it was encrypted under the new key.
+      vi.stubEnv("TOKEN_ENCRYPTION_KEY", oldKey);
+      vi.stubEnv("TOKEN_ENCRYPTION_KEY_PREVIOUS", "");
+      const { decryptToken } = await loadCipher();
+      expect(() => decryptToken(envelope)).toThrow();
+    });
+
+    it("throws when neither the active nor the previous key matches the envelope", async () => {
+      const writeKey = randomBytes(32).toString("base64");
+      vi.stubEnv("TOKEN_ENCRYPTION_KEY", writeKey);
+      vi.stubEnv("TOKEN_ENCRYPTION_KEY_PREVIOUS", "");
+      const { encryptToken } = await loadCipher();
+      const envelope = encryptToken("orphaned-secret");
+
+      // Reload with two unrelated keys — neither can decrypt the
+      // original envelope.
+      vi.stubEnv("TOKEN_ENCRYPTION_KEY", randomBytes(32).toString("base64"));
+      vi.stubEnv(
+        "TOKEN_ENCRYPTION_KEY_PREVIOUS",
+        randomBytes(32).toString("base64")
+      );
+      const { decryptToken } = await loadCipher();
+      expect(() => decryptToken(envelope)).toThrow();
+    });
+
+    it("ignores TOKEN_ENCRYPTION_KEY_PREVIOUS when empty (single-key behaviour preserved)", async () => {
+      // Regression guard: an absent / empty previous key must keep the
+      // pre-#215 behaviour exactly. No fallback, no surprise re-tries.
+      vi.stubEnv("TOKEN_ENCRYPTION_KEY_PREVIOUS", "");
+      const { encryptToken, decryptToken } = await loadCipher();
+      const envelope = encryptToken("simple-roundtrip");
+      expect(decryptToken(envelope)).toBe("simple-roundtrip");
+    });
+
+    it("throws when TOKEN_ENCRYPTION_KEY_PREVIOUS is set but malformed", async () => {
+      // The previous key follows the same parsing rules as the active
+      // key — fail fast at first use instead of silently dropping it.
+      vi.stubEnv("TOKEN_ENCRYPTION_KEY_PREVIOUS", "!!!not-base64!!!");
+      const { encryptToken } = await loadCipher();
+      expect(() => encryptToken("x")).toThrow(/TOKEN_ENCRYPTION_KEY_PREVIOUS/);
+    });
+
+    it("throws when TOKEN_ENCRYPTION_KEY_PREVIOUS decodes to the wrong length", async () => {
+      vi.stubEnv(
+        "TOKEN_ENCRYPTION_KEY_PREVIOUS",
+        randomBytes(16).toString("base64")
+      );
+      const { encryptToken } = await loadCipher();
+      expect(() => encryptToken("x")).toThrow(/TOKEN_ENCRYPTION_KEY_PREVIOUS/);
+    });
+
+    it("does not log the derivation warning when both keys are explicit", async () => {
+      // Sanity: setting the previous-key env shouldn't accidentally trip
+      // the dev-mode HKDF fallback branch.
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      vi.stubEnv("TOKEN_ENCRYPTION_KEY_PREVIOUS", TEST_KEY_B64);
+      const { encryptToken } = await loadCipher();
+      encryptToken("anything");
+      const derivationWarns = warnSpy.mock.calls.filter(
+        (args) =>
+          typeof args[0] === "string" &&
+          args[0].includes("TOKEN_ENCRYPTION_KEY")
+      );
+      expect(derivationWarns.length).toBe(0);
+      warnSpy.mockRestore();
+    });
+  });
 });

--- a/src/lib/crypto/token-cipher.ts
+++ b/src/lib/crypto/token-cipher.ts
@@ -234,8 +234,11 @@ export function decryptToken(
 
   // Dual-read (#215): try the active key first; on auth-tag mismatch
   // fall back to the previous key (if configured) so a rolling
-  // rotation can decrypt envelopes written under either key. Surface
-  // the active-key error if both attempts fail — operators triaging
+  // rotation can decrypt envelopes written under either key. Cross-
+  // key false-positive probability is 2⁻¹²⁸ (GCM's MAC length), so a
+  // ciphertext written under one key cannot spuriously pass auth-tag
+  // verification under an unrelated key. Surface the active-key
+  // error if both attempts fail — operators triaging
   // `RefreshTokenDecryptFailed` see the failure that matters.
   const { active, previous } = resolveKeys();
   try {

--- a/src/lib/crypto/token-cipher.ts
+++ b/src/lib/crypto/token-cipher.ts
@@ -24,7 +24,12 @@ const AUTH_TAG_LENGTH = 16;
 const CURRENT_VERSION = "v1";
 const HKDF_INFO = "token-cipher/v1";
 
-let cachedKey: Buffer | null = null;
+interface ResolvedKeys {
+  active: Buffer;
+  previous: Buffer | null;
+}
+
+let cachedKeys: ResolvedKeys | null = null;
 let cachedKeySource: string | null = null;
 let loggedDerivationWarning = false;
 
@@ -49,32 +54,39 @@ function decodeBase64Key(input: string): Buffer | null {
   return decoded;
 }
 
-function resolveKey(): Buffer {
+function decodeNamedKey(envVar: string, value: string): Buffer {
+  const decoded = decodeBase64Key(value);
+  if (!decoded) {
+    throw new Error(
+      `${envVar} is not valid base64/base64url (generate with \`openssl rand -base64 32\`).`
+    );
+  }
+  if (decoded.length !== KEY_LENGTH) {
+    throw new Error(
+      `${envVar} must decode to ${KEY_LENGTH} bytes (got ${decoded.length}).`
+    );
+  }
+  return decoded;
+}
+
+function resolveKeys(): ResolvedKeys {
   const envKey = process.env.TOKEN_ENCRYPTION_KEY;
+  const previousEnvKey = process.env.TOKEN_ENCRYPTION_KEY_PREVIOUS;
   const nodeEnv = process.env.NODE_ENV;
   const nextAuthSecret = process.env.NEXTAUTH_SECRET;
 
+  // Cache key must include the previous-key value so a rotation
+  // (active ↔ previous flip in env) invalidates the cached pair.
   const source = envKey
-    ? `env:${envKey}`
-    : `derived:${nextAuthSecret ?? ""}:${nodeEnv ?? ""}`;
-  if (cachedKey && cachedKeySource === source) {
-    return cachedKey;
+    ? `env:${envKey}|prev:${previousEnvKey ?? ""}`
+    : `derived:${nextAuthSecret ?? ""}:${nodeEnv ?? ""}|prev:${previousEnvKey ?? ""}`;
+  if (cachedKeys && cachedKeySource === source) {
+    return cachedKeys;
   }
 
-  let key: Buffer;
+  let active: Buffer;
   if (envKey && envKey.length > 0) {
-    const decoded = decodeBase64Key(envKey);
-    if (!decoded) {
-      throw new Error(
-        "TOKEN_ENCRYPTION_KEY is not valid base64/base64url (generate with `openssl rand -base64 32`)."
-      );
-    }
-    if (decoded.length !== KEY_LENGTH) {
-      throw new Error(
-        `TOKEN_ENCRYPTION_KEY must decode to ${KEY_LENGTH} bytes (got ${decoded.length}).`
-      );
-    }
-    key = decoded;
+    active = decodeNamedKey("TOKEN_ENCRYPTION_KEY", envKey);
   } else if (nodeEnv !== "production" && nextAuthSecret) {
     // Dev / test convenience: derive a stable 32-byte key from NEXTAUTH_SECRET
     // so developers don't need to generate and distribute a second secret.
@@ -95,7 +107,7 @@ function resolveKey(): Buffer {
       Buffer.from(HKDF_INFO, "utf8"),
       KEY_LENGTH
     );
-    key = Buffer.from(derived);
+    active = Buffer.from(derived);
   } else if (nodeEnv === "production") {
     throw new Error(
       "TOKEN_ENCRYPTION_KEY is required in production. " +
@@ -108,9 +120,15 @@ function resolveKey(): Buffer {
     );
   }
 
-  cachedKey = key;
+  const previous =
+    previousEnvKey && previousEnvKey.length > 0
+      ? decodeNamedKey("TOKEN_ENCRYPTION_KEY_PREVIOUS", previousEnvKey)
+      : null;
+
+  const keys: ResolvedKeys = { active, previous };
+  cachedKeys = keys;
   cachedKeySource = source;
-  return key;
+  return keys;
 }
 
 function toBase64Url(buf: Buffer): string {
@@ -142,9 +160,9 @@ export function encryptToken(
 ): string | null {
   if (plaintext == null) return null;
 
-  const key = resolveKey();
+  const { active } = resolveKeys();
   const iv = randomBytes(IV_LENGTH);
-  const cipher = createCipheriv(ALGORITHM, key, iv);
+  const cipher = createCipheriv(ALGORITHM, active, iv);
   const ciphertext = Buffer.concat([
     cipher.update(plaintext, "utf8"),
     cipher.final(),
@@ -157,6 +175,21 @@ export function encryptToken(
     toBase64Url(authTag),
     toBase64Url(ciphertext),
   ].join(":");
+}
+
+function decryptWithKey(
+  key: Buffer,
+  iv: Buffer,
+  authTag: Buffer,
+  ciphertext: Buffer
+): string {
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(authTag);
+  const plaintext = Buffer.concat([
+    decipher.update(ciphertext),
+    decipher.final(),
+  ]);
+  return plaintext.toString("utf8");
 }
 
 /**
@@ -199,12 +232,20 @@ export function decryptToken(
     );
   }
 
-  const key = resolveKey();
-  const decipher = createDecipheriv(ALGORITHM, key, iv);
-  decipher.setAuthTag(authTag);
-  const plaintext = Buffer.concat([
-    decipher.update(ciphertext),
-    decipher.final(),
-  ]);
-  return plaintext.toString("utf8");
+  // Dual-read (#215): try the active key first; on auth-tag mismatch
+  // fall back to the previous key (if configured) so a rolling
+  // rotation can decrypt envelopes written under either key. Surface
+  // the active-key error if both attempts fail — operators triaging
+  // `RefreshTokenDecryptFailed` see the failure that matters.
+  const { active, previous } = resolveKeys();
+  try {
+    return decryptWithKey(active, iv, authTag, ciphertext);
+  } catch (activeErr) {
+    if (!previous) throw activeErr;
+    try {
+      return decryptWithKey(previous, iv, authTag, ciphertext);
+    } catch {
+      throw activeErr;
+    }
+  }
 }


### PR DESCRIPTION
## Summary

PR #158 introduced the v1 token envelope but explicitly deferred the operational tooling for key rotation. Today rotating `TOKEN_ENCRYPTION_KEY` invalidates every stored envelope and forces every user to re-login on their next refresh — defensible for a single-family deploy but not a posture we want to ship to the self-host audience.

This change adds a **rolling-rotation pattern** that never breaks a user's session:

- **Dual-read in `src/lib/crypto/token-cipher.ts`** — a new `TOKEN_ENCRYPTION_KEY_PREVIOUS` env var holds the retired key during a rotation window. `decryptToken` tries the active key first, then falls back to previous on auth-tag mismatch. `encryptToken` always uses active.
- **`scripts/rotate-token-encryption-key.mjs`** — walks `Account` in batches, re-encrypts every encrypted token column under the active key, leaves legacy plaintext alone. `--dry-run` prints planned counts without writing; per-batch `prisma.$transaction` rolls back a batch on any in-batch failure; idempotent on partial reruns.
- **`docs/auth-token-encryption.md`** — replaces the "rotation = forced re-login" stub with a four-step rolling runbook (deploy both keys → run the CLI → confirm `failed=0` → drop the previous key).

Includes a separate prep commit (`fix(deps): repair broken pnpm-lock.yaml from #359 merge`) — `main`'s `pnpm-lock.yaml` had duplicate mapping keys (`tinyglobby@0.2.17`, `@microsoft/applicationinsights-cfgsync-js@3.3.11`) and a missing `ajv@6.15.0` entry left behind by the eslint-config-next bump in PR #359. Regenerating cleared all three; nothing else moved.

## Plan

Linked plan: [`.claude/plans/token-key-rotation-215.md`](./.claude/plans/token-key-rotation-215.md)
Project: https://github.com/users/BenSeymourODB/projects/1

## Out of scope (deferred)

- A full live integration test against a seeded Postgres instance — the pure `reencryptAccountTokens` helper is unit-tested across null / legacy-plaintext / mixed / idempotent / tampered cases (6 tests), and the Prisma I/O wrapper in `main()` stays thin.
- Multiple previous keys — the cipher takes a single `TOKEN_ENCRYPTION_KEY_PREVIOUS`; expanding to a list is a small change later if needed.
- Envelope-version bump on rotation — the issue body suggested it but a pure key rotation under the same AES-256-GCM algorithm doesn't need it; the version byte stays reserved for algorithm changes.

## Test plan

- [x] `pnpm test` — 2231 tests pass (32 cipher tests including 7 new dual-read cases; 6 new CLI helper tests)
- [x] `pnpm lint:fix && pnpm format:fix && pnpm check-types` clean
- [ ] CI — green
- [ ] Manual smoke against a dev DB with a real rotation cycle (deferred to follow-up; the unit harness exercises the same `reencryptAccountTokens` path the CLI uses)

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BzD5orBYarvhuJfXXMh1Xr)_