### PR TITLE
fix(auth): reclassify unsupported_grant_type as transient (#378)

### DIFF
--- a/.claude/plans/auth-unsupported-grant-type-378.md
+++ b/.claude/plans/auth-unsupported-grant-type-378.md
@@ -1,0 +1,56 @@
+# Auth: reclassify `unsupported_grant_type` as transient (#378)
+
+Follow-up to PR #348 (merged) and parent plan `auth-session-expired-315.md`.
+
+## Problem
+
+`classifyTokenRefreshError` in `src/lib/auth/refresh-error-classifier.ts`
+currently treats Google OAuth `unsupported_grant_type` as **terminal**, forcing
+re-auth. But `unsupported_grant_type` is always a server-side code/config bug —
+we control the `grant_type` we send. Re-auth can never fix it; the next refresh
+sends the same wrong `grant_type` and fails identically, trapping the user in a
+re-auth loop until an operator deploys a fix.
+
+## Decision
+
+Apply Option 1 from issue #378: classify `unsupported_grant_type` as
+**transient**. Rationale recap from the issue:
+
+- The failure is loud in server logs (operator sees the alert) but not
+  user-facing — the cached UI keeps working while the operator deploys a fix.
+- Misclassifying toward transient just delays a forced re-auth by one callback
+  cycle when the diagnosis is wrong; misclassifying toward terminal dumps every
+  authenticated user back to a sign-in screen on what is purely an internal bug
+  — the exact failure mode #315 fixes.
+- Option 2 (a third "operator-terminal" classification) depends on Part D of
+  #315 (`/api/health/auth` + admin banner), which has not landed. Revisit then.
+
+## Scope
+
+Two files:
+
+1. `src/lib/auth/refresh-error-classifier.ts` — remove
+   `"unsupported_grant_type"` from `TERMINAL_GOOGLE_ERROR_CODES`; rewrite the
+   inline comment that justified its inclusion to instead document why it is
+   intentionally treated as transient (and link #378).
+2. `src/lib/auth/__tests__/refresh-error-classifier.test.ts` — move the
+   `unsupported_grant_type` test out of the "terminal" describe block into
+   "transient", flip the assertion, and update the comment.
+
+No other callers need changes — `refresh-session-tokens.ts` already routes by
+the returned classification.
+
+## TDD
+
+1. Update the test for `unsupported_grant_type` to expect `"transient"`.
+2. Run — it fails (current code returns `"terminal"`).
+3. Remove `"unsupported_grant_type"` from `TERMINAL_GOOGLE_ERROR_CODES`.
+4. Run — test passes; full suite stays green.
+
+## Acceptance
+
+- `pnpm test src/lib/auth/__tests__/refresh-error-classifier.test.ts` passes.
+- `pnpm lint:fix && pnpm format:fix && pnpm check-types && pnpm test` all
+  green.
+- PR body closes #378 and notes the deferred Option-2 follow-up tied to #315
+  Part D.

--- a/src/lib/auth/__tests__/refresh-error-classifier.test.ts
+++ b/src/lib/auth/__tests__/refresh-error-classifier.test.ts
@@ -129,6 +129,9 @@ describe("classifyTokenRefreshError", () => {
         "temporarily_unavailable",
         "rate_limit_exceeded",
         "slow_down",
+        // Recognised but intentionally transient — guards against a
+        // regression that re-promotes it to the terminal allow-list (#378).
+        "unsupported_grant_type",
         "",
       ];
       for (const code of codes) {

--- a/src/lib/auth/__tests__/refresh-error-classifier.test.ts
+++ b/src/lib/auth/__tests__/refresh-error-classifier.test.ts
@@ -27,15 +27,6 @@ describe("classifyTokenRefreshError", () => {
       });
       expect(classifyTokenRefreshError(err)).toBe("terminal");
     });
-
-    it("classifies unsupported_grant_type as terminal", () => {
-      // Misconfiguration on our side — sending the wrong grant_type can
-      // never succeed on retry, so force re-auth.
-      const err = new GoogleTokenRefreshError(400, {
-        error: "unsupported_grant_type",
-      });
-      expect(classifyTokenRefreshError(err)).toBe("terminal");
-    });
   });
 
   describe("internal sentinel errors (locally-permanent state)", () => {
@@ -62,6 +53,17 @@ describe("classifyTokenRefreshError", () => {
     it("classifies rate_limit_exceeded as transient", () => {
       const err = new GoogleTokenRefreshError(429, {
         error: "rate_limit_exceeded",
+      });
+      expect(classifyTokenRefreshError(err)).toBe("transient");
+    });
+
+    it("classifies unsupported_grant_type as transient (#378)", () => {
+      // Server-side code/config bug — we control the grant_type we send, so
+      // re-auth can never fix it (the next refresh sends the same wrong
+      // grant_type). Treating it as transient keeps the cached UI working
+      // while the failure is loud in server logs for the operator to fix.
+      const err = new GoogleTokenRefreshError(400, {
+        error: "unsupported_grant_type",
       });
       expect(classifyTokenRefreshError(err)).toBe("transient");
     });

--- a/src/lib/auth/refresh-error-classifier.ts
+++ b/src/lib/auth/refresh-error-classifier.ts
@@ -33,16 +33,14 @@ export class RefreshTokenDecryptError extends Error {
 
 // Closed allow-list of Google OAuth error codes that mean "this refresh token
 // is dead — re-auth is the only path forward". Everything else (network, rate
-// limit, 5xx, decrypt failure, unknown error) is treated as transient so the
-// next session callback can retry. See #315 for the failure mode this is
-// defending against — any transient error silently forcing a 1-hour re-auth.
+// limit, 5xx, decrypt failure, unknown error, and server-side misconfig like
+// `unsupported_grant_type` — see #378) is treated as transient so the next
+// session callback can retry. See #315 for the failure mode this is defending
+// against — any transient error silently forcing a 1-hour re-auth.
 const TERMINAL_GOOGLE_ERROR_CODES: ReadonlySet<string> = new Set([
   "invalid_grant",
   "invalid_client",
   "unauthorized_client",
-  // Misconfiguration on our side — retrying with the same grant_type can never
-  // succeed, so force re-auth rather than silently never refreshing.
-  "unsupported_grant_type",
 ]);
 
 /**


### PR DESCRIPTION
## Summary

- Removed `unsupported_grant_type` from `TERMINAL_GOOGLE_ERROR_CODES`; it now falls through to the safe-default `transient` classification.
- Rewrote the inline comment to document why the code is intentionally treated as transient (and link #378).
- Moved the corresponding test from the "terminal" describe block to "transient" with updated rationale.

## Why

`unsupported_grant_type` is always a server-side code/config bug — we control the `grant_type` we send on refresh. Re-auth can never fix it: the next refresh sends the same wrong `grant_type` and fails identically, trapping the user in a re-auth loop until an operator deploys a fix. Reclassifying as transient keeps the cached UI working while the failure stays loud in server logs, which is the exact failure mode #315 is defending against.

Option 2 from #378 (a distinct "operator-terminal" classification surfaced via the AccountManager admin banner) depends on Part D of #315 (`/api/health/auth` + admin banner) which has not landed. Revisit when it does.

## Plan

Linked plan: `.claude/plans/auth-unsupported-grant-type-378.md`
Project: https://github.com/users/BenSeymourODB/projects/1
Parent context: `.claude/plans/auth-session-expired-315.md`

## Test plan

- [x] `pnpm test src/lib/auth/__tests__/refresh-error-classifier.test.ts` — 16/16 passing, including the new `classifies unsupported_grant_type as transient (#378)` case.
- [x] `pnpm test` — full suite 2330/2330 passing.
- [x] `pnpm lint:fix && pnpm format:fix && pnpm check-types` — 0 errors (pre-existing warnings only).

## Deferred follow-up

- Option 2 from the issue: once #315 Part D (`/api/health/auth` + AccountManager admin banner) lands, add a distinct `operator-terminal` classification so `unsupported_grant_type` surfaces in the admin banner without invalidating user sessions. Not blocking — current behaviour is already correct from the user's perspective; this is a future operator-UX improvement.

Closes #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PB9gLCLvELauT7uTqo1WVT)_