### PR TITLE
feat(calendar): port E2E tests + canWriteToCalendar from PR #316 (#266)

### DIFF
--- a/e2e/event-detail-modal-readonly.spec.ts
+++ b/e2e/event-detail-modal-readonly.spec.ts
@@ -41,12 +41,18 @@ test.describe("EventDetailModal — read-only access (#266)", () => {
 
     const dialog = page.getByRole("dialog");
     await expect(dialog).toBeVisible();
+    // Guard that the dialog actually opened for the right event before
+    // asserting the button is absent — prevents a silent false-pass if
+    // the trigger selector misses and the dialog never opens.
+    await expect(
+      dialog.getByRole("heading", { name: "Free Busy Event" })
+    ).toBeVisible();
     await expect(
       dialog.getByRole("button", { name: /^delete event$/i })
     ).toHaveCount(0);
   });
 
-  test("still shows the delete button for writable events (control case)", async ({
+  test("shows the delete button when accessRole is absent (permissive default)", async ({
     page,
   }) => {
     await page.goto("/test/calendar?events=single&view=month");

--- a/e2e/event-detail-modal-readonly.spec.ts
+++ b/e2e/event-detail-modal-readonly.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * E2E for #266 — EventDetailModal must not render its delete button when the
+ * source calendar's accessRole is `reader` or `freeBusyReader`. The test page
+ * seeds MockCalendarProvider with the matching accessRolesByCalendarId so the
+ * gating path is exercised without a real Google OAuth session.
+ */
+
+test.use({ video: "retain-on-failure" });
+
+test.describe("EventDetailModal — read-only access (#266)", () => {
+  test("hides the delete button for a reader-access calendar", async ({
+    page,
+  }) => {
+    await page.goto("/test/calendar?events=read-only&view=month");
+
+    const trigger = page.getByRole("button", { name: "Read Only Event" });
+    await expect(trigger).toBeVisible();
+    await trigger.click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    await expect(
+      dialog.getByRole("heading", { name: "Read Only Event" })
+    ).toBeVisible();
+
+    await expect(
+      dialog.getByRole("button", { name: /^delete event$/i })
+    ).toHaveCount(0);
+  });
+
+  test("hides the delete button for a freeBusyReader calendar", async ({
+    page,
+  }) => {
+    await page.goto("/test/calendar?events=free-busy&view=month");
+
+    const trigger = page.getByRole("button", { name: "Free Busy Event" });
+    await expect(trigger).toBeVisible();
+    await trigger.click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    await expect(
+      dialog.getByRole("button", { name: /^delete event$/i })
+    ).toHaveCount(0);
+  });
+
+  test("still shows the delete button for writable events (control case)", async ({
+    page,
+  }) => {
+    await page.goto("/test/calendar?events=single&view=month");
+
+    const trigger = page.getByRole("button", { name: "Single Event" });
+    await expect(trigger).toBeVisible();
+    await trigger.click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    await expect(
+      dialog.getByRole("button", { name: /^delete event$/i })
+    ).toBeVisible();
+  });
+});

--- a/src/app/test/calendar/page.tsx
+++ b/src/app/test/calendar/page.tsx
@@ -17,6 +17,7 @@ import {
 import { Button } from "@/components/ui/button";
 import type {
   IEvent,
+  TCalendarAccessRole,
   TCalendarView,
   TEventColor,
   TWeekStartDay,
@@ -179,6 +180,33 @@ function buildMockEventSets(anchor: Date): Record<string, IEvent[]> {
         startDate: getRelativeDate(6, 10, 0),
         endDate: getRelativeDate(6, 12, 0),
         color: "blue",
+      }),
+    ],
+
+    // Single event on a read-only calendar (accessRole="reader"). Paired with
+    // `?events=read-only` so the E2E suite can assert that EventDetailModal
+    // hides the delete button for reader-access calendars (#266).
+    "read-only": [
+      createMockEvent({
+        id: "ro-1",
+        title: "Read Only Event",
+        calendarId: "shared-readonly",
+        startDate: getRelativeDate(0, 10, 0),
+        endDate: getRelativeDate(0, 11, 0),
+        color: "purple",
+      }),
+    ],
+
+    // Single event on a freeBusyReader calendar. Covers the stricter
+    // accessRole branch of the delete-gating path in its own E2E lane (#266).
+    "free-busy": [
+      createMockEvent({
+        id: "fb-1",
+        title: "Free Busy Event",
+        calendarId: "freebusy-cal",
+        startDate: getRelativeDate(0, 10, 0),
+        endDate: getRelativeDate(0, 11, 0),
+        color: "purple",
       }),
     ],
 
@@ -503,6 +531,19 @@ function TestCalendarContent() {
   // Get events for the specified set
   const events = mockEventSets[eventSet] || mockEventSets.default;
 
+  // Seed accessRoles for the read-only test sets so EventDetailModal's
+  // delete-gating logic (#266) is exercisable without a real Google OAuth
+  // session. Other event sets get no access-role map and fall through to the
+  // permissive default.
+  const accessRolesByCalendarId:
+    | Record<string, TCalendarAccessRole>
+    | undefined =
+    eventSet === "read-only"
+      ? { "shared-readonly": "reader" }
+      : eventSet === "free-busy"
+        ? { "freebusy-cal": "freeBusyReader" }
+        : undefined;
+
   return (
     <MockCalendarProvider
       initialEvents={events}
@@ -514,6 +555,7 @@ function TestCalendarContent() {
       use24HourFormat={use24Hour}
       weekStartDay={weekStartDayParam}
       transitionDurationMs={transitionDurationMs}
+      accessRolesByCalendarId={accessRolesByCalendarId}
     >
       <div className="container mx-auto max-w-6xl p-4" data-testid="test-page">
         <h1 className="mb-4 text-2xl font-bold text-gray-900">

--- a/src/components/calendar/EventDetailModal.tsx
+++ b/src/components/calendar/EventDetailModal.tsx
@@ -20,6 +20,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { canWriteToCalendar } from "@/lib/google-calendar-mappers";
 import type {
   IEvent,
   TCalendarAccessRole,
@@ -65,10 +66,6 @@ interface EventDetailModalProps {
    * list doesn't accidentally hide the button on owned calendars.
    */
   accessRole?: TCalendarAccessRole;
-}
-
-function isReadOnlyRole(role: TCalendarAccessRole | undefined): boolean {
-  return role === "reader" || role === "freeBusyReader";
 }
 
 function getInitials(name: string): string {
@@ -118,7 +115,7 @@ export function EventDetailModal({
   // Single chokepoint for "this calendar disallows mutation". When #265
   // adds the edit (PATCH) button it should reuse this same flag rather
   // than re-deriving the rule.
-  const canDelete = Boolean(onDelete) && !isReadOnlyRole(accessRole);
+  const canDelete = Boolean(onDelete) && canWriteToCalendar(accessRole);
 
   const handleConfirmDelete = async () => {
     if (!onDelete) return;

--- a/src/lib/__tests__/google-calendar-mappers.test.ts
+++ b/src/lib/__tests__/google-calendar-mappers.test.ts
@@ -16,6 +16,7 @@ import {
   normalizeCalendarListEntry,
   normalizeFetchedEvent,
 } from "@/lib/google-calendar";
+import { canWriteToCalendar } from "@/lib/google-calendar-mappers";
 import { describe, expect, it } from "vitest";
 
 describe("normalizeFetchedEvent", () => {
@@ -342,6 +343,26 @@ describe("end-to-end: enriched API responses flow through the mappers", () => {
     expect(mapped[0]?.selected).toBe(true);
     expect(mapped[1]?.accessRole).toBe("reader");
     expect(mapped[1]?.summary).toBe("Shared");
+  });
+});
+
+describe("canWriteToCalendar (#266)", () => {
+  it("returns true for owner and writer roles", () => {
+    expect(canWriteToCalendar("owner")).toBe(true);
+    expect(canWriteToCalendar("writer")).toBe(true);
+  });
+
+  it("returns false for reader and freeBusyReader roles", () => {
+    expect(canWriteToCalendar("reader")).toBe(false);
+    expect(canWriteToCalendar("freeBusyReader")).toBe(false);
+  });
+
+  it("returns true when role is undefined (permissive default)", () => {
+    // `undefined` means the calendar list hasn't loaded yet or the
+    // calendarId wasn't in the payload. Failing closed here would
+    // silently hide delete buttons on owned calendars — Google's
+    // server-side 403 is the backstop for actual permission changes.
+    expect(canWriteToCalendar(undefined)).toBe(true);
   });
 });
 

--- a/src/lib/google-calendar-mappers.ts
+++ b/src/lib/google-calendar-mappers.ts
@@ -13,6 +13,18 @@
 import type { TCalendarAccessRole } from "@/types/calendar";
 
 /**
+ * Returns true when the access role permits write actions (create, update,
+ * delete). `undefined` is treated as permissive so a not-yet-loaded calendar
+ * list doesn't silently disable UI for owner/writer calendars — Google's
+ * server-side 403 remains the safety net for race conditions (#266).
+ */
+export function canWriteToCalendar(
+  role: TCalendarAccessRole | undefined
+): boolean {
+  return role === undefined || role === "owner" || role === "writer";
+}
+
+/**
  * Canonical shape of a Google Calendar event inside the app.
  *
  * Extends `Omit<gapi.client.calendar.Event, "summary">` so every field on the


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Three additions from the competing PR #316 that were absent from the merged PR #304, as identified in issue #365's triage:

- **`canWriteToCalendar()` export** — extracted from the file-private `isReadOnlyRole()` helper in `EventDetailModal` and moved to `google-calendar-mappers.ts` as a named export. The modal now calls it directly. Future callers (e.g. the edit-button gating planned in #265) can import it without reimplementing the rule.

- **Test-page fixtures** — `?events=read-only` and `?events=free-busy` query params added to `/test/calendar`. Each seeds `MockCalendarProvider` with the matching `accessRolesByCalendarId` so the delete-gating path is exercisable without a real Google OAuth session.

- **E2E Playwright suite** — `e2e/event-detail-modal-readonly.spec.ts` with three tests: `reader` hides delete, `freeBusyReader` hides delete, writable event shows delete (control case).

## What was deliberately *not* ported

PR #316's core implementation diverged from #304 in API shape (`canDelete` bool prop vs `accessRole` prop; `canEditCalendar()` vs `getAccessRole()` on context). Those differences are not ported — #304's API is already on `main` and the two are incompatible. Only the additions that don't conflict were cherry-picked.

## Test plan

- [ ] `pnpm lint:fix && pnpm format:fix && pnpm check-types` — clean (verified locally)
- [ ] `pnpm test` — existing suite passes unchanged
- [ ] Playwright: `pnpm exec playwright test e2e/event-detail-modal-readonly.spec.ts` — all 3 tests green (requires dev server)
- [ ] Manual smoke: `/test/calendar?events=read-only&view=month` → click event → no Delete button; `?events=single` → Delete button present

Closes #316 (supersedes competing implementation — the unique additions are now on `main`).

https://claude.ai/code/session_01PL3FYAUAqLro6vqgKzDHoY
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PL3FYAUAqLro6vqgKzDHoY)_