### PR TITLE
feat(cache): LRU eviction on QuotaExceededError (#290 sub-task 1)

### DIFF
--- a/.claude/plans/event-cache-lru-eviction-290.md
+++ b/.claude/plans/event-cache-lru-eviction-290.md
@@ -1,0 +1,138 @@
+# Event-cache LRU eviction on QuotaExceededError — issue #290 (sub-task 1)
+
+Tracking issue: [#290](https://github.com/BenSeymourODB/next-digital-wall-calendar/issues/290).
+Predecessor: `.claude/plans/event-cache-rework-218.md` (issue #218, PR #258).
+
+## Slice
+
+This plan covers **only the first of #290's three sub-tasks**: LRU eviction on
+`QuotaExceededError`. The other two sub-tasks (visibility-change cleanup
+sweep, TTL wired to user settings) ship in separate PRs. The TTL sub-task
+specifically waits for the `useUserSettings.mutate` + `user-settings-bus`
+pattern from PR #344 (issue #337) to land first.
+
+## Goal
+
+When `EventCache.saveEvents` causes the IndexedDB store's `put` to fail
+with `QuotaExceededError`, evict least-recently-cached rows from the store
+and retry the put. If we cannot free enough space, fall through to the
+existing in-memory fallback path so the cache always remains functional.
+
+## Design decisions
+
+### Recency index
+
+The issue body suggests "likely `lastReadAt` per row". I'm using the
+existing `cachedAt` index instead, for two reasons:
+
+1. Today's read access pattern is bulk `getAll()` — there is no
+   per-row read. A `lastReadAt` field would either be (a) a no-op
+   (every row touched by every getAll, so all values converge) or
+   (b) require expensive per-row writes on every read. Neither
+   beats `cachedAt` as a recency signal.
+2. `cachedAt` is already indexed (`objectStore.createIndex("cachedAt", …)`
+   at `src/lib/event-cache.ts:112`), so no schema bump is needed.
+
+If a future access pattern surfaces per-row reads (e.g. event-detail
+hover bumping recency), we can swap to `lastReadAt` then. Documented
+in the implementation comment so the next reader doesn't have to
+re-derive this.
+
+### Eviction unit
+
+Evict in **batches** rather than one row at a time. IndexedDB transactions
+are heavyweight; doing N tiny transactions instead of one is wasteful and
+keeps the cache in a "writes failing" state longer. Batch size of
+`EVICTION_BATCH_SIZE = 50` — small enough to free meaningful space on a
+typical cache, large enough that the retry loop terminates quickly.
+
+### Termination
+
+Three safeguards against an infinite loop:
+
+1. **Bounded retries** — at most `MAX_EVICTION_ATTEMPTS = 5` evict-and-
+   retry cycles per `saveEvents()` call. After that we give up and let
+   the existing fallback path catch the error.
+2. **Empty-batch break** — if `evictOldest(N)` returns 0 (nothing
+   left to evict), we stop immediately. This handles the pathological
+   "the rows we're trying to write are themselves bigger than the quota"
+   case.
+3. **Non-quota errors propagate** — only `DOMException`s with
+   `name === "QuotaExceededError"` trigger the LRU path. Any other
+   error short-circuits to the existing fallback handler.
+
+### Logging
+
+`logger.event("event-cache.lru-evicted", { evicted, attempts, retried })`
+once per successful eviction-then-retry-succeeded cycle. `logger.event`
+is the right tool here per `src/lib/logger.ts` — it's a structured
+business event, not an error.
+
+## Phases
+
+### Phase 1 — `EventStore.evictOldest` + tests
+
+- Extend the `EventStore` interface with
+  `evictOldest(count: number): Promise<number>` (returns the actual
+  number of rows evicted; may be `< count` if the store has fewer rows).
+- Implement on `InMemoryEventStore` by sorting entries by `cachedAt`
+  ascending and deleting the first `count`.
+- Implement on `IndexedDBEventStore` by opening a cursor on the
+  `cachedAt` index (ascending) and deleting the first `count` keys.
+- Tests:
+  - `evictOldest(2)` from an in-memory store of 3 rows leaves the most
+    recent row, returns 2.
+  - `evictOldest(10)` from a 3-row store evicts everything, returns 3.
+  - `evictOldest(0)` is a no-op, returns 0.
+  - Same semantics asserted on a stubbed IndexedDB-backed store (fake-
+    indexeddb).
+
+### Phase 2 — `EventCache.saveEvents` retry-after-evict
+
+The retry loop lives in `EventCache.saveEvents` (via a private
+`putWithLruRetry` helper) rather than inside `IndexedDBEventStore`.
+Rationale:
+
+- `EventStore` already exposes the only two operations the loop needs
+  (`put`, `evictOldest`) — pushing the logic into the cache facade
+  avoids duplicating it across every future `EventStore` backend.
+- Testability: the existing test fixture uses a mock `EventStore`
+  (e.g. the "in-memory fallback" test). Putting the orchestration on
+  the facade lets us reuse that same mock pattern to inject quota
+  errors deterministically, with no need to add `fake-indexeddb` as a
+  dependency.
+- The store-level `evictOldest` still belongs on `IndexedDBEventStore`
+  because the cursor-on-`cachedAt`-index implementation is backend-
+  specific; only the eviction policy (batch size, attempt count, what
+  triggers a retry) moves up to the facade.
+
+- Wrap `store.put` in a loop that catches `QuotaExceededError`, calls
+  `store.evictOldest(EVICTION_BATCH_SIZE)`, and retries.
+- Bound by `MAX_EVICTION_ATTEMPTS`.
+- Emit the structured `logger.event` after a successful retry.
+- Tests use the existing `EventStore` mock pattern; no IndexedDB shim
+  required.
+
+### Phase 3 — Verify the existing fallback path still wins on exhaustion
+
+- After `MAX_EVICTION_ATTEMPTS`, `put` re-throws the original
+  `QuotaExceededError`. `EventCache.withFallback` catches it and
+  swaps in `InMemoryEventStore` for the lifetime of the page.
+- Test asserts that:
+  - The fallback path is exercised after the bounded LRU loop fails.
+  - The fallback message in `logger.error` is unchanged.
+
+## Acceptance criteria mapping
+
+From the issue:
+
+- [x] LRU eviction passes a unit test that simulates `QuotaExceededError`
+- [x] Eviction is bounded (no infinite loops on pathological input)
+- [x] Structured `logger.event` records evicted-row count on success
+- [x] Defaults preserved for existing users — no schema bump, the new
+      retry logic is invisible until quota is hit
+
+Out of scope for this PR (will land separately under #290):
+
+- Visibility-change cleanup sweep
+- TTL wired to user settings (waits on PR #344 / issue #337)

--- a/src/lib/__tests__/event-cache.test.ts
+++ b/src/lib/__tests__/event-cache.test.ts
@@ -7,7 +7,29 @@ import {
   selectEventStore,
 } from "@/lib/event-cache";
 import type { GoogleCalendarEvent } from "@/lib/google-calendar";
+import { logger } from "@/lib/logger";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    error: vi.fn(),
+    log: vi.fn(),
+    event: vi.fn(),
+    dependency: vi.fn(),
+  },
+}));
+
+/**
+ * Mimic the `DOMException` shape that IndexedDB throws when a write exceeds
+ * the storage quota. `name === "QuotaExceededError"` is the contract; in
+ * Chromium-family browsers this is a `DOMException` instance, but tests
+ * just need an `Error`-shaped object with the right `name`.
+ */
+function quotaExceededError(message = "Quota exceeded"): Error {
+  const err = new Error(message);
+  err.name = "QuotaExceededError";
+  return err;
+}
 
 function makeEvent(
   id: string,
@@ -91,6 +113,46 @@ describe("InMemoryEventStore", () => {
   it("returns an empty array when nothing has been written", async () => {
     expect(await store.getAll(1_000)).toEqual([]);
   });
+
+  describe("evictOldest (#290 — LRU support)", () => {
+    it("removes the N rows with the smallest cachedAt", async () => {
+      await store.put([makeEvent("old1")], 1_000);
+      await store.put([makeEvent("old2")], 2_000);
+      await store.put([makeEvent("recent1")], 3_000);
+      await store.put([makeEvent("recent2")], 4_000);
+
+      const evicted = await store.evictOldest(2);
+
+      expect(evicted).toBe(2);
+      // Use a `now` close to the most recent write so the TTL filter does
+      // not also remove rows; this isolates the LRU eviction effect.
+      const remaining = await store.getAll(4_000);
+      expect(remaining.map((e) => e.id).sort()).toEqual(["recent1", "recent2"]);
+    });
+
+    it("returns the actual evicted count when fewer than N rows exist", async () => {
+      await store.put([makeEvent("a"), makeEvent("b")], 1_000);
+
+      const evicted = await store.evictOldest(10);
+
+      expect(evicted).toBe(2);
+      expect(await store.getAll(1_000)).toEqual([]);
+    });
+
+    it("is a no-op when asked to evict zero rows", async () => {
+      await store.put([makeEvent("a"), makeEvent("b")], 1_000);
+
+      const evicted = await store.evictOldest(0);
+
+      expect(evicted).toBe(0);
+      const all = await store.getAll(1_000);
+      expect(all.map((e) => e.id).sort()).toEqual(["a", "b"]);
+    });
+
+    it("returns 0 when the store is already empty", async () => {
+      expect(await store.evictOldest(5)).toBe(0);
+    });
+  });
 });
 
 describe("EventCache facade", () => {
@@ -146,6 +208,7 @@ describe("EventCache facade", () => {
       }),
       getAll: vi.fn(async () => []),
       clear: vi.fn(async () => {}),
+      evictOldest: vi.fn(async () => 0),
     };
     const flakyCache = new EventCache(flaky);
 
@@ -159,6 +222,142 @@ describe("EventCache facade", () => {
     expect(flaky.getAll).not.toHaveBeenCalled();
   });
 
+  describe("LRU eviction on QuotaExceededError (#290)", () => {
+    beforeEach(() => {
+      vi.mocked(logger.event).mockClear();
+    });
+
+    it("retries the put after evicting LRU rows on QuotaExceededError", async () => {
+      let putCalls = 0;
+      const evictedRows = new Set<string>();
+      const store: EventStore = {
+        put: vi.fn(async () => {
+          putCalls += 1;
+          // First attempt fails with quota; second succeeds (after eviction).
+          if (putCalls === 1) throw quotaExceededError();
+        }),
+        getAll: vi.fn(async () => []),
+        clear: vi.fn(async () => {}),
+        evictOldest: vi.fn(async (count: number) => {
+          for (let i = 0; i < count; i++) {
+            evictedRows.add(`evicted-${evictedRows.size}`);
+          }
+          return count;
+        }),
+      };
+
+      const c = new EventCache(store);
+      await c.saveEvents([makeEvent("new")]);
+
+      // Two put calls: original + one retry.
+      expect(store.put).toHaveBeenCalledTimes(2);
+      expect(store.evictOldest).toHaveBeenCalledTimes(1);
+      // The retry must NOT trigger the in-memory fallback path — the IDB
+      // store stays in use after a successful eviction-then-retry.
+      expect((c as unknown as { hasFallenBack: boolean }).hasFallenBack).toBe(
+        false
+      );
+    });
+
+    it("emits a structured logger.event after a successful eviction retry", async () => {
+      let putCalls = 0;
+      const store: EventStore = {
+        put: vi.fn(async () => {
+          putCalls += 1;
+          if (putCalls === 1) throw quotaExceededError();
+        }),
+        getAll: vi.fn(async () => []),
+        clear: vi.fn(async () => {}),
+        evictOldest: vi.fn(async (count: number) => count),
+      };
+
+      const c = new EventCache(store);
+      await c.saveEvents([makeEvent("a")]);
+
+      expect(logger.event).toHaveBeenCalledWith(
+        "event-cache.lru-evicted",
+        expect.objectContaining({
+          context: "EventCache.saveEvents",
+        }),
+        expect.objectContaining({
+          evicted: expect.any(Number) as number,
+          attempts: expect.any(Number) as number,
+        })
+      );
+    });
+
+    it("bounds the eviction retry loop and falls back when quota is unrecoverable", async () => {
+      const store: EventStore = {
+        put: vi.fn(async () => {
+          throw quotaExceededError();
+        }),
+        getAll: vi.fn(async () => []),
+        clear: vi.fn(async () => {}),
+        evictOldest: vi.fn(async (count: number) => count),
+      };
+
+      const c = new EventCache(store);
+      // Should not throw — falls back to in-memory after the bounded loop.
+      await c.saveEvents([makeEvent("a")]);
+
+      // The retry loop attempted at most a fixed bound (the constant is
+      // intentionally not pinned to a specific number in this assertion —
+      // we only care that it terminated and fell back).
+      expect(
+        (store.put as ReturnType<typeof vi.fn>).mock.calls.length
+      ).toBeGreaterThan(1);
+      expect(
+        (store.put as ReturnType<typeof vi.fn>).mock.calls.length
+      ).toBeLessThan(20);
+      expect((c as unknown as { hasFallenBack: boolean }).hasFallenBack).toBe(
+        true
+      );
+    });
+
+    it("breaks out of the loop as soon as evictOldest reports nothing left to evict", async () => {
+      const store: EventStore = {
+        put: vi.fn(async () => {
+          throw quotaExceededError();
+        }),
+        getAll: vi.fn(async () => []),
+        clear: vi.fn(async () => {}),
+        evictOldest: vi.fn(async () => 0),
+      };
+
+      const c = new EventCache(store);
+      await c.saveEvents([makeEvent("a")]);
+
+      // One initial put, then one evict-attempt that returns 0, then the
+      // loop bails out. No further put calls beyond the original attempt.
+      expect(store.put).toHaveBeenCalledTimes(1);
+      expect(store.evictOldest).toHaveBeenCalledTimes(1);
+      // Falls back to in-memory because the quota error was never resolved.
+      expect((c as unknown as { hasFallenBack: boolean }).hasFallenBack).toBe(
+        true
+      );
+    });
+
+    it("does NOT invoke the eviction path for non-quota errors", async () => {
+      const store: EventStore = {
+        put: vi.fn(async () => {
+          throw new Error("not a quota error");
+        }),
+        getAll: vi.fn(async () => []),
+        clear: vi.fn(async () => {}),
+        evictOldest: vi.fn(async () => 0),
+      };
+
+      const c = new EventCache(store);
+      await c.saveEvents([makeEvent("a")]);
+
+      // Goes straight to the in-memory fallback path; no eviction attempted.
+      expect(store.evictOldest).not.toHaveBeenCalled();
+      expect((c as unknown as { hasFallenBack: boolean }).hasFallenBack).toBe(
+        true
+      );
+    });
+  });
+
   it("re-throws when even the in-memory fallback rejects", async () => {
     const dead: EventStore = {
       put: vi.fn(async () => {
@@ -166,6 +365,7 @@ describe("EventCache facade", () => {
       }),
       getAll: vi.fn(),
       clear: vi.fn(),
+      evictOldest: vi.fn(async () => 0),
     };
     const deadCache = new EventCache(new InMemoryEventStore());
     // Force the cache into a state where the active store is the failing one.

--- a/src/lib/__tests__/event-cache.test.ts
+++ b/src/lib/__tests__/event-cache.test.ts
@@ -274,15 +274,16 @@ describe("EventCache facade", () => {
       const c = new EventCache(store);
       await c.saveEvents([makeEvent("a")]);
 
+      // Exact positional match — pins `evicted`/`attempts` to the third
+      // argument (measurements bucket) rather than the second (properties).
+      // A future refactor that swaps them around will fail this test.
       expect(logger.event).toHaveBeenCalledWith(
         "event-cache.lru-evicted",
-        expect.objectContaining({
-          context: "EventCache.saveEvents",
-        }),
-        expect.objectContaining({
+        { context: "EventCache.saveEvents" },
+        {
           evicted: expect.any(Number) as number,
           attempts: expect.any(Number) as number,
-        })
+        }
       );
     });
 
@@ -335,6 +336,38 @@ describe("EventCache facade", () => {
       expect((c as unknown as { hasFallenBack: boolean }).hasFallenBack).toBe(
         true
       );
+    });
+
+    it("propagates a non-quota error thrown on the retry put (after eviction)", async () => {
+      // First put: quota error. Eviction runs. Second put: non-quota error
+      // (e.g. AbortError, disk corruption). The retry loop must NOT swallow
+      // the non-quota error — it should propagate so `withFallback` can
+      // engage the in-memory store. Catches a future refactor that
+      // accidentally widens the inner `catch` to non-quota errors.
+      let putCalls = 0;
+      const nonQuotaError = new Error("AbortError");
+      nonQuotaError.name = "AbortError";
+      const store: EventStore = {
+        put: vi.fn(async () => {
+          putCalls += 1;
+          if (putCalls === 1) throw quotaExceededError();
+          throw nonQuotaError;
+        }),
+        getAll: vi.fn(async () => []),
+        clear: vi.fn(async () => {}),
+        evictOldest: vi.fn(async (count: number) => count),
+      };
+
+      const c = new EventCache(store);
+      // `withFallback` catches the re-thrown AbortError → engages fallback.
+      await c.saveEvents([makeEvent("a")]);
+      expect((c as unknown as { hasFallenBack: boolean }).hasFallenBack).toBe(
+        true
+      );
+      // Eviction was attempted exactly once before the non-quota error
+      // terminated the retry loop.
+      expect(store.evictOldest).toHaveBeenCalledTimes(1);
+      expect(store.put).toHaveBeenCalledTimes(2);
     });
 
     it("does NOT invoke the eviction path for non-quota errors", async () => {

--- a/src/lib/event-cache.ts
+++ b/src/lib/event-cache.ts
@@ -38,6 +38,28 @@ export interface EventStore {
   put(events: GoogleCalendarEvent[], cachedAt: number): Promise<void>;
   getAll(now: number): Promise<GoogleCalendarEvent[]>;
   clear(): Promise<void>;
+  /**
+   * Remove up to `count` rows in least-recently-cached order
+   * (smallest `cachedAt` first). Resolves with the actual number of rows
+   * removed (may be less than `count` if the store has fewer rows).
+   * Used by `EventCache` to recover from `QuotaExceededError` (#290).
+   */
+  evictOldest(count: number): Promise<number>;
+}
+
+/**
+ * Recovery configuration for the `QuotaExceededError` → LRU-evict → retry
+ * loop in `EventCache.saveEvents` (#290). The values are deliberately
+ * conservative: enough to make a dent on a typical Chromium IndexedDB
+ * quota without thrashing the cache, and bounded enough that an
+ * unrecoverable quota error short-circuits to the in-memory fallback
+ * quickly. See `.claude/plans/event-cache-lru-eviction-290.md`.
+ */
+const EVICTION_BATCH_SIZE = 50;
+const MAX_EVICTION_ATTEMPTS = 5;
+
+function isQuotaExceededError(error: unknown): boolean {
+  return error instanceof Error && error.name === "QuotaExceededError";
 }
 
 export class InMemoryEventStore implements EventStore {
@@ -63,6 +85,18 @@ export class InMemoryEventStore implements EventStore {
 
   async clear(): Promise<void> {
     this.rows.clear();
+  }
+
+  async evictOldest(count: number): Promise<number> {
+    if (count <= 0 || this.rows.size === 0) return 0;
+    const sorted = Array.from(this.rows.entries()).sort(
+      (a, b) => a[1].cachedAt - b[1].cachedAt
+    );
+    const toEvict = sorted.slice(0, count);
+    for (const [id] of toEvict) {
+      this.rows.delete(id);
+    }
+    return toEvict.length;
   }
 }
 
@@ -175,6 +209,34 @@ export class IndexedDBEventStore implements EventStore {
       request.onerror = () => reject(request.error);
     });
   }
+
+  async evictOldest(count: number): Promise<number> {
+    if (count <= 0) return 0;
+    await this.init();
+    if (!this.db) {
+      throw new Error("Database not initialized");
+    }
+    return new Promise((resolve, reject) => {
+      const transaction = this.db!.transaction([STORE_NAME], "readwrite");
+      const objectStore = transaction.objectStore(STORE_NAME);
+      const index = objectStore.index("cachedAt");
+      // Ascending cursor over `cachedAt` — first key is the oldest row.
+      const cursorRequest = index.openCursor(null, "next");
+      let evicted = 0;
+      cursorRequest.onsuccess = () => {
+        const cursor = cursorRequest.result;
+        if (!cursor || evicted >= count) {
+          resolve(evicted);
+          return;
+        }
+        cursor.delete();
+        evicted += 1;
+        cursor.continue();
+      };
+      cursorRequest.onerror = () => reject(cursorRequest.error);
+      transaction.onerror = () => reject(transaction.error);
+    });
+  }
 }
 
 /**
@@ -201,9 +263,56 @@ export class EventCache {
 
   async saveEvents(events: GoogleCalendarEvent[]): Promise<void> {
     return this.withFallback(
-      async (store) => store.put(events, Date.now()),
+      async (store) => this.putWithLruRetry(store, events),
       "EventCache.saveEvents"
     );
+  }
+
+  /**
+   * Attempt `store.put`; on `QuotaExceededError`, evict the least-recently-
+   * cached rows in bounded batches and retry. Non-quota errors propagate
+   * immediately so the existing `withFallback` path handles them. Loop
+   * terminates on success, on `MAX_EVICTION_ATTEMPTS`, or when
+   * `evictOldest` reports nothing left to evict (#290).
+   */
+  private async putWithLruRetry(
+    store: EventStore,
+    events: GoogleCalendarEvent[]
+  ): Promise<void> {
+    const cachedAt = Date.now();
+    try {
+      await store.put(events, cachedAt);
+      return;
+    } catch (error) {
+      if (!isQuotaExceededError(error)) throw error;
+
+      let totalEvicted = 0;
+      for (let attempt = 1; attempt <= MAX_EVICTION_ATTEMPTS; attempt++) {
+        const evicted = await store.evictOldest(EVICTION_BATCH_SIZE);
+        totalEvicted += evicted;
+        if (evicted === 0) {
+          // Nothing left to evict — propagate so the in-memory fallback
+          // can take over. The thrown error is the original quota error,
+          // preserved so logs upstream stay accurate.
+          throw error;
+        }
+        try {
+          await store.put(events, cachedAt);
+          logger.event(
+            "event-cache.lru-evicted",
+            { context: "EventCache.saveEvents" },
+            { evicted: totalEvicted, attempts: attempt }
+          );
+          return;
+        } catch (retryError) {
+          if (!isQuotaExceededError(retryError)) throw retryError;
+          // Still quota-bound — loop and evict another batch.
+        }
+      }
+      // Exhausted the bounded retry budget. Propagate the original quota
+      // error so `withFallback` switches to the in-memory store.
+      throw error;
+    }
   }
 
   async getEvents(): Promise<GoogleCalendarEvent[]> {

--- a/src/lib/event-cache.ts
+++ b/src/lib/event-cache.ts
@@ -225,15 +225,18 @@ export class IndexedDBEventStore implements EventStore {
       let evicted = 0;
       cursorRequest.onsuccess = () => {
         const cursor = cursorRequest.result;
-        if (!cursor || evicted >= count) {
-          resolve(evicted);
-          return;
-        }
+        // Stop iterating either at end-of-range or once we've evicted N.
+        // Resolution itself is deferred to `transaction.oncomplete` so the
+        // promise only settles after every `cursor.delete()` has actually
+        // committed — otherwise the caller could open a follow-up `put`
+        // before the disk space is reclaimed (#290 review).
+        if (!cursor || evicted >= count) return;
         cursor.delete();
         evicted += 1;
         cursor.continue();
       };
       cursorRequest.onerror = () => reject(cursorRequest.error);
+      transaction.oncomplete = () => resolve(evicted);
       transaction.onerror = () => reject(transaction.error);
     });
   }
@@ -279,9 +282,13 @@ export class EventCache {
     store: EventStore,
     events: GoogleCalendarEvent[]
   ): Promise<void> {
-    const cachedAt = Date.now();
+    // `cachedAt` is re-sampled before every `store.put` attempt so the row's
+    // recency reflects when it was actually written — otherwise the eviction
+    // loop's `evictOldest` latency could backdate the eventual successful
+    // write by hundreds of ms, which would make it look LRU-eligible
+    // sooner than it deserves on the next quota event.
     try {
-      await store.put(events, cachedAt);
+      await store.put(events, Date.now());
       return;
     } catch (error) {
       if (!isQuotaExceededError(error)) throw error;
@@ -297,7 +304,7 @@ export class EventCache {
           throw error;
         }
         try {
-          await store.put(events, cachedAt);
+          await store.put(events, Date.now());
           logger.event(
             "event-cache.lru-evicted",
             { context: "EventCache.saveEvents" },


### PR DESCRIPTION
## Summary

- When `EventCache.saveEvents` trips a `QuotaExceededError`, retry the write after evicting least-recently-cached rows in bounded batches instead of immediately falling back to the in-memory store.
- Add `EventStore.evictOldest(count)` (implemented for both `InMemoryEventStore` and `IndexedDBEventStore`); the IDB path reuses the existing `cachedAt` index, no schema bump.
- Successful eviction-then-retry surfaces a structured `logger.event("event-cache.lru-evicted", …)` carrying the evicted-row count and attempt number.

## Slice

This PR implements **only sub-task 1** of issue #290. The other two sub-tasks are deferred to follow-ups under the same issue:

- [ ] Background `visibilitychange` cleanup sweep (next PR).
- [ ] TTL wired to `UserSettings` — waits on PR #344 (issue #337) to land so it can reuse the `useUserSettings.mutate` + `user-settings-bus` cross-surface sync pattern instead of re-inventing it.

The issue body explicitly says "each can ship as its own PR", so `#290` intentionally stays open after this merges — the remaining sub-tasks track the rest. **No auto-close** keyword in this body.

## Plan

Linked plan: [`.claude/plans/event-cache-lru-eviction-290.md`](https://github.com/BenSeymourODB/next-digital-wall-calendar/blob/claude/ecstatic-mayer-XDMBH/.claude/plans/event-cache-lru-eviction-290.md)
Project: https://github.com/users/BenSeymourODB/projects/1

### Design notes

- **Retry loop lives on the facade**, not the store. `EventStore` already exposes `put` + `evictOldest`; orchestrating the loop in `EventCache.saveEvents` keeps `IndexedDBEventStore` simple and lets the existing mock-`EventStore` test pattern inject `QuotaExceededError` deterministically without needing `fake-indexeddb`.
- **Recency = `cachedAt`**. The issue body suggests "likely `lastReadAt`"; I'm using the existing `cachedAt` because today's access pattern is bulk `getAll` (no per-row reads), so a `lastReadAt` field would either be a no-op (every row touched, all values converge) or require expensive per-row writes on every read. `cachedAt` is already indexed → no schema bump. Documented in the plan.
- **Termination**: bounded by `MAX_EVICTION_ATTEMPTS = 5`, empty-batch break (`evictOldest` returning 0 short-circuits), and non-quota errors propagate immediately to the existing fallback path. After exhausting the budget, the original `QuotaExceededError` is re-thrown so `withFallback` swaps in the in-memory store as before.

## Test plan

- [x] Unit tests cover `InMemoryEventStore.evictOldest` (full, partial, zero, empty-store).
- [x] Unit tests cover `EventCache` orchestration through a mock `EventStore`: retry-after-evict succeeds; structured `logger.event` fires; the bounded retry loop terminates and falls back when quota is unrecoverable; the loop breaks on empty `evictOldest`; non-quota errors skip the eviction path.
- [x] Pre-existing tests (in-memory fallback path, TTL filter, upsert semantics) all still pass.
- [x] `pnpm test` — 2120/2120 green.
- [x] `pnpm lint:fix && pnpm format:fix && pnpm check-types` — clean.

Tracking: #290 (sub-task 1 of 3 — issue intentionally stays open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)