### PR TITLE
refactor(settings): DisplaySection radios → shadcn RadioGroup (#373)

### DIFF
--- a/src/components/settings/display-section.tsx
+++ b/src/components/settings/display-section.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Slider } from "@/components/ui/slider";
 import type { TWeekStartDay } from "@/types/calendar";
 import { useTheme } from "next-themes";
@@ -42,21 +43,18 @@ export function DisplaySection({ values, onChange }: DisplaySectionProps) {
         {/* Theme selection */}
         <fieldset>
           <legend className="text-foreground text-sm font-medium">Theme</legend>
-          <div className="mt-2 flex gap-4">
+          <RadioGroup
+            value={currentTheme}
+            onValueChange={handleThemeChange}
+            className="mt-2 flex gap-4"
+          >
             {THEME_OPTIONS.map((theme) => (
               <Label key={theme} className="flex items-center gap-2">
-                <input
-                  type="radio"
-                  name="theme"
-                  value={theme}
-                  checked={currentTheme === theme}
-                  onChange={() => handleThemeChange(theme)}
-                  className="text-blue-600"
-                />
+                <RadioGroupItem value={theme} />
                 <span className="capitalize">{theme}</span>
               </Label>
             ))}
-          </div>
+          </RadioGroup>
         </fieldset>
 
         {/* Time format */}
@@ -64,30 +62,20 @@ export function DisplaySection({ values, onChange }: DisplaySectionProps) {
           <legend className="text-foreground text-sm font-medium">
             Time Format
           </legend>
-          <div className="mt-2 flex gap-4">
+          <RadioGroup
+            value={values.timeFormat}
+            onValueChange={(timeFormat) => onChange({ timeFormat })}
+            className="mt-2 flex gap-4"
+          >
             <Label className="flex items-center gap-2">
-              <input
-                type="radio"
-                name="timeFormat"
-                value="12h"
-                checked={values.timeFormat === "12h"}
-                onChange={() => onChange({ timeFormat: "12h" })}
-                className="text-blue-600"
-              />
+              <RadioGroupItem value="12h" />
               12-hour
             </Label>
             <Label className="flex items-center gap-2">
-              <input
-                type="radio"
-                name="timeFormat"
-                value="24h"
-                checked={values.timeFormat === "24h"}
-                onChange={() => onChange({ timeFormat: "24h" })}
-                className="text-blue-600"
-              />
+              <RadioGroupItem value="24h" />
               24-hour
             </Label>
-          </div>
+          </RadioGroup>
         </fieldset>
 
         {/* Week start day */}
@@ -95,30 +83,22 @@ export function DisplaySection({ values, onChange }: DisplaySectionProps) {
           <legend className="text-foreground text-sm font-medium">
             Week starts on
           </legend>
-          <div className="mt-2 flex gap-4">
+          <RadioGroup
+            value={String(values.weekStartDay)}
+            onValueChange={(value) =>
+              onChange({ weekStartDay: Number(value) as TWeekStartDay })
+            }
+            className="mt-2 flex gap-4"
+          >
             <Label className="flex items-center gap-2">
-              <input
-                type="radio"
-                name="weekStartDay"
-                value="0"
-                checked={values.weekStartDay === 0}
-                onChange={() => onChange({ weekStartDay: 0 })}
-                className="accent-blue-600"
-              />
+              <RadioGroupItem value="0" />
               Sunday
             </Label>
             <Label className="flex items-center gap-2">
-              <input
-                type="radio"
-                name="weekStartDay"
-                value="1"
-                checked={values.weekStartDay === 1}
-                onChange={() => onChange({ weekStartDay: 1 })}
-                className="accent-blue-600"
-              />
+              <RadioGroupItem value="1" />
               Monday
             </Label>
-          </div>
+          </RadioGroup>
         </fieldset>
 
         {/* Zoom level */}

--- a/src/components/settings/display-section.tsx
+++ b/src/components/settings/display-section.tsx
@@ -50,7 +50,10 @@ export function DisplaySection({ values, onChange }: DisplaySectionProps) {
           >
             {THEME_OPTIONS.map((theme) => (
               <Label key={theme} className="flex items-center gap-2">
-                <RadioGroupItem value={theme} />
+                <RadioGroupItem
+                  value={theme}
+                  data-testid={`display-theme-${theme}`}
+                />
                 <span className="capitalize">{theme}</span>
               </Label>
             ))}
@@ -68,11 +71,17 @@ export function DisplaySection({ values, onChange }: DisplaySectionProps) {
             className="mt-2 flex gap-4"
           >
             <Label className="flex items-center gap-2">
-              <RadioGroupItem value="12h" />
+              <RadioGroupItem
+                value="12h"
+                data-testid="display-time-format-12h"
+              />
               12-hour
             </Label>
             <Label className="flex items-center gap-2">
-              <RadioGroupItem value="24h" />
+              <RadioGroupItem
+                value="24h"
+                data-testid="display-time-format-24h"
+              />
               24-hour
             </Label>
           </RadioGroup>
@@ -91,11 +100,17 @@ export function DisplaySection({ values, onChange }: DisplaySectionProps) {
             className="mt-2 flex gap-4"
           >
             <Label className="flex items-center gap-2">
-              <RadioGroupItem value="0" />
+              <RadioGroupItem
+                value="0"
+                data-testid="display-week-start-day-sunday"
+              />
               Sunday
             </Label>
             <Label className="flex items-center gap-2">
-              <RadioGroupItem value="1" />
+              <RadioGroupItem
+                value="1"
+                data-testid="display-week-start-day-monday"
+              />
               Monday
             </Label>
           </RadioGroup>


### PR DESCRIPTION
## Summary

Closes #373.

Replaces the three native `<input type="radio">` fieldsets (Theme, Time Format, Week starts on) in `src/components/settings/display-section.tsx` with shadcn `RadioGroup` / `RadioGroupItem` — the same primitive `CalendarSettingsPanel` already uses for its radio controls.

- Drops the residual no-op `text-blue-600` (and `accent-blue-600` on Week-starts-on) classes — Radix radio styling now flows through the shadcn primitive's `text-primary` / `border-input` tokens, all on the standard Tailwind palette per CLAUDE.md.
- Preserves the existing `onChange({ … })` contract end-to-end: theme is `string`, timeFormat is `string`, weekStartDay is `Number(value) as TWeekStartDay`. The Theme-section side effect (`setTheme(...)` from `next-themes`) is unchanged.
- The `setTheme` call routes through `handleThemeChange`, which is now the `RadioGroup.onValueChange` handler — semantically the same flow as before.

## Why

Filed from PR #354's review thread ([#discussion_r3204811542](https://github.com/BenSeymourODB/next-digital-wall-calendar/pull/354#discussion_r3204811542)). Theme + Time Format still carried the stale `text-blue-600` class (no visual effect on a native radio — accent comes from `accent-color`, not `color`). #354 fixed the new Week-starts-on radios to `accent-blue-600` as an in-scope correction; this PR finishes the job by moving all three to the shadcn primitive and dropping the colour classes entirely. Consistent radio styling + built-in keyboard/a11y semantics across Settings UI.

## Test plan

- [x] All 13 existing `display-section.test.tsx` tests still pass — `getByLabelText` and `toBeChecked()` work against Radix `role="radio"` + `aria-checked` semantics.
- [x] Full suite (`pnpm test`): 2330 / 2330 passing across 146 files.
- [x] `pnpm lint:fix && pnpm format:fix && pnpm check-types`: clean (0 errors; pre-existing warnings unrelated to this change).

## Plan

No `.claude/plans/` file — this is a small, well-scoped refactor with crisp acceptance criteria in the issue body.

Project: https://github.com/users/BenSeymourODB/projects/1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011yck24117y7RAxcf1oQxVX)_