### PR TITLE
fix(tasks): /test/tasks list-agnostic by default (rebased #256)

### DIFF
--- a/.claude/plans/test-tasks-list-agnostic-236.md
+++ b/.claude/plans/test-tasks-list-agnostic-236.md
@@ -1,0 +1,85 @@
+# `/test/tasks` page — list-agnostic by default (Issue #236)
+
+## Problem
+
+`src/app/test/tasks/page.tsx` always renders `TaskList` against a hard-coded
+mock config containing `listId: "list-groceries"`. Playwright suites work
+because they mock every `/api/tasks*` call, but a real signed-in user gets
+the inline error _"Failed to fetch tasks from list Groceries"_ because the
+list does not exist in their Google Tasks account.
+
+## Goal
+
+Make `/test/tasks` work for any signed-in user by defaulting to a "live"
+mode that fetches the user's real task lists, auto-selects the first
+available one, and exposes a picker so they can switch between lists.
+Preserve the existing `?lists=single` / `?lists=multi` mock harnesses
+unchanged so the existing Playwright suite keeps passing.
+
+## Phases
+
+### Phase 1 — Add live mode + UI affordances
+
+Refactor `page.tsx`:
+
+- Mode resolved from `?lists=` query param:
+  - `?lists=single` → existing single-list mock (unchanged)
+  - `?lists=multi` → existing multi-list mock (unchanged)
+  - **default (no param) → new live mode**
+- Live mode is a small client component that:
+  - Fetches `GET /api/tasks/lists` on mount
+  - Renders a loading skeleton while the fetch is in-flight
+  - Renders an error card with a "Try again" button if the fetch fails
+  - Renders an empty-state card when the user has no task lists
+  - Otherwise renders a `<select>` list-picker (auto-selected to the first
+    list) plus the existing `TaskList` for the chosen list
+- A small `data-testid` per state so component tests + Playwright can
+  assert deterministically.
+- Update `e2e/new-task-modal.spec.ts` to explicitly use `?lists=single`
+  (the variant the existing assertions describe). This is not a test
+  weakening — the same behaviour is still asserted, just under the
+  explicit URL that documents the mock harness.
+
+Mapping `GoogleTaskList[]` → `TaskListSelection[]`: cycle through
+`DEFAULT_LIST_COLORS` so each list gets a distinct swatch. This keeps
+the live-mode picker visually consistent with the existing settings UI.
+
+### Phase 2 — Component test + Playwright E2E
+
+- New Vitest spec `src/app/test/tasks/__tests__/page.test.tsx` covering
+  the page component:
+  1. Renders single-list mock when `?lists=single`
+  2. Renders multi-list mock when `?lists=multi`
+  3. Live mode shows loading skeleton while `/api/tasks/lists` is in-flight
+  4. Live mode shows error card on fetch failure; "Try again" refetches
+  5. Live mode shows empty state when the user has zero lists
+  6. Live mode auto-selects the first list and renders `TaskList`
+  7. Switching the picker swaps the rendered list
+- New Playwright spec `e2e/test-tasks-live-mode.spec.ts` (video: on)
+  intercepts `/api/tasks/lists` and `/api/tasks*` and asserts:
+  - Loading → list-picker visible → first list auto-selected → TaskList renders
+  - Switching the picker re-fetches against the new listId
+  - Empty state when the user has no lists
+  - Error state with retry when the fetch fails
+- Existing `e2e/new-task-modal.spec.ts` updated to use `?lists=single` /
+  `?lists=multi`. No assertion changes — just URL prefix.
+
+## Acceptance criteria
+
+- [ ] `/test/tasks` (no query param) renders the user's real task lists
+      with a picker, auto-selecting the first
+- [ ] Loading, error, and empty states all render with helpful copy
+- [ ] `/test/tasks?lists=single` and `/test/tasks?lists=multi` continue
+      to render the existing mock harnesses unchanged
+- [ ] All existing tests still pass
+- [ ] New Vitest + Playwright tests cover the live mode states + picker
+- [ ] No `test-results/` / `playwright-report/` / `blob-report/` committed
+- [ ] `pnpm test && pnpm lint:fix && pnpm format:fix && pnpm check-types` clean
+
+## Out of scope / deferred
+
+- Persisting the picker selection to localStorage (probably worth a
+  follow-up alongside #208's filter-persistence work).
+- Surfacing the live mode at the production tasks UI (`/test/tasks` is
+  explicitly a developer harness; the production wiring lives elsewhere
+  and is tracked under #166 / #200).

--- a/.claude/plans/test-tasks-list-agnostic-236.md
+++ b/.claude/plans/test-tasks-list-agnostic-236.md
@@ -76,10 +76,16 @@ the live-mode picker visually consistent with the existing settings UI.
 - [ ] No `test-results/` / `playwright-report/` / `blob-report/` committed
 - [ ] `pnpm test && pnpm lint:fix && pnpm format:fix && pnpm check-types` clean
 
+## Shipped beyond the original scope
+
+- Persisting the picker selection to localStorage — folded in during the
+  rebase onto current `main` (commit `3018c50`) to preserve the behaviour
+  PR #289 added while this branch sat on a stale base. Driven by
+  `useLocalStorage(LIVE_LIST_LS_KEY)`; covered by the `picker persistence
+(#289)` describe block in `page.test.tsx`.
+
 ## Out of scope / deferred
 
-- Persisting the picker selection to localStorage (probably worth a
-  follow-up alongside #208's filter-persistence work).
 - Surfacing the live mode at the production tasks UI (`/test/tasks` is
   explicitly a developer harness; the production wiring lives elsewhere
   and is tracked under #166 / #200).

--- a/e2e/new-task-modal.spec.ts
+++ b/e2e/new-task-modal.spec.ts
@@ -97,7 +97,7 @@ test.describe("NewTaskModal launched from TaskList", () => {
   test("opens the dialog from the Add Task footer button", async ({ page }) => {
     await mockTasksApi(page);
 
-    await page.goto("/test/tasks");
+    await page.goto("/test/tasks?lists=single");
 
     const addBtn = page.getByRole("button", { name: /add task/i });
     await expect(addBtn).toBeVisible();
@@ -112,7 +112,7 @@ test.describe("NewTaskModal launched from TaskList", () => {
 
   test("smart default pre-selects the only enabled list", async ({ page }) => {
     await mockTasksApi(page);
-    await page.goto("/test/tasks");
+    await page.goto("/test/tasks?lists=single");
 
     await page.getByRole("button", { name: /add task/i }).click();
     const dialog = page.getByRole("dialog");
@@ -138,7 +138,7 @@ test.describe("NewTaskModal launched from TaskList", () => {
     page,
   }) => {
     await mockTasksApi(page);
-    await page.goto("/test/tasks");
+    await page.goto("/test/tasks?lists=single");
 
     await page.getByRole("button", { name: /add task/i }).click();
     const dialog = page.getByRole("dialog");
@@ -154,7 +154,7 @@ test.describe("NewTaskModal launched from TaskList", () => {
     page,
   }) => {
     const { created } = await mockTasksApi(page);
-    await page.goto("/test/tasks");
+    await page.goto("/test/tasks?lists=single");
 
     // Initial empty state
     await expect(page.getByText(/no tasks/i)).toBeVisible();
@@ -187,7 +187,7 @@ test.describe("NewTaskModal launched from TaskList", () => {
     const api = await mockTasksApi(page);
     api.setNextPostFailure(500, { error: "Server boom" });
 
-    await page.goto("/test/tasks");
+    await page.goto("/test/tasks?lists=single");
 
     await page.getByRole("button", { name: /add task/i }).click();
     const dialog = page.getByRole("dialog");
@@ -203,7 +203,7 @@ test.describe("NewTaskModal launched from TaskList", () => {
     page,
   }) => {
     const { created } = await mockTasksApi(page);
-    await page.goto("/test/tasks");
+    await page.goto("/test/tasks?lists=single");
 
     await page.getByRole("button", { name: /add task/i }).click();
     const dialog = page.getByRole("dialog");

--- a/e2e/test-tasks-live-mode.spec.ts
+++ b/e2e/test-tasks-live-mode.spec.ts
@@ -22,7 +22,6 @@ async function mockLiveListsApi(
   page: Page,
   options: {
     lists?: MockGoogleTaskList[] | "fail";
-    delayLists?: number;
     tasksByListId?: Record<string, Array<{ id: string; title: string }>>;
   } = {}
 ): Promise<{ failNextLists: () => void; getListsRequestCount: () => number }> {
@@ -39,10 +38,6 @@ async function mockLiveListsApi(
 
   await page.route("**/api/tasks/lists", async (route) => {
     listsRequestCount += 1;
-
-    if (options.delayLists && listsRequestCount === 1) {
-      await new Promise((resolve) => setTimeout(resolve, options.delayLists));
-    }
 
     if (options.lists === "fail" || failNext) {
       failNext = false;
@@ -85,7 +80,7 @@ async function mockLiveListsApi(
 }
 
 test.describe("/test/tasks live mode", () => {
-  test("renders a loading state then auto-selects the first list", async ({
+  test("auto-selects the first list and renders its tasks", async ({
     page,
   }) => {
     await mockLiveListsApi(page, {
@@ -93,7 +88,6 @@ test.describe("/test/tasks live mode", () => {
         { id: "list-personal", title: "Personal" },
         { id: "list-work", title: "Work" },
       ],
-      delayLists: 200,
       tasksByListId: {
         "list-personal": [{ id: "t1", title: "Personal task" }],
         "list-work": [{ id: "t2", title: "Work task" }],
@@ -102,10 +96,10 @@ test.describe("/test/tasks live mode", () => {
 
     await page.goto("/test/tasks");
 
-    // Loading skeleton shows briefly while the lists fetch resolves.
-    await expect(page.getByTestId("test-tasks-live-loading")).toBeVisible();
-
-    // Once ready, the picker is rendered with the first list selected.
+    // The loading skeleton is asserted in the Vitest unit tests where we
+    // can pause the fetch deterministically. In Playwright the skeleton
+    // can flash for less than a frame on a fast CI runner, so we go
+    // straight to asserting the steady-state UI.
     await expect(page.getByTestId("test-tasks-live-ready")).toBeVisible();
     const picker = page.getByTestId("test-tasks-live-picker");
     await expect(picker).toHaveValue("list-personal");
@@ -204,6 +198,35 @@ test.describe("/test/tasks live mode", () => {
       "list-recovered"
     );
     expect(listsCallCount).toBeGreaterThanOrEqual(2);
+  });
+
+  test("renders the reauth state with a Sign-in link when the API requires reauth", async ({
+    page,
+  }) => {
+    await page.route("**/api/tasks/lists", async (route) => {
+      await route.fulfill({
+        status: 401,
+        contentType: "application/json",
+        body: JSON.stringify({
+          error: "Missing Google Tasks scope. Please sign in again.",
+          requiresReauth: true,
+        }),
+      });
+    });
+
+    await page.goto("/test/tasks");
+
+    const reauth = page.getByTestId("test-tasks-live-reauth");
+    await expect(reauth).toBeVisible();
+    await expect(reauth).toContainText(/sign in again/i);
+    // Critical: the generic "Try again" button must NOT render in this
+    // state — clicking it would refire the same 401 in a loop.
+    await expect(page.getByRole("button", { name: /try again/i })).toHaveCount(
+      0
+    );
+    await expect(
+      page.getByRole("link", { name: /sign in again/i })
+    ).toHaveAttribute("href", "/api/auth/signin");
   });
 
   test("mock-harness ?lists=single still renders the existing single-list mock", async ({

--- a/e2e/test-tasks-live-mode.spec.ts
+++ b/e2e/test-tasks-live-mode.spec.ts
@@ -1,0 +1,249 @@
+import { type Page, type Route, expect, test } from "@playwright/test";
+
+/**
+ * E2E for the live mode of /test/tasks (#236).
+ *
+ * The default URL (`/test/tasks` with no query param) fetches the
+ * user's real task lists from `/api/tasks/lists`, auto-selects the
+ * first, and exposes a `<select>` picker. We intercept both
+ * `/api/tasks/lists` and `/api/tasks*` so the suite runs without a
+ * Google session, and capture video so the PR can visually document
+ * the loading → ready → switch flow.
+ */
+
+test.use({ video: "on" });
+
+interface MockGoogleTaskList {
+  id: string;
+  title: string;
+}
+
+async function mockLiveListsApi(
+  page: Page,
+  options: {
+    lists?: MockGoogleTaskList[] | "fail";
+    delayLists?: number;
+    tasksByListId?: Record<string, Array<{ id: string; title: string }>>;
+  } = {}
+): Promise<{ failNextLists: () => void; getListsRequestCount: () => number }> {
+  let listsRequestCount = 0;
+  let failNext = false;
+  const tasksByListId = options.tasksByListId ?? {};
+
+  const fulfillJson = (route: Route, status: number, body: unknown) =>
+    route.fulfill({
+      status,
+      contentType: "application/json",
+      body: JSON.stringify(body),
+    });
+
+  await page.route("**/api/tasks/lists", async (route) => {
+    listsRequestCount += 1;
+
+    if (options.delayLists && listsRequestCount === 1) {
+      await new Promise((resolve) => setTimeout(resolve, options.delayLists));
+    }
+
+    if (options.lists === "fail" || failNext) {
+      failNext = false;
+      await fulfillJson(route, 500, { error: "boom" });
+      return;
+    }
+
+    await fulfillJson(route, 200, { lists: options.lists ?? [] });
+  });
+
+  await page.route("**/api/tasks*", async (route) => {
+    const url = new URL(route.request().url());
+
+    // Tasks query — return tasks for the requested listId
+    if (url.pathname === "/api/tasks" && route.request().method() === "GET") {
+      const listId = url.searchParams.get("listId") ?? "";
+      const tasks = tasksByListId[listId] ?? [];
+      await fulfillJson(route, 200, {
+        tasks: tasks.map((t) => ({
+          id: t.id,
+          title: t.title,
+          status: "needsAction",
+          updated: new Date().toISOString(),
+          position: "00000000000000000000",
+        })),
+      });
+      return;
+    }
+
+    // Anything else — let through (page.route() unmocked = network).
+    await route.continue();
+  });
+
+  return {
+    failNextLists: () => {
+      failNext = true;
+    },
+    getListsRequestCount: () => listsRequestCount,
+  };
+}
+
+test.describe("/test/tasks live mode", () => {
+  test("renders a loading state then auto-selects the first list", async ({
+    page,
+  }) => {
+    await mockLiveListsApi(page, {
+      lists: [
+        { id: "list-personal", title: "Personal" },
+        { id: "list-work", title: "Work" },
+      ],
+      delayLists: 200,
+      tasksByListId: {
+        "list-personal": [{ id: "t1", title: "Personal task" }],
+        "list-work": [{ id: "t2", title: "Work task" }],
+      },
+    });
+
+    await page.goto("/test/tasks");
+
+    // Loading skeleton shows briefly while the lists fetch resolves.
+    await expect(page.getByTestId("test-tasks-live-loading")).toBeVisible();
+
+    // Once ready, the picker is rendered with the first list selected.
+    await expect(page.getByTestId("test-tasks-live-ready")).toBeVisible();
+    const picker = page.getByTestId("test-tasks-live-picker");
+    await expect(picker).toHaveValue("list-personal");
+
+    // The TaskList for the auto-selected list renders its task.
+    await expect(page.getByText("Personal task")).toBeVisible();
+  });
+
+  test("switching the picker fetches tasks for the chosen list", async ({
+    page,
+  }) => {
+    await mockLiveListsApi(page, {
+      lists: [
+        { id: "list-personal", title: "Personal" },
+        { id: "list-work", title: "Work" },
+      ],
+      tasksByListId: {
+        "list-personal": [{ id: "t1", title: "Personal task" }],
+        "list-work": [{ id: "t2", title: "Work task" }],
+      },
+    });
+
+    await page.goto("/test/tasks");
+
+    await expect(page.getByText("Personal task")).toBeVisible();
+
+    await page.getByTestId("test-tasks-live-picker").selectOption("list-work");
+
+    await expect(page.getByText("Work task")).toBeVisible();
+    await expect(page.getByText("Personal task")).not.toBeVisible();
+  });
+
+  test("shows the empty state when the user has no task lists", async ({
+    page,
+  }) => {
+    await mockLiveListsApi(page, { lists: [] });
+
+    await page.goto("/test/tasks");
+
+    const empty = page.getByTestId("test-tasks-live-empty");
+    await expect(empty).toBeVisible();
+    await expect(empty).toContainText(/no task lists/i);
+
+    // Picker is not rendered when there are no lists.
+    await expect(page.getByTestId("test-tasks-live-picker")).toHaveCount(0);
+  });
+
+  test("shows the error state with a working retry when the fetch fails", async ({
+    page,
+  }) => {
+    let listsCallCount = 0;
+
+    await page.route("**/api/tasks/lists", async (route) => {
+      listsCallCount += 1;
+      if (listsCallCount === 1) {
+        await route.fulfill({
+          status: 500,
+          contentType: "application/json",
+          body: JSON.stringify({ error: "boom" }),
+        });
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          lists: [{ id: "list-recovered", title: "Recovered" }],
+        }),
+      });
+    });
+
+    // Tasks endpoint just needs to return empty so TaskList doesn't error.
+    await page.route("**/api/tasks*", async (route) => {
+      const url = new URL(route.request().url());
+      if (url.pathname === "/api/tasks") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ tasks: [] }),
+        });
+        return;
+      }
+      await route.continue();
+    });
+
+    await page.goto("/test/tasks");
+
+    const error = page.getByTestId("test-tasks-live-error");
+    await expect(error).toBeVisible();
+    await expect(error).toContainText(/couldn.?t load your task lists/i);
+
+    await page.getByRole("button", { name: /try again/i }).click();
+
+    await expect(page.getByTestId("test-tasks-live-ready")).toBeVisible();
+    await expect(page.getByTestId("test-tasks-live-picker")).toHaveValue(
+      "list-recovered"
+    );
+    expect(listsCallCount).toBeGreaterThanOrEqual(2);
+  });
+
+  test("mock-harness ?lists=single still renders the existing single-list mock", async ({
+    page,
+  }) => {
+    // Live mode would call /api/tasks/lists; assert it is NOT called by
+    // setting up a route that fails the test if hit.
+    let listsCalled = false;
+    await page.route("**/api/tasks/lists", async (route) => {
+      listsCalled = true;
+      await route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "should-not-be-called" }),
+      });
+    });
+
+    await page.route("**/api/tasks*", async (route) => {
+      const url = new URL(route.request().url());
+      if (url.pathname === "/api/tasks") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ tasks: [] }),
+        });
+        return;
+      }
+      await route.continue();
+    });
+
+    await page.goto("/test/tasks?lists=single");
+
+    await expect(page.getByTestId("test-tasks-mode-banner")).toContainText(
+      /\?lists=single/
+    );
+    expect(listsCalled).toBe(false);
+
+    // The single-list mock harness renders the TaskList card.
+    await expect(
+      page.getByRole("heading", { name: /my tasks/i })
+    ).toBeVisible();
+  });
+});

--- a/src/app/test/tasks/__tests__/page.test.tsx
+++ b/src/app/test/tasks/__tests__/page.test.tsx
@@ -1,119 +1,255 @@
 /**
- * Tests for /test/tasks page — live-mode list-picker localStorage persistence (#289)
+ * Tests for `/test/tasks` page (#236).
  *
- * The page always renders a live-mode section with a <select> that lets the
- * tester pick which Google Tasks list to display. The selection is persisted
- * to localStorage under the key "test-tasks.live-list" so it survives reloads.
+ * The page exposes three modes:
+ * - `?lists=single` — renders a hard-coded single-list mock harness
+ * - `?lists=multi`  — renders a hard-coded multi-list mock harness
+ * - default         — live mode: fetches the user's real lists from
+ *                     `/api/tasks/lists`, auto-selects the first, and
+ *                     exposes a picker so the user can switch between
+ *                     them. Renders loading / error / empty states.
  */
-import { render, screen, waitFor } from "@testing-library/react";
+import { TaskList } from "@/components/tasks/task-list";
+import type { TaskListConfig } from "@/components/tasks/types";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-// ---- component import (after mocks) -------------------------------------- //
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import TestTasksPage from "../page";
 
-// ---- localStorage stub --------------------------------------------------- //
-const mockStorage: Record<string, string> = {};
-vi.stubGlobal("localStorage", {
-  getItem: (key: string) => mockStorage[key] ?? null,
-  setItem: (key: string, value: string) => {
-    mockStorage[key] = value;
-  },
-  removeItem: (key: string) => {
-    delete mockStorage[key];
-  },
-  clear: () => {
-    Object.keys(mockStorage).forEach((k) => delete mockStorage[k]);
-  },
-});
+let mockSearch = new URLSearchParams();
 
-// ---- next/navigation stub ------------------------------------------------ //
 vi.mock("next/navigation", () => ({
-  useSearchParams: () => ({
-    get: () => null,
-  }),
+  useSearchParams: () => mockSearch,
 }));
 
-// ---- fetch stub ---------------------------------------------------------- //
+vi.mock("@/components/tasks/task-list", () => ({
+  TaskList: vi.fn(() => null),
+}));
+
+const mockTaskList = vi.mocked(TaskList);
+
 const mockFetch = vi.fn();
-global.fetch = mockFetch;
+global.fetch = mockFetch as unknown as typeof fetch;
 
-const MOCK_LISTS = [
-  { id: "list-1", title: "Groceries", updated: "2024-01-01T00:00:00Z" },
-  { id: "list-2", title: "Work", updated: "2024-01-01T00:00:00Z" },
-];
-
-function makeFetchResponse(data: unknown) {
-  return Promise.resolve({
-    ok: true,
-    json: () => Promise.resolve(data),
-  } as Response);
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  } as unknown as Response;
 }
 
-// -------------------------------------------------------------------------- //
+function getRenderedConfig(callIndex = 0): TaskListConfig {
+  const call = mockTaskList.mock.calls[callIndex];
+  if (!call) {
+    throw new Error(
+      `TaskList was not rendered (looking for call ${callIndex}, ` +
+        `received ${mockTaskList.mock.calls.length})`
+    );
+  }
+  return (call[0] as { config: TaskListConfig }).config;
+}
 
-const LS_KEY = "test-tasks.live-list";
-
-describe("/test/tasks page — live-mode list picker", () => {
+describe("/test/tasks page", () => {
   beforeEach(() => {
-    // Clear storage and mock state between tests
-    Object.keys(mockStorage).forEach((k) => delete mockStorage[k]);
+    mockSearch = new URLSearchParams();
     mockFetch.mockReset();
-    mockFetch.mockReturnValue(makeFetchResponse({ lists: MOCK_LISTS }));
+    mockTaskList.mockClear();
   });
 
-  it("renders a list picker select element", async () => {
-    render(<TestTasksPage />);
-    await waitFor(() => {
-      expect(
-        screen.getByRole("combobox", { name: /live list/i })
-      ).toBeInTheDocument();
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("mock harness mode", () => {
+    it("renders the single-list mock when ?lists=single", async () => {
+      mockSearch = new URLSearchParams("lists=single");
+      render(<TestTasksPage />);
+      await waitFor(() => expect(mockTaskList).toHaveBeenCalled());
+
+      const config = getRenderedConfig();
+      expect(config.lists).toHaveLength(1);
+      expect(config.lists[0]).toMatchObject({
+        listId: "list-groceries",
+        listTitle: "Groceries",
+        enabled: true,
+      });
+    });
+
+    it("renders the multi-list mock when ?lists=multi", async () => {
+      mockSearch = new URLSearchParams("lists=multi");
+      render(<TestTasksPage />);
+      await waitFor(() => expect(mockTaskList).toHaveBeenCalled());
+
+      const config = getRenderedConfig();
+      expect(config.lists).toHaveLength(2);
+      expect(config.lists.map((l) => l.listId)).toEqual([
+        "list-groceries",
+        "list-work",
+      ]);
+    });
+
+    it("does not call the lists API in mock mode", async () => {
+      mockSearch = new URLSearchParams("lists=single");
+      render(<TestTasksPage />);
+      await waitFor(() => expect(mockTaskList).toHaveBeenCalled());
+
+      expect(mockFetch).not.toHaveBeenCalled();
     });
   });
 
-  it("populates the picker with fetched lists", async () => {
-    render(<TestTasksPage />);
-    await waitFor(() => {
-      expect(
-        screen.getByRole("option", { name: "Groceries" })
-      ).toBeInTheDocument();
-      expect(screen.getByRole("option", { name: "Work" })).toBeInTheDocument();
-    });
-  });
-
-  it("persists selection to localStorage when user changes the picker", async () => {
-    const user = userEvent.setup();
-    render(<TestTasksPage />);
-
-    const select = await screen.findByRole("combobox", { name: /live list/i });
-    await user.selectOptions(select, "list-2");
-
-    expect(mockStorage[LS_KEY]).toBe(JSON.stringify("list-2"));
-  });
-
-  it("restores a previously saved selection on remount", async () => {
-    // Pre-seed storage with a saved list id
-    mockStorage[LS_KEY] = JSON.stringify("list-2");
-
-    render(<TestTasksPage />);
-
-    const select = await screen.findByRole("combobox", { name: /live list/i });
-    await waitFor(() => {
-      expect((select as HTMLSelectElement).value).toBe("list-2");
-    });
-  });
-
-  it("falls back to default when persisted id is not in the fetched lists (stale)", async () => {
-    // Persisted id references a list that no longer exists
-    mockStorage[LS_KEY] = JSON.stringify("list-stale-deleted");
-
-    render(<TestTasksPage />);
-
-    const select = await screen.findByRole("combobox", { name: /live list/i });
-    await waitFor(() => {
-      // Should not throw; value should fall back to an empty/default selection
-      expect((select as HTMLSelectElement).value).not.toBe(
-        "list-stale-deleted"
+  describe("live mode", () => {
+    it("shows a loading state while /api/tasks/lists is in flight", async () => {
+      let resolveFetch: ((value: Response) => void) | undefined;
+      mockFetch.mockImplementation(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolveFetch = resolve;
+          })
       );
+
+      render(<TestTasksPage />);
+
+      expect(screen.getByTestId("test-tasks-live-loading")).toBeInTheDocument();
+      expect(mockFetch).toHaveBeenCalledWith("/api/tasks/lists");
+      expect(mockTaskList).not.toHaveBeenCalled();
+
+      // Cleanup: resolve the promise so the test doesn't leak.
+      await act(async () => {
+        resolveFetch?.(jsonResponse({ lists: [] }));
+        await Promise.resolve();
+      });
+    });
+
+    it("renders the error state when the lists fetch fails", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ error: "boom" }, 500));
+
+      render(<TestTasksPage />);
+
+      const errorBox = await screen.findByTestId("test-tasks-live-error");
+      expect(errorBox).toBeInTheDocument();
+      expect(errorBox).toHaveTextContent(/couldn.?t load your task lists/i);
+      expect(
+        screen.getByRole("button", { name: /try again/i })
+      ).toBeInTheDocument();
+      expect(mockTaskList).not.toHaveBeenCalled();
+    });
+
+    it("retries the fetch when 'Try again' is clicked", async () => {
+      mockFetch
+        .mockResolvedValueOnce(jsonResponse({ error: "boom" }, 500))
+        .mockResolvedValueOnce(
+          jsonResponse({
+            lists: [
+              { id: "abc", title: "Personal", updated: "2026-05-01T00:00Z" },
+            ],
+          })
+        );
+
+      const user = userEvent.setup();
+      render(<TestTasksPage />);
+
+      await screen.findByTestId("test-tasks-live-error");
+      await user.click(screen.getByRole("button", { name: /try again/i }));
+
+      await waitFor(() => expect(mockTaskList).toHaveBeenCalled());
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(getRenderedConfig().lists[0].listId).toBe("abc");
+    });
+
+    it("renders the empty state when the user has no task lists", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ lists: [] }));
+
+      render(<TestTasksPage />);
+
+      const empty = await screen.findByTestId("test-tasks-live-empty");
+      expect(empty).toBeInTheDocument();
+      expect(empty).toHaveTextContent(/no task lists/i);
+      expect(mockTaskList).not.toHaveBeenCalled();
+    });
+
+    it("auto-selects the first list and renders TaskList for it", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({
+          lists: [
+            { id: "list-a", title: "Personal", updated: "2026-05-01T00:00Z" },
+            { id: "list-b", title: "Work", updated: "2026-05-01T00:00Z" },
+          ],
+        })
+      );
+
+      render(<TestTasksPage />);
+
+      await waitFor(() => expect(mockTaskList).toHaveBeenCalled());
+
+      const picker = screen.getByLabelText(/^task list$/i);
+      expect((picker as HTMLSelectElement).value).toBe("list-a");
+
+      const config = getRenderedConfig();
+      expect(config.lists).toHaveLength(1);
+      expect(config.lists[0]).toMatchObject({
+        listId: "list-a",
+        listTitle: "Personal",
+        enabled: true,
+      });
+    });
+
+    it("re-renders TaskList for the chosen list when the picker changes", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({
+          lists: [
+            { id: "list-a", title: "Personal", updated: "2026-05-01T00:00Z" },
+            { id: "list-b", title: "Work", updated: "2026-05-01T00:00Z" },
+          ],
+        })
+      );
+
+      const user = userEvent.setup();
+      render(<TestTasksPage />);
+
+      await waitFor(() => expect(mockTaskList).toHaveBeenCalled());
+
+      const picker = screen.getByLabelText(/^task list$/i);
+      await user.selectOptions(picker, "list-b");
+
+      await waitFor(() => {
+        const latest =
+          mockTaskList.mock.calls[mockTaskList.mock.calls.length - 1];
+        const cfg = (latest?.[0] as { config: TaskListConfig }).config;
+        expect(cfg.lists[0].listId).toBe("list-b");
+      });
+    });
+
+    it("renders only the picker (no TaskList) until the fetch resolves", async () => {
+      let resolveFetch: ((value: Response) => void) | undefined;
+      mockFetch.mockImplementation(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolveFetch = resolve;
+          })
+      );
+
+      render(<TestTasksPage />);
+
+      // Loading skeleton, no TaskList
+      expect(screen.getByTestId("test-tasks-live-loading")).toBeInTheDocument();
+      expect(mockTaskList).not.toHaveBeenCalled();
+
+      await act(async () => {
+        resolveFetch?.(
+          jsonResponse({
+            lists: [
+              { id: "list-a", title: "Personal", updated: "2026-05-01T00:00Z" },
+            ],
+          })
+        );
+        await Promise.resolve();
+      });
+
+      await waitFor(() => expect(mockTaskList).toHaveBeenCalled());
+      expect(
+        screen.queryByTestId("test-tasks-live-loading")
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/src/app/test/tasks/__tests__/page.test.tsx
+++ b/src/app/test/tasks/__tests__/page.test.tsx
@@ -8,13 +8,16 @@
  *                     `/api/tasks/lists`, auto-selects the first, and
  *                     exposes a picker so the user can switch between
  *                     them. Renders loading / error / empty states.
+ *
+ * The live-mode picker selection persists across reloads via
+ * localStorage (#289 — `LIVE_LIST_LS_KEY`).
  */
 import { TaskList } from "@/components/tasks/task-list";
 import type { TaskListConfig } from "@/components/tasks/types";
 import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import TestTasksPage from "../page";
+import TestTasksPage, { LIVE_LIST_LS_KEY } from "../page";
 
 let mockSearch = new URLSearchParams();
 
@@ -58,11 +61,16 @@ describe("/test/tasks page", () => {
     mockFetch.mockReset();
     mockTaskList.mockClear();
     global.fetch = mockFetch as unknown as typeof fetch;
+    // jsdom's localStorage is shared across tests in the same worker —
+    // clear it so each test starts from a clean slate (the persisted
+    // picker selection is the only key we touch here, but be defensive).
+    window.localStorage.clear();
   });
 
   afterEach(() => {
     vi.useRealTimers();
     global.fetch = originalFetch;
+    window.localStorage.clear();
   });
 
   describe("mock harness mode", () => {
@@ -341,6 +349,95 @@ describe("/test/tasks page", () => {
         (screen.getByTestId("test-tasks-live-picker") as HTMLSelectElement)
           .value
       ).toBe("list-b");
+    });
+  });
+
+  describe("picker persistence (#289)", () => {
+    const SAMPLE_LISTS = [
+      { id: "list-a", title: "Personal", updated: "2026-05-01T00:00Z" },
+      { id: "list-b", title: "Work", updated: "2026-05-01T00:00Z" },
+    ];
+
+    it("persists the user's picker choice to localStorage", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ lists: SAMPLE_LISTS }));
+
+      const user = userEvent.setup();
+      render(<TestTasksPage />);
+
+      const picker = (await screen.findByTestId(
+        "test-tasks-live-picker"
+      )) as HTMLSelectElement;
+      await user.selectOptions(picker, "list-b");
+
+      // `useLocalStorage` JSON-stringifies its value — match the on-disk
+      // shape, not the bare id, so a future caller swapping the codec
+      // won't silently pass this assertion.
+      expect(window.localStorage.getItem(LIVE_LIST_LS_KEY)).toBe(
+        JSON.stringify("list-b")
+      );
+    });
+
+    it("restores a previously persisted selection on mount", async () => {
+      window.localStorage.setItem(LIVE_LIST_LS_KEY, JSON.stringify("list-b"));
+      mockFetch.mockResolvedValueOnce(jsonResponse({ lists: SAMPLE_LISTS }));
+
+      render(<TestTasksPage />);
+
+      const picker = (await screen.findByTestId(
+        "test-tasks-live-picker"
+      )) as HTMLSelectElement;
+      await waitFor(() => expect(picker.value).toBe("list-b"));
+
+      // TaskList should be rendered with the persisted list, not lists[0].
+      await waitFor(() => expect(mockTaskList).toHaveBeenCalled());
+      const config = getRenderedConfig();
+      expect(config.lists[0]).toMatchObject({
+        listId: "list-b",
+        listTitle: "Work",
+      });
+    });
+
+    it("falls back to the first list when the persisted id is stale", async () => {
+      window.localStorage.setItem(
+        LIVE_LIST_LS_KEY,
+        JSON.stringify("list-deleted")
+      );
+      mockFetch.mockResolvedValueOnce(jsonResponse({ lists: SAMPLE_LISTS }));
+
+      render(<TestTasksPage />);
+
+      const picker = (await screen.findByTestId(
+        "test-tasks-live-picker"
+      )) as HTMLSelectElement;
+      // The `selectedList = lists.find(...) ?? lists[0]` fallback resolves
+      // the stale id to lists[0]; the `<select value>` is driven by the
+      // resolved list's id so the picker can never display "list-deleted".
+      await waitFor(() => expect(picker.value).toBe("list-a"));
+      expect(picker.value).not.toBe("list-deleted");
+    });
+
+    it("preserves the persisted selection across a 'Try again' retry", async () => {
+      window.localStorage.setItem(LIVE_LIST_LS_KEY, JSON.stringify("list-b"));
+      mockFetch
+        .mockResolvedValueOnce(jsonResponse({ error: "boom" }, 500))
+        .mockResolvedValueOnce(jsonResponse({ lists: SAMPLE_LISTS }));
+
+      const user = userEvent.setup();
+      render(<TestTasksPage />);
+
+      await screen.findByTestId("test-tasks-live-error");
+      // Storage should still hold list-b through the error state — the
+      // retry handler must not clobber the user's saved choice.
+      expect(window.localStorage.getItem(LIVE_LIST_LS_KEY)).toBe(
+        JSON.stringify("list-b")
+      );
+
+      await user.click(screen.getByRole("button", { name: /try again/i }));
+
+      const picker = (await screen.findByTestId(
+        "test-tasks-live-picker"
+      )) as HTMLSelectElement;
+      await waitFor(() => expect(picker.value).toBe("list-b"));
     });
   });
 });

--- a/src/app/test/tasks/__tests__/page.test.tsx
+++ b/src/app/test/tasks/__tests__/page.test.tsx
@@ -28,8 +28,10 @@ vi.mock("@/components/tasks/task-list", () => ({
 
 const mockTaskList = vi.mocked(TaskList);
 
+// Assigned per-test inside beforeEach so worker isolation can't leak the
+// override between test files.
 const mockFetch = vi.fn();
-global.fetch = mockFetch as unknown as typeof fetch;
+const originalFetch = global.fetch;
 
 function jsonResponse(body: unknown, status = 200): Response {
   return {
@@ -55,10 +57,12 @@ describe("/test/tasks page", () => {
     mockSearch = new URLSearchParams();
     mockFetch.mockReset();
     mockTaskList.mockClear();
+    global.fetch = mockFetch as unknown as typeof fetch;
   });
 
   afterEach(() => {
     vi.useRealTimers();
+    global.fetch = originalFetch;
   });
 
   describe("mock harness mode", () => {
@@ -250,6 +254,93 @@ describe("/test/tasks page", () => {
       expect(
         screen.queryByTestId("test-tasks-live-loading")
       ).not.toBeInTheDocument();
+    });
+
+    it("renders the reauth state when the API returns requiresReauth", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse(
+          {
+            error: "Missing Google Tasks scope. Please sign in again.",
+            requiresReauth: true,
+          },
+          401
+        )
+      );
+
+      render(<TestTasksPage />);
+
+      const reauth = await screen.findByTestId("test-tasks-live-reauth");
+      expect(reauth).toBeInTheDocument();
+      expect(reauth).toHaveTextContent(/sign in again/i);
+      // The reauth state must NOT show the generic "Try again" button —
+      // retrying would just hit the same 401 in a loop.
+      expect(
+        screen.queryByRole("button", { name: /try again/i })
+      ).not.toBeInTheDocument();
+      const signInLink = screen.getByRole("link", { name: /sign in again/i });
+      expect(signInLink).toHaveAttribute("href", "/api/auth/signin");
+    });
+
+    it("falls back to the generic error state when an error body is not JSON", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 502,
+        json: () => Promise.reject(new Error("not json")),
+      } as unknown as Response);
+
+      render(<TestTasksPage />);
+
+      const error = await screen.findByTestId("test-tasks-live-error");
+      expect(error).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /try again/i })
+      ).toBeInTheDocument();
+    });
+
+    it("keeps the picker in sync with the rendered TaskList after a stale selection", async () => {
+      mockFetch
+        .mockResolvedValueOnce(
+          jsonResponse({
+            lists: [
+              { id: "list-a", title: "Personal", updated: "2026-05-01T00:00Z" },
+              { id: "list-b", title: "Work", updated: "2026-05-01T00:00Z" },
+            ],
+          })
+        )
+        .mockResolvedValueOnce(jsonResponse({ error: "boom" }, 500))
+        // Returned lists differ from the user's previous selection — the
+        // picker must not display the stale id.
+        .mockResolvedValueOnce(
+          jsonResponse({
+            lists: [
+              { id: "list-c", title: "Renamed", updated: "2026-05-01T00:00Z" },
+            ],
+          })
+        );
+
+      const user = userEvent.setup();
+      render(<TestTasksPage />);
+
+      await waitFor(() => expect(mockTaskList).toHaveBeenCalled());
+
+      // Pick the second list, then trigger a reload that fails. We can
+      // simulate a reload by advancing the URL; here we drive it via the
+      // retry button in the error state, so we need the next fetch (the
+      // automatic one after picker change) to fail. Easier: directly
+      // advance the picker, then assert that an unrelated re-fetch which
+      // returns a different list shape still sets the picker's
+      // <select value> to a real list id.
+      await user.selectOptions(
+        screen.getByTestId("test-tasks-live-picker"),
+        "list-b"
+      );
+
+      // Selection is "list-b"; lists in state still contain list-b, so
+      // the picker shows list-b. (Sanity check that onChange wired up.)
+      expect(
+        (screen.getByTestId("test-tasks-live-picker") as HTMLSelectElement)
+          .value
+      ).toBe("list-b");
     });
   });
 });

--- a/src/app/test/tasks/__tests__/page.test.tsx
+++ b/src/app/test/tasks/__tests__/page.test.tsx
@@ -305,19 +305,16 @@ describe("/test/tasks page", () => {
       ).toBeInTheDocument();
     });
 
-    it("keeps the picker in sync with the rendered TaskList after a stale selection", async () => {
+    it("falls back to lists[0] when a retry returns lists without the persisted selection", async () => {
+      // The user previously chose "list-b" (persisted in localStorage). The
+      // first load fails, and the retry returns a list set where "list-b"
+      // has since been deleted. The resolved `selectedList ?? lists[0]`
+      // fallback must drive both the <select value> and the rendered
+      // TaskList to a real list id — the picker can never display the stale
+      // "list-b" once it's gone from the fetched set.
+      window.localStorage.setItem(LIVE_LIST_LS_KEY, JSON.stringify("list-b"));
       mockFetch
-        .mockResolvedValueOnce(
-          jsonResponse({
-            lists: [
-              { id: "list-a", title: "Personal", updated: "2026-05-01T00:00Z" },
-              { id: "list-b", title: "Work", updated: "2026-05-01T00:00Z" },
-            ],
-          })
-        )
         .mockResolvedValueOnce(jsonResponse({ error: "boom" }, 500))
-        // Returned lists differ from the user's previous selection — the
-        // picker must not display the stale id.
         .mockResolvedValueOnce(
           jsonResponse({
             lists: [
@@ -329,26 +326,22 @@ describe("/test/tasks page", () => {
       const user = userEvent.setup();
       render(<TestTasksPage />);
 
+      await screen.findByTestId("test-tasks-live-error");
+      await user.click(screen.getByRole("button", { name: /try again/i }));
+
+      const picker = (await screen.findByTestId(
+        "test-tasks-live-picker"
+      )) as HTMLSelectElement;
+      await waitFor(() => expect(picker.value).toBe("list-c"));
+      expect(picker.value).not.toBe("list-b");
+
+      // TaskList must render the resolved list, not the stale persisted id.
       await waitFor(() => expect(mockTaskList).toHaveBeenCalled());
-
-      // Pick the second list, then trigger a reload that fails. We can
-      // simulate a reload by advancing the URL; here we drive it via the
-      // retry button in the error state, so we need the next fetch (the
-      // automatic one after picker change) to fail. Easier: directly
-      // advance the picker, then assert that an unrelated re-fetch which
-      // returns a different list shape still sets the picker's
-      // <select value> to a real list id.
-      await user.selectOptions(
-        screen.getByTestId("test-tasks-live-picker"),
-        "list-b"
-      );
-
-      // Selection is "list-b"; lists in state still contain list-b, so
-      // the picker shows list-b. (Sanity check that onChange wired up.)
-      expect(
-        (screen.getByTestId("test-tasks-live-picker") as HTMLSelectElement)
-          .value
-      ).toBe("list-b");
+      const config = getRenderedConfig(mockTaskList.mock.calls.length - 1);
+      expect(config.lists[0]).toMatchObject({
+        listId: "list-c",
+        listTitle: "Renamed",
+      });
     });
   });
 

--- a/src/app/test/tasks/page.tsx
+++ b/src/app/test/tasks/page.tsx
@@ -11,21 +11,38 @@
  *                     `/api/tasks/lists`, auto-selects the first, and
  *                     exposes a picker so they can switch between lists.
  *                     Renders loading / error / empty states. (#236)
+ *
+ * The live-mode picker selection is persisted to localStorage under
+ * `LIVE_LIST_LS_KEY` so it survives reloads (#289). Stale ids that no
+ * longer match a fetched list fall back to `lists[0]` via the
+ * `selectedList = lists.find(...) ?? lists[0]` resolver below.
  */
 import { TaskList } from "@/components/tasks/task-list";
 import {
   DEFAULT_LIST_COLORS,
   type GoogleTaskList,
-  type TaskApiError,
   type TaskListConfig,
   type TaskListsApiResponse,
 } from "@/components/tasks/types";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useLocalStorage } from "@/hooks/useLocalStorage";
 import { Suspense, useEffect, useState } from "react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { Loader2 } from "lucide-react";
+
+// The `/api/tasks*` 401/403 error envelope (defined in `task-api-error.ts`).
+// The class form (`TaskApiError`) is consumed by the production hooks via
+// `instanceof`; the parsed JSON body here just needs the `requiresReauth`
+// flag, so a tiny structural type keeps this page free of the class import.
+interface TaskApiErrorBody {
+  error?: string;
+  requiresReauth?: boolean;
+}
+
+/** localStorage key for the live-mode picker selection (introduced in #289). */
+export const LIVE_LIST_LS_KEY = "test-tasks.live-list";
 
 const SINGLE_LIST_CONFIG: TaskListConfig = {
   id: "test-single",
@@ -85,7 +102,14 @@ type LiveStatus = "loading" | "error" | "reauth" | "ready";
 function LiveTasksPanel() {
   const [status, setStatus] = useState<LiveStatus>("loading");
   const [lists, setLists] = useState<GoogleTaskList[]>([]);
-  const [selectedListId, setSelectedListId] = useState<string>("");
+  // Persist the picker selection across reloads (#289). The fallback when
+  // the persisted id is missing or stale is handled by `selectedList` below,
+  // which resolves to `lists[0]` whenever `selectedListId` doesn't match
+  // a fetched list — so the on-fetch path no longer needs to seed the id.
+  const [selectedListId, setSelectedListId] = useLocalStorage<string>(
+    LIVE_LIST_LS_KEY,
+    ""
+  );
   const [reloadToken, setReloadToken] = useState(0);
 
   useEffect(() => {
@@ -99,9 +123,9 @@ function LiveTasksPanel() {
           // doesn't crash the panel. The `requiresReauth` flag from the
           // API tells us a retry is futile — the user has to re-grant
           // the Google Tasks scope before any future request can succeed.
-          let body: TaskApiError | null = null;
+          let body: TaskApiErrorBody | null = null;
           try {
-            body = (await response.json()) as TaskApiError;
+            body = (await response.json()) as TaskApiErrorBody;
           } catch {
             body = null;
           }
@@ -118,7 +142,6 @@ function LiveTasksPanel() {
         if (cancelled) return;
         const fetched = data.lists ?? [];
         setLists(fetched);
-        setSelectedListId(fetched[0]?.id ?? "");
         setStatus("ready");
       })
       .catch(() => {
@@ -181,10 +204,11 @@ function LiveTasksPanel() {
             variant="secondary"
             onClick={() => {
               setStatus("loading");
-              // Reset selection so the next successful fetch's
-              // `setSelectedListId(fetched[0]?.id)` is unambiguous and we
-              // never render the picker against a stale id.
-              setSelectedListId("");
+              // Don't clobber the persisted picker selection on retry —
+              // the stale-id fallback (`selectedList ?? lists[0]`) already
+              // protects against a missing list, and clearing here would
+              // surprise the user by forgetting their saved choice after
+              // a transient gateway error.
               setReloadToken((token) => token + 1);
             }}
           >

--- a/src/app/test/tasks/page.tsx
+++ b/src/app/test/tasks/page.tsx
@@ -1,27 +1,29 @@
 "use client";
 
 /**
- * E2E test surface for TaskList + NewTaskModal (#165).
+ * E2E + manual test surface for TaskList + NewTaskModal.
  *
- * Renders TaskList with a hard-coded config so Playwright can exercise
- * the open → fill → submit flow against `page.route()` interception of
- * `/api/tasks*`. No auth, no real Google API.
- *
- * Query params:
- * - `lists=single` (default) renders one enabled list — exercises the
- *   smart-default pre-selection.
- * - `lists=multi` renders two enabled lists — exercises the
- *   no-default-selected branch.
- *
- * A live-mode list picker is always shown below the static fixture.
- * Its selection is persisted to localStorage ("test-tasks.live-list")
- * so it survives page reloads during repeated manual testing (#289).
+ * Three modes resolved from `?lists=`:
+ * - `?lists=single` — hard-coded single-list mock harness (existing
+ *   Playwright suites intercept `/api/tasks*` against this).
+ * - `?lists=multi`  — hard-coded multi-list mock harness.
+ * - default         — live mode: fetches the user's real task lists from
+ *                     `/api/tasks/lists`, auto-selects the first, and
+ *                     exposes a picker so they can switch between lists.
+ *                     Renders loading / error / empty states. (#236)
  */
 import { TaskList } from "@/components/tasks/task-list";
-import type { TaskListConfig } from "@/components/tasks/types";
-import { useLocalStorage } from "@/hooks/useLocalStorage";
+import {
+  DEFAULT_LIST_COLORS,
+  type GoogleTaskList,
+  type TaskListConfig,
+  type TaskListsApiResponse,
+} from "@/components/tasks/types";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Suspense, useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
+import { Loader2 } from "lucide-react";
 
 const SINGLE_LIST_CONFIG: TaskListConfig = {
   id: "test-single",
@@ -59,80 +61,139 @@ const MULTI_LIST_CONFIG: TaskListConfig = {
   ],
 };
 
-/** localStorage key for the live-mode list picker selection */
-export const LIVE_LIST_LS_KEY = "test-tasks.live-list";
-
-interface GoogleTaskListItem {
-  id: string;
-  title: string;
-  updated: string;
-}
-
-/**
- * Live-mode section: fetches real task lists from /api/tasks/lists and lets
- * the tester pick one. Selection is persisted to localStorage.
- */
-function LiveListPicker() {
-  const [lists, setLists] = useState<GoogleTaskListItem[]>([]);
-  const [savedListId, setSavedListId] = useLocalStorage<string>(
-    LIVE_LIST_LS_KEY,
-    ""
-  );
-
-  useEffect(() => {
-    fetch("/api/tasks/lists")
-      .then((res) => res.json())
-      .then((data: { lists: GoogleTaskListItem[] }) => {
-        setLists(data.lists ?? []);
-      })
-      .catch(() => {
-        // silently ignore fetch errors on the test page
-      });
-  }, []);
-
-  // Validate the restored id against the fetched lists; fall back to "" if stale
-  const availableIds = lists.map((l) => l.id);
-  const validatedId =
-    savedListId !== "" && availableIds.includes(savedListId) ? savedListId : "";
-
-  const liveConfig: TaskListConfig = {
-    id: "test-live",
-    title: "Live Tasks",
+function buildLiveConfig(list: GoogleTaskList, color: string): TaskListConfig {
+  return {
+    id: `test-live-${list.id}`,
+    title: "My Tasks",
     showCompleted: false,
     sortBy: "dueDate",
-    lists: validatedId
-      ? [
-          {
-            listId: validatedId,
-            listTitle:
-              lists.find((l) => l.id === validatedId)?.title ?? validatedId,
-            color: "#3b82f6",
-            enabled: true,
-          },
-        ]
-      : [],
+    lists: [
+      {
+        listId: list.id,
+        listTitle: list.title,
+        color,
+        enabled: true,
+      },
+    ],
   };
+}
+
+type LiveStatus = "loading" | "error" | "ready";
+
+function LiveTasksPanel() {
+  const [status, setStatus] = useState<LiveStatus>("loading");
+  const [lists, setLists] = useState<GoogleTaskList[]>([]);
+  const [selectedListId, setSelectedListId] = useState<string>("");
+  const [reloadToken, setReloadToken] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    fetch("/api/tasks/lists")
+      .then(async (response) => {
+        if (cancelled) return;
+        if (!response.ok) {
+          setStatus("error");
+          return;
+        }
+        const data = (await response.json()) as TaskListsApiResponse;
+        if (cancelled) return;
+        const fetched = data.lists ?? [];
+        setLists(fetched);
+        setSelectedListId(fetched[0]?.id ?? "");
+        setStatus("ready");
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setStatus("error");
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadToken]);
+
+  if (status === "loading") {
+    return (
+      <Card data-testid="test-tasks-live-loading">
+        <CardContent className="flex items-center justify-center py-8 text-gray-500">
+          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          Loading your task lists…
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (status === "error") {
+    return (
+      <Card data-testid="test-tasks-live-error">
+        <CardHeader>
+          <CardTitle className="text-base">
+            Couldn&rsquo;t load your task lists
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <p className="text-sm text-gray-600">
+            The request to <code>/api/tasks/lists</code> failed. This usually
+            means the session is missing the Google Tasks scope; sign out and
+            back in to re-grant access.
+          </p>
+          <Button
+            variant="secondary"
+            onClick={() => {
+              setStatus("loading");
+              setReloadToken((token) => token + 1);
+            }}
+          >
+            Try again
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (lists.length === 0) {
+    return (
+      <Card data-testid="test-tasks-live-empty">
+        <CardHeader>
+          <CardTitle className="text-base">
+            No task lists on this account
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-gray-600">
+            You haven&rsquo;t created any task lists in Google Tasks yet. Create
+            one (e.g.&nbsp;in the Google Tasks side panel of Gmail or Calendar)
+            and then refresh this page.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const selectedIndex = Math.max(
+    0,
+    lists.findIndex((list) => list.id === selectedListId)
+  );
+  const selectedList = lists[selectedIndex];
+  const color = DEFAULT_LIST_COLORS[selectedIndex % DEFAULT_LIST_COLORS.length];
 
   return (
-    <div className="mt-8 border-t border-gray-200 pt-6">
-      <h2 className="mb-3 text-lg font-semibold text-gray-800">
-        Live Mode (real API)
-      </h2>
-      <div className="mb-4 flex items-center gap-3">
+    <div className="space-y-4" data-testid="test-tasks-live-ready">
+      <div className="space-y-1">
         <label
-          htmlFor="live-list-picker"
+          htmlFor="test-tasks-live-picker"
           className="text-sm font-medium text-gray-700"
         >
-          Live list
+          Task list
         </label>
         <select
-          id="live-list-picker"
-          className="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
-          value={validatedId}
-          onChange={(e) => setSavedListId(e.target.value)}
-          aria-label="Live list"
+          id="test-tasks-live-picker"
+          data-testid="test-tasks-live-picker"
+          value={selectedListId}
+          onChange={(event) => setSelectedListId(event.target.value)}
+          className="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
         >
-          <option value="">— select a list —</option>
           {lists.map((list) => (
             <option key={list.id} value={list.id}>
               {list.title}
@@ -140,21 +201,53 @@ function LiveListPicker() {
           ))}
         </select>
       </div>
-      {validatedId && <TaskList config={liveConfig} />}
+      <TaskList config={buildLiveConfig(selectedList, color)} />
     </div>
   );
 }
 
 function TestTasksContent() {
   const searchParams = useSearchParams();
-  const variant = searchParams.get("lists") === "multi" ? "multi" : "single";
-  const config = variant === "multi" ? MULTI_LIST_CONFIG : SINGLE_LIST_CONFIG;
+  const variant = searchParams.get("lists");
+
+  if (variant === "single") {
+    return (
+      <div className="container mx-auto max-w-md p-4" data-testid="test-tasks">
+        <h1 className="mb-4 text-2xl font-bold text-gray-900">
+          Tasks Test Page
+        </h1>
+        <p
+          className="mb-3 text-xs text-gray-500"
+          data-testid="test-tasks-mode-banner"
+        >
+          Mock harness mode: <code>?lists=single</code>
+        </p>
+        <TaskList config={SINGLE_LIST_CONFIG} />
+      </div>
+    );
+  }
+
+  if (variant === "multi") {
+    return (
+      <div className="container mx-auto max-w-md p-4" data-testid="test-tasks">
+        <h1 className="mb-4 text-2xl font-bold text-gray-900">
+          Tasks Test Page
+        </h1>
+        <p
+          className="mb-3 text-xs text-gray-500"
+          data-testid="test-tasks-mode-banner"
+        >
+          Mock harness mode: <code>?lists=multi</code>
+        </p>
+        <TaskList config={MULTI_LIST_CONFIG} />
+      </div>
+    );
+  }
 
   return (
     <div className="container mx-auto max-w-md p-4" data-testid="test-tasks">
       <h1 className="mb-4 text-2xl font-bold text-gray-900">Tasks Test Page</h1>
-      <TaskList config={config} />
-      <LiveListPicker />
+      <LiveTasksPanel />
     </div>
   );
 }

--- a/src/app/test/tasks/page.tsx
+++ b/src/app/test/tasks/page.tsx
@@ -16,12 +16,14 @@ import { TaskList } from "@/components/tasks/task-list";
 import {
   DEFAULT_LIST_COLORS,
   type GoogleTaskList,
+  type TaskApiError,
   type TaskListConfig,
   type TaskListsApiResponse,
 } from "@/components/tasks/types";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Suspense, useEffect, useState } from "react";
+import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { Loader2 } from "lucide-react";
 
@@ -78,7 +80,7 @@ function buildLiveConfig(list: GoogleTaskList, color: string): TaskListConfig {
   };
 }
 
-type LiveStatus = "loading" | "error" | "ready";
+type LiveStatus = "loading" | "error" | "reauth" | "ready";
 
 function LiveTasksPanel() {
   const [status, setStatus] = useState<LiveStatus>("loading");
@@ -91,11 +93,27 @@ function LiveTasksPanel() {
 
     fetch("/api/tasks/lists")
       .then(async (response) => {
-        if (cancelled) return;
         if (!response.ok) {
-          setStatus("error");
+          // The error body may be missing or non-JSON (e.g. an HTML 502
+          // from a proxy); guard the parse so a transient gateway error
+          // doesn't crash the panel. The `requiresReauth` flag from the
+          // API tells us a retry is futile — the user has to re-grant
+          // the Google Tasks scope before any future request can succeed.
+          let body: TaskApiError | null = null;
+          try {
+            body = (await response.json()) as TaskApiError;
+          } catch {
+            body = null;
+          }
+          if (cancelled) return;
+          setStatus(body?.requiresReauth ? "reauth" : "error");
           return;
         }
+        // The fetch promise has resolved but `json()` is still streaming
+        // the body; if the component unmounts in this window the second
+        // guard below catches it. We intentionally do not abort the
+        // underlying request — the body parse is cheap and the response
+        // is already in transit.
         const data = (await response.json()) as TaskListsApiResponse;
         if (cancelled) return;
         const fetched = data.lists ?? [];
@@ -124,6 +142,28 @@ function LiveTasksPanel() {
     );
   }
 
+  if (status === "reauth") {
+    return (
+      <Card data-testid="test-tasks-live-reauth">
+        <CardHeader>
+          <CardTitle className="text-base">
+            Sign in again to access Google Tasks
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <p className="text-sm text-gray-600">
+            Your session has expired or is missing the Google Tasks scope.
+            Retrying the request will hit the same error — you need to grant
+            access again.
+          </p>
+          <Button asChild variant="secondary">
+            <Link href="/api/auth/signin">Sign in again</Link>
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
   if (status === "error") {
     return (
       <Card data-testid="test-tasks-live-error">
@@ -134,14 +174,17 @@ function LiveTasksPanel() {
         </CardHeader>
         <CardContent className="space-y-3">
           <p className="text-sm text-gray-600">
-            The request to <code>/api/tasks/lists</code> failed. This usually
-            means the session is missing the Google Tasks scope; sign out and
-            back in to re-grant access.
+            The request to <code>/api/tasks/lists</code> failed. This is usually
+            a transient network or server issue — try again in a moment.
           </p>
           <Button
             variant="secondary"
             onClick={() => {
               setStatus("loading");
+              // Reset selection so the next successful fetch's
+              // `setSelectedListId(fetched[0]?.id)` is unambiguous and we
+              // never render the picker against a stale id.
+              setSelectedListId("");
               setReloadToken((token) => token + 1);
             }}
           >
@@ -171,11 +214,14 @@ function LiveTasksPanel() {
     );
   }
 
-  const selectedIndex = Math.max(
-    0,
-    lists.findIndex((list) => list.id === selectedListId)
-  );
-  const selectedList = lists[selectedIndex];
+  // Resolve the rendered list from the selected id; fall back to the first
+  // list if the selection is stale (e.g. a previously-selected list was
+  // deleted between fetches). The `<select value>` is driven by
+  // `selectedList.id` rather than `selectedListId` so the picker can never
+  // visually disagree with what TaskList renders.
+  const selectedList =
+    lists.find((list) => list.id === selectedListId) ?? lists[0];
+  const selectedIndex = lists.indexOf(selectedList);
   const color = DEFAULT_LIST_COLORS[selectedIndex % DEFAULT_LIST_COLORS.length];
 
   return (
@@ -190,7 +236,7 @@ function LiveTasksPanel() {
         <select
           id="test-tasks-live-picker"
           data-testid="test-tasks-live-picker"
-          value={selectedListId}
+          value={selectedList.id}
           onChange={(event) => setSelectedListId(event.target.value)}
           className="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
         >


### PR DESCRIPTION
## What this is

A rebased, conflict-resolved, locally-green companion to **#256**. Same scope and same intent — see #256 for the full design discussion and the round-1 review thread (all three blockers and four nits already addressed in upstream commits).

This branch exists because #256's base (`c3c1007`) is no longer reachable from `main` — a normal `git merge origin/main` fails with "refusing to merge unrelated histories", and `--allow-unrelated-histories` produces 160 add/add conflicts. Rebasing the three PR-specific commits onto current `main` is the only tractable path, and updating #256's branch with the rebased history requires a force-push — which the `/implement-issue` skill's guardrails forbid. So the rebase is pushed here instead.

## Use one or the other, not both

- If you'd rather keep #256's review history → **force-push** the four commits below onto `claude/loving-faraday-wmrll` and **close this draft**.
- If you'd rather take the rebased branch as the canonical one → **close #256** and promote this PR (mark ready for review).

Either way, the diff that lands on `main` is identical.

## Commits on top of `main` @ `d6daba5`

1. `a1d2c6e` — fix(tasks): make /test/tasks list-agnostic by default (#236)
2. `7efff21` — test(tasks): add Playwright E2E for /test/tasks live mode (#236)
3. `7a86879` — fix(tasks): address PR review feedback on /test/tasks live mode (#236)
4. `3018c50` — fix(tasks): preserve #289 picker-selection persistence in /test/tasks rebase

(1)–(3) are the original PR-#256 commits replayed against current `main`. (4) is new — it re-introduces the `LIVE_LIST_LS_KEY` localStorage persistence that PR #289 added to `main` while #256 was sitting on a stale base, so the merged result is a strict superset of both PRs' behaviour.

## Local quality gate

- `pnpm lint:fix` → 0 errors, 6 pre-existing warnings unrelated
- `pnpm format:fix` → clean
- `pnpm check-types` → clean
- `pnpm test` → **146 files / 2342 tests passing**

## Conflict resolution rationale

| File | Resolution |
|---|---|
| `src/components/calendar/__tests__/AgendaList.test.tsx` | Took `main`'s version — the drive-by `deleteEvent: vi.fn()` mock add in #256 is superseded by main's refactor to the `makeCalendarContext()` fixture helper. |
| `src/app/test/tasks/page.tsx` | Took the branch's design — live mode as default, mock harness behind `?lists=`, explicit error/reauth/empty/loading states. Strict superset of #289's design (which only added a picker below the static fixture, leaving `/test/tasks` still defaulting to the failing `list-groceries` config). |
| `src/app/test/tasks/__tests__/page.test.tsx` | Took the branch's tests — they cover the new design end-to-end. |

Then commit `3018c50` re-introduces #289's behaviour on the new design.

Closes #236 (alongside #256 — whichever lands first marks the issue closed).

---
🤖 Generated by [Claude Code](https://claude.ai/code) — `/implement-issue` PR-review fallback

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qy3FN4ZkrQtNnoWtyfKZUU)_