### PR TITLE
test(fixtures): add Profile / ProfileSettings factories (#371)

### DIFF
--- a/.claude/plans/fixture-factory-profile-371.md
+++ b/.claude/plans/fixture-factory-profile-371.md
@@ -41,10 +41,10 @@ export function makeProfileSettings(
 ```
 
 Defaults mirror the `@default(...)` values in `schema.prisma`. `avatar` defaults
-to a stable `{ type: "initials", value: "TU", backgroundColor: "#3b82f6" }` so
-multi-profile renders never collide on identical avatars. `id`s are constant
-(`"profile-1"` / `"profile-settings-1"`) — tests that need uniqueness pass
-`id` via overrides.
+to a stable `{ type: "initials", value: "TP", backgroundColor: "#3b82f6" }`
+(matching the default `name: "Test Profile"`) so multi-profile renders never
+collide on identical avatars. `id`s are constant (`"profile-1"` /
+`"profile-settings-1"`) — tests that need uniqueness pass `id` via overrides.
 
 ## Phases
 

--- a/.claude/plans/fixture-factory-profile-371.md
+++ b/.claude/plans/fixture-factory-profile-371.md
@@ -1,0 +1,120 @@
+# Profile / ProfileSettings fixture factory — plan for #371
+
+## Intent
+
+Eliminate the "one new Profile field forces ~13 near-identical test diffs" problem by introducing `makeProfile()` / `makePrismaProfile()` / `makeProfileSettings()` factories under `src/test/fixtures/`, mirroring `makeUserSettings` (PR #354) and `makeCalendarContext` (PR #304).
+
+The duplication exists in two layers and the factory needs to serve both:
+
+- **App-level `Profile`** (`src/components/profiles/profile-context.tsx`) — lightweight shape (no `pinHash`, dates optional ISO strings). Used by every component/page test that mounts a `ProfileProvider` or renders a profile.
+- **Prisma-level `Profile`** (`@/generated/prisma/client`) — full row with `pinHash`, `failedPinAttempts`, `pinLockedUntil`, `createdAt: Date`, `updatedAt: Date`. Used by every API route test.
+
+Two factories with distinct names cleanly express that boundary and keep type errors localized.
+
+## Module surface
+
+`src/test/fixtures/profile.ts`:
+
+```ts
+import type { Profile, ProfileAvatar } from "@/components/profiles/profile-context";
+import type {
+  Profile as PrismaProfile,
+  ProfileSettings as PrismaProfileSettings,
+} from "@/generated/prisma/client";
+
+/** App-level Profile (lightweight, UI-facing). */
+export type MockProfile = Profile;
+export function makeProfile(overrides?: Partial<MockProfile>): MockProfile;
+
+/**
+ * Prisma row, with `avatar` retyped from `JsonValue` to `ProfileAvatar` so the
+ * factory's return value matches what real route handlers store/return.
+ */
+export type MockPrismaProfile = Omit<PrismaProfile, "avatar"> & {
+  avatar: ProfileAvatar;
+};
+export function makePrismaProfile(overrides?: Partial<MockPrismaProfile>): MockPrismaProfile;
+
+export function makeProfileSettings(
+  overrides?: Partial<PrismaProfileSettings>
+): PrismaProfileSettings;
+```
+
+Defaults mirror the `@default(...)` values in `schema.prisma`. `avatar` defaults
+to a stable `{ type: "initials", value: "TU", backgroundColor: "#3b82f6" }` so
+multi-profile renders never collide on identical avatars. `id`s are constant
+(`"profile-1"` / `"profile-settings-1"`) — tests that need uniqueness pass
+`id` via overrides.
+
+## Phases
+
+### Phase 1 — factory + unit tests (TDD)
+
+1. Write `src/test/fixtures/__tests__/profile.test.ts` first. Tests cover:
+   - `makeProfile()` defaults are assignable to app-level `Profile`
+   - `makeProfile({ pinEnabled: true })` overrides applied
+   - `makePrismaProfile()` defaults are assignable to Prisma `Profile` (with the narrowed `avatar`)
+   - `makePrismaProfile({ pinHash: "h", pinLockedUntil: new Date() })` overrides applied
+   - `makeProfileSettings()` defaults align with `schema.prisma @default(...)`
+   - `makeProfileSettings({ theme: "dark" })` overrides applied
+2. Implement `src/test/fixtures/profile.ts` to make tests pass.
+3. `pnpm test src/test/fixtures && pnpm lint:fix && pnpm format:fix && pnpm check-types`.
+
+### Phase 2 — migrate app-level component tests
+
+Replace inline Profile literals with `makeProfile({ ... })` calls. Each file
+gains an `import { makeProfile } from "@/test/fixtures/profile"`.
+
+- `src/components/profiles/__tests__/profile-context.test.tsx`
+- `src/components/profiles/__tests__/profile-card.test.tsx`
+- `src/components/profiles/__tests__/profile-grid.test.tsx`
+- `src/components/profiles/__tests__/profile-switcher.test.tsx`
+- `src/components/profiles/__tests__/give-points-modal.test.tsx`
+- `src/components/profiles/__tests__/pin-settings.test.tsx`
+- `src/components/tasks/__tests__/profile-scoped-task-list.test.tsx`
+- `src/components/settings/__tests__/settings-form.test.tsx`
+- `src/app/profiles/__tests__/page.test.tsx`
+- `src/app/profiles/[id]/settings/__tests__/page.test.tsx`
+
+`pnpm test && pnpm lint:fix && pnpm format:fix && pnpm check-types` after each
+sub-batch.
+
+### Phase 3 — re-express the static `fixtures.ts` + migrate API route tests
+
+- `src/app/api/profiles/__tests__/fixtures.ts` — rewrite `mockAdminProfile`,
+  `mockStandardProfile`, `mockProfileSettings`, `mockProfileList` to delegate
+  to `makePrismaProfile` / `makeProfileSettings`. Keep the named exports so
+  importers don't need to change yet.
+- `src/app/api/profiles/__tests__/route.test.ts`
+- `src/app/api/profiles/[id]/reset-pin/__tests__/route.test.ts`
+- `src/app/api/profiles/[id]/give-points/__tests__/route.test.ts`
+
+`pnpm test && pnpm lint:fix && pnpm format:fix && pnpm check-types` to confirm
+no behavioural drift.
+
+### Phase 4 — finalize
+
+- Full suite green: `pnpm test`
+- `pnpm lint:fix && pnpm format:fix && pnpm check-types`
+- Push, open draft PR, mark ready, request review.
+
+## Out of scope (deferred follow-ups)
+
+- Session/auth mock factory (`getServerSession` mocks vary across files but the
+  shape is small enough that the savings are marginal; defer until a real fan-
+  out happens).
+- Google API payload factories (mentioned in the issue body as future scope).
+- Deriving `UserSettings` defaults + Zod schema from a single source (separate
+  follow-up issue already filed: #372).
+- `pin-setup-modal.test.tsx`, `pin-entry-modal.test.tsx` etc. — these tests
+  don't inline Profile literals; they reference profile data via props from
+  parent mocks and don't suffer the fan-out problem.
+
+## Risk / rollback
+
+Pure refactor, behaviour-preserving. The factory pattern is already proven in
+this repo for `UserSettings` and `ICalendarContext`. If a migration introduces
+a regression, the static `fixtures.ts` exports remain (rewritten internally to
+call the factory) so API tests continue to import the same names.
+
+Rollback = revert the PR.

--- a/src/app/api/profiles/[id]/give-points/__tests__/route.test.ts
+++ b/src/app/api/profiles/[id]/give-points/__tests__/route.test.ts
@@ -11,6 +11,7 @@ import {
   createParams,
   parseResponse,
 } from "@/lib/test-utils/api-test-helpers";
+import { makePrismaProfile } from "@/test/fixtures/profile";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   mockAdminProfile,
@@ -319,22 +320,15 @@ describe("/api/profiles/[id]/give-points", () => {
   });
 
   describe("multiple admin support", () => {
-    const mockSecondAdmin = {
+    const mockSecondAdmin = makePrismaProfile({
       id: "profile-admin-2",
       userId: mockUserId,
       name: "Second Admin",
-      type: "admin" as const,
-      ageGroup: "adult" as const,
       color: "#ef4444",
       avatar: { type: "initials", value: "SA", backgroundColor: "#ef4444" },
       pinHash: "$2b$10$mockHashedPin2",
       pinEnabled: true,
-      failedPinAttempts: 0,
-      pinLockedUntil: null,
-      isActive: true,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    };
+    });
 
     it("allows second admin to award points", async () => {
       vi.mocked(getSession).mockResolvedValue(mockSession);

--- a/src/app/api/profiles/__tests__/fixtures.ts
+++ b/src/app/api/profiles/__tests__/fixtures.ts
@@ -1,60 +1,47 @@
 /**
- * Test fixtures for Profile API tests
+ * Test fixtures for Profile API tests.
+ *
+ * Delegates the row defaults to the shared `makePrismaProfile` /
+ * `makeProfileSettings` factories under `src/test/fixtures/profile.ts` (#371)
+ * so a new column on `Profile` / `ProfileSettings` only needs to be added in
+ * one place. The named exports are preserved for backwards compatibility
+ * with existing route-test imports.
  */
-import type {
-  Profile,
-  ProfileRewardPoints,
-  ProfileSettings,
-} from "@/generated/prisma/client";
+import type { ProfileRewardPoints } from "@/generated/prisma/client";
+import {
+  makePrismaProfile,
+  makeProfileSettings,
+} from "@/test/fixtures/profile";
 
 export const mockUserId = "test-user-123";
 
 /**
  * Mock profile with admin type
  */
-export const mockAdminProfile: Profile = {
+export const mockAdminProfile = makePrismaProfile({
   id: "profile-admin-1",
   userId: mockUserId,
   name: "Admin User",
-  type: "admin",
-  ageGroup: "adult",
   color: "#3b82f6",
-  avatar: {
-    type: "initials",
-    value: "AU",
-    backgroundColor: "#3b82f6",
-  },
+  avatar: { type: "initials", value: "AU", backgroundColor: "#3b82f6" },
   pinHash: "$2b$10$mockHashedPin", // Mock bcrypt hash
   pinEnabled: true,
-  failedPinAttempts: 0,
-  pinLockedUntil: null,
-  isActive: true,
-  createdAt: new Date("2024-01-01T00:00:00Z"),
-  updatedAt: new Date("2024-01-01T00:00:00Z"),
-};
+});
 
 /**
  * Mock profile with standard type
  */
-export const mockStandardProfile: Profile = {
+export const mockStandardProfile = makePrismaProfile({
   id: "profile-standard-1",
   userId: mockUserId,
   name: "Child User",
   type: "standard",
   ageGroup: "child",
   color: "#22c55e",
-  avatar: {
-    type: "emoji",
-    value: "👦",
-  },
-  pinHash: null,
-  pinEnabled: false,
-  failedPinAttempts: 0,
-  pinLockedUntil: null,
-  isActive: true,
+  avatar: { type: "emoji", value: "👦" },
   createdAt: new Date("2024-01-02T00:00:00Z"),
   updatedAt: new Date("2024-01-02T00:00:00Z"),
-};
+});
 
 /**
  * Mock profile reward points
@@ -72,27 +59,30 @@ export const mockProfileRewardPoints: ProfileRewardPoints = {
 /**
  * Mock profile settings
  */
-export const mockProfileSettings: ProfileSettings = {
+export const mockProfileSettings = makeProfileSettings({
   id: "settings-1",
   profileId: mockAdminProfile.id,
-  defaultTaskListId: null,
-  showCompletedTasks: false,
-  taskSortOrder: "dueDate",
-  theme: "light",
-  language: "en",
-  enableNotifications: false,
-  notificationTime: null,
-};
+});
 
 /**
- * Factory function to create custom mock profiles
+ * Factory function to create custom mock profiles.
+ *
+ * Delegates to `makePrismaProfile` but injects a sequential `id` based on the
+ * current timestamp by default so multi-profile renders in a single test
+ * don't collide on identical ids.
  */
-export function createMockProfile(overrides: Partial<Profile> = {}): Profile {
-  return {
-    ...mockStandardProfile,
+export function createMockProfile(
+  overrides: Parameters<typeof makePrismaProfile>[0] = {}
+): ReturnType<typeof makePrismaProfile> {
+  return makePrismaProfile({
+    name: "Child User",
+    type: "standard",
+    ageGroup: "child",
+    color: "#22c55e",
+    avatar: { type: "emoji", value: "👦" },
     id: `profile-${Date.now()}`,
     ...overrides,
-  };
+  });
 }
 
 /**
@@ -125,7 +115,7 @@ export const mockCreateProfileInput: CreateProfileInput = {
 /**
  * Array of mock profiles for list testing
  */
-export const mockProfileList: Profile[] = [
+export const mockProfileList = [
   mockAdminProfile,
   mockStandardProfile,
   createMockProfile({
@@ -134,9 +124,6 @@ export const mockProfileList: Profile[] = [
     type: "standard",
     ageGroup: "teen",
     color: "#a855f7",
-    avatar: {
-      type: "emoji",
-      value: "👧",
-    },
+    avatar: { type: "emoji", value: "👧" },
   }),
 ];

--- a/src/app/api/profiles/__tests__/fixtures.ts
+++ b/src/app/api/profiles/__tests__/fixtures.ts
@@ -22,7 +22,6 @@ export const mockAdminProfile = makePrismaProfile({
   id: "profile-admin-1",
   userId: mockUserId,
   name: "Admin User",
-  color: "#3b82f6",
   avatar: { type: "initials", value: "AU", backgroundColor: "#3b82f6" },
   pinHash: "$2b$10$mockHashedPin", // Mock bcrypt hash
   pinEnabled: true,

--- a/src/app/api/profiles/__tests__/route.test.ts
+++ b/src/app/api/profiles/__tests__/route.test.ts
@@ -10,6 +10,7 @@ import {
   createMockRequest,
   parseResponse,
 } from "@/lib/test-utils/api-test-helpers";
+import { makePrismaProfile } from "@/test/fixtures/profile";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 // Import route handlers and db after mocks are set up
 import { GET, POST } from "../route";
@@ -170,20 +171,13 @@ describe("/api/profiles", () => {
       mockPrisma.user.findUnique.mockResolvedValue({ maxProfiles: 10 });
 
       const createdProfile = {
-        id: "new-profile-id",
-        userId: mockSession.user.id,
-        name: "New Profile",
-        type: "standard",
-        ageGroup: "adult",
-        color: "#3b82f6",
-        avatar: { type: "initials", value: "NE", backgroundColor: "#3b82f6" },
-        pinHash: null,
-        pinEnabled: false,
-        failedPinAttempts: 0,
-        pinLockedUntil: null,
-        isActive: true,
-        createdAt: new Date(),
-        updatedAt: new Date(),
+        ...makePrismaProfile({
+          id: "new-profile-id",
+          userId: mockSession.user.id,
+          name: "New Profile",
+          type: "standard",
+          avatar: { type: "initials", value: "NE", backgroundColor: "#3b82f6" },
+        }),
         rewardPoints: mockProfileRewardPoints,
         settings: mockProfileSettings,
       };
@@ -294,20 +288,12 @@ describe("/api/profiles", () => {
       mockPrisma.user.findUnique.mockResolvedValue({ maxProfiles: 10 });
 
       const createdProfile = {
-        id: "first-admin-id",
-        userId: mockSession.user.id,
-        name: "Admin User",
-        type: "admin",
-        ageGroup: "adult",
-        color: "#3b82f6",
-        avatar: { type: "initials", value: "AD", backgroundColor: "#3b82f6" },
-        pinHash: null,
-        pinEnabled: false,
-        failedPinAttempts: 0,
-        pinLockedUntil: null,
-        isActive: true,
-        createdAt: new Date(),
-        updatedAt: new Date(),
+        ...makePrismaProfile({
+          id: "first-admin-id",
+          userId: mockSession.user.id,
+          name: "Admin User",
+          avatar: { type: "initials", value: "AD", backgroundColor: "#3b82f6" },
+        }),
         rewardPoints: mockProfileRewardPoints,
         settings: mockProfileSettings,
       };
@@ -334,20 +320,15 @@ describe("/api/profiles", () => {
       mockPrisma.user.findUnique.mockResolvedValue({ maxProfiles: 10 });
 
       const createdProfile = {
-        id: "standard-profile-id",
-        userId: mockSession.user.id,
-        name: "Child User",
-        type: "standard",
-        ageGroup: "child",
-        color: "#22c55e",
-        avatar: { type: "initials", value: "CH", backgroundColor: "#22c55e" },
-        pinHash: null,
-        pinEnabled: false,
-        failedPinAttempts: 0,
-        pinLockedUntil: null,
-        isActive: true,
-        createdAt: new Date(),
-        updatedAt: new Date(),
+        ...makePrismaProfile({
+          id: "standard-profile-id",
+          userId: mockSession.user.id,
+          name: "Child User",
+          type: "standard",
+          ageGroup: "child",
+          color: "#22c55e",
+          avatar: { type: "initials", value: "CH", backgroundColor: "#22c55e" },
+        }),
         rewardPoints: mockProfileRewardPoints,
         settings: mockProfileSettings,
       };
@@ -376,20 +357,13 @@ describe("/api/profiles", () => {
       mockPrisma.user.findUnique.mockResolvedValue({ maxProfiles: 10 });
 
       const createdProfile = {
-        id: "second-admin-id",
-        userId: mockSession.user.id,
-        name: "Second Admin",
-        type: "admin",
-        ageGroup: "adult",
-        color: "#ef4444",
-        avatar: { type: "initials", value: "SA", backgroundColor: "#ef4444" },
-        pinHash: null,
-        pinEnabled: false,
-        failedPinAttempts: 0,
-        pinLockedUntil: null,
-        isActive: true,
-        createdAt: new Date(),
-        updatedAt: new Date(),
+        ...makePrismaProfile({
+          id: "second-admin-id",
+          userId: mockSession.user.id,
+          name: "Second Admin",
+          color: "#ef4444",
+          avatar: { type: "initials", value: "SA", backgroundColor: "#ef4444" },
+        }),
         rewardPoints: mockProfileRewardPoints,
         settings: mockProfileSettings,
       };
@@ -416,20 +390,13 @@ describe("/api/profiles", () => {
       mockPrisma.user.findUnique.mockResolvedValue({ maxProfiles: 10 });
 
       const createdProfile = {
-        id: "third-admin-id",
-        userId: mockSession.user.id,
-        name: "Third Admin",
-        type: "admin",
-        ageGroup: "adult",
-        color: "#8b5cf6",
-        avatar: { type: "initials", value: "TA", backgroundColor: "#8b5cf6" },
-        pinHash: null,
-        pinEnabled: false,
-        failedPinAttempts: 0,
-        pinLockedUntil: null,
-        isActive: true,
-        createdAt: new Date(),
-        updatedAt: new Date(),
+        ...makePrismaProfile({
+          id: "third-admin-id",
+          userId: mockSession.user.id,
+          name: "Third Admin",
+          color: "#8b5cf6",
+          avatar: { type: "initials", value: "TA", backgroundColor: "#8b5cf6" },
+        }),
         rewardPoints: mockProfileRewardPoints,
         settings: mockProfileSettings,
       };

--- a/src/app/profiles/[id]/settings/__tests__/page.test.tsx
+++ b/src/app/profiles/[id]/settings/__tests__/page.test.tsx
@@ -1,7 +1,7 @@
 /**
  * Tests for /profiles/[id]/settings page
  */
-import type { Profile } from "@/components/profiles/profile-context";
+import { makeProfile } from "@/test/fixtures/profile";
 import { render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 // Import after mocks
@@ -12,36 +12,23 @@ const mockFetch = vi.fn();
 global.fetch = mockFetch;
 
 // Mock profile data
-const mockAdminProfile: Profile = {
+const mockAdminProfile = makeProfile({
   id: "profile-admin",
   userId: "user-1",
   name: "Admin User",
-  type: "admin",
-  ageGroup: "adult",
-  color: "#3b82f6",
-  avatar: {
-    type: "initials",
-    value: "AU",
-    backgroundColor: "#3b82f6",
-  },
+  avatar: { type: "initials", value: "AU", backgroundColor: "#3b82f6" },
   pinEnabled: true,
-  isActive: true,
-};
+});
 
-const mockStandardProfile: Profile = {
+const mockStandardProfile = makeProfile({
   id: "profile-standard",
   userId: "user-1",
   name: "Child User",
   type: "standard",
   ageGroup: "child",
   color: "#22c55e",
-  avatar: {
-    type: "emoji",
-    value: "👦",
-  },
-  pinEnabled: false,
-  isActive: true,
-};
+  avatar: { type: "emoji", value: "👦" },
+});
 
 const mockProfiles = [mockAdminProfile, mockStandardProfile];
 

--- a/src/app/profiles/__tests__/page.test.tsx
+++ b/src/app/profiles/__tests__/page.test.tsx
@@ -1,7 +1,7 @@
 /**
  * Tests for /profiles page
  */
-import type { Profile } from "@/components/profiles/profile-context";
+import { makeProfile } from "@/test/fixtures/profile";
 import { render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import ProfilesPage from "../page";
@@ -28,36 +28,22 @@ vi.mock("next/navigation", () => ({
 }));
 
 // Mock profile data
-const mockAdminProfile: Profile = {
+const mockAdminProfile = makeProfile({
   id: "profile-admin",
   userId: "user-1",
   name: "Admin User",
-  type: "admin",
-  ageGroup: "adult",
-  color: "#3b82f6",
-  avatar: {
-    type: "initials",
-    value: "AU",
-    backgroundColor: "#3b82f6",
-  },
-  pinEnabled: false,
-  isActive: true,
-};
+  avatar: { type: "initials", value: "AU", backgroundColor: "#3b82f6" },
+});
 
-const mockStandardProfile: Profile = {
+const mockStandardProfile = makeProfile({
   id: "profile-standard",
   userId: "user-1",
   name: "Child User",
   type: "standard",
   ageGroup: "child",
   color: "#22c55e",
-  avatar: {
-    type: "emoji",
-    value: "👦",
-  },
-  pinEnabled: false,
-  isActive: true,
-};
+  avatar: { type: "emoji", value: "👦" },
+});
 
 const mockProfiles = [mockAdminProfile, mockStandardProfile];
 

--- a/src/components/profiles/__tests__/give-points-modal.test.tsx
+++ b/src/components/profiles/__tests__/give-points-modal.test.tsx
@@ -1,6 +1,7 @@
 /**
  * Tests for GivePointsModal component
  */
+import { makeProfile } from "@/test/fixtures/profile";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -12,36 +13,23 @@ const mockFetch = vi.fn();
 global.fetch = mockFetch;
 
 // Mock profiles
-const mockAdminProfile: Profile = {
+const mockAdminProfile = makeProfile({
   id: "admin-1",
   userId: "user-1",
   name: "Admin User",
-  type: "admin",
-  ageGroup: "adult",
-  color: "#3b82f6",
-  avatar: {
-    type: "initials",
-    value: "AU",
-    backgroundColor: "#3b82f6",
-  },
+  avatar: { type: "initials", value: "AU", backgroundColor: "#3b82f6" },
   pinEnabled: true,
-  isActive: true,
-};
+});
 
-const mockStandardProfile: Profile = {
+const mockStandardProfile = makeProfile({
   id: "child-1",
   userId: "user-1",
   name: "Child User",
   type: "standard",
   ageGroup: "child",
   color: "#22c55e",
-  avatar: {
-    type: "emoji",
-    value: "👦",
-  },
-  pinEnabled: false,
-  isActive: true,
-};
+  avatar: { type: "emoji", value: "👦" },
+});
 
 const mockProfiles: Profile[] = [mockAdminProfile, mockStandardProfile];
 

--- a/src/components/profiles/__tests__/pin-settings.test.tsx
+++ b/src/components/profiles/__tests__/pin-settings.test.tsx
@@ -1,49 +1,40 @@
 /**
  * Tests for PinSettings component
  */
+import { makeProfile } from "@/test/fixtures/profile";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { PinSettings, type PinSettingsProfile } from "../pin-settings";
+import { PinSettings } from "../pin-settings";
 
 // Mock fetch
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
 
-// Mock profiles
-const standardProfileWithoutPin: PinSettingsProfile = {
+// Mock profiles. PinSettings accepts the narrower PinSettingsProfile shape;
+// the full Profile from makeProfile() is structurally assignable.
+const standardProfileWithoutPin = makeProfile({
   id: "profile-standard-1",
   name: "Child User",
   type: "standard",
-  pinEnabled: false,
   color: "#22c55e",
   avatar: { type: "emoji", value: "👦" },
-};
+});
 
-const standardProfileWithPin: PinSettingsProfile = {
+const standardProfileWithPin = makeProfile({
   id: "profile-standard-2",
   name: "Teen User",
   type: "standard",
   pinEnabled: true,
   color: "#a855f7",
-  avatar: {
-    type: "initials",
-    value: "TU",
-    backgroundColor: "#a855f7",
-  },
-};
+  avatar: { type: "initials", value: "TU", backgroundColor: "#a855f7" },
+});
 
-const adminProfile: PinSettingsProfile = {
+const adminProfile = makeProfile({
   id: "profile-admin-1",
   name: "Admin User",
-  type: "admin",
   pinEnabled: true,
-  color: "#3b82f6",
-  avatar: {
-    type: "initials",
-    value: "AU",
-    backgroundColor: "#3b82f6",
-  },
-};
+  avatar: { type: "initials", value: "AU", backgroundColor: "#3b82f6" },
+});
 
 describe("PinSettings", () => {
   const mockOnPinChange = vi.fn();

--- a/src/components/profiles/__tests__/profile-card.test.tsx
+++ b/src/components/profiles/__tests__/profile-card.test.tsx
@@ -1,44 +1,30 @@
 /**
  * Tests for ProfileCard component
  */
+import { makeProfile } from "@/test/fixtures/profile";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ProfileCard, ProfileCardSkeleton } from "../profile-card";
-import type { Profile } from "../profile-context";
 
 // Mock fetch for stats API
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
 
 // Mock profile data
-const mockProfile: Profile = {
-  id: "profile-1",
+const mockProfile = makeProfile({
   userId: "user-1",
   name: "Test User",
   type: "standard",
-  ageGroup: "adult",
-  color: "#3b82f6",
-  avatar: {
-    type: "initials",
-    value: "TU",
-    backgroundColor: "#3b82f6",
-  },
-  pinEnabled: false,
-  isActive: true,
-};
+  avatar: { type: "initials", value: "TU", backgroundColor: "#3b82f6" },
+});
 
-const mockAdminProfile: Profile = {
-  ...mockProfile,
+const mockAdminProfile = makeProfile({
   id: "profile-admin",
+  userId: "user-1",
   name: "Admin User",
-  type: "admin",
-  avatar: {
-    type: "initials",
-    value: "AU",
-    backgroundColor: "#3b82f6",
-  },
-};
+  avatar: { type: "initials", value: "AU", backgroundColor: "#3b82f6" },
+});
 
 const mockStats = {
   profileId: "profile-1",

--- a/src/components/profiles/__tests__/profile-context.test.tsx
+++ b/src/components/profiles/__tests__/profile-context.test.tsx
@@ -1,6 +1,7 @@
 /**
  * Tests for ProfileContext and ProfileProvider
  */
+import { makeProfile } from "@/test/fixtures/profile";
 import { type ReactNode } from "react";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -29,18 +30,14 @@ vi.stubGlobal("localStorage", {
 
 // Mock profiles data
 const mockProfiles: Profile[] = [
-  {
+  makeProfile({
     id: "profile-admin-1",
     userId: "user-1",
     name: "Admin User",
-    type: "admin",
-    ageGroup: "adult",
-    color: "#3b82f6",
     avatar: { type: "initials", value: "AU" },
     pinEnabled: true,
-    isActive: true,
-  },
-  {
+  }),
+  makeProfile({
     id: "profile-standard-1",
     userId: "user-1",
     name: "Child User",
@@ -48,9 +45,7 @@ const mockProfiles: Profile[] = [
     ageGroup: "child",
     color: "#22c55e",
     avatar: { type: "emoji", value: "👦" },
-    pinEnabled: false,
-    isActive: true,
-  },
+  }),
 ];
 
 // Wrapper component

--- a/src/components/profiles/__tests__/profile-grid.test.tsx
+++ b/src/components/profiles/__tests__/profile-grid.test.tsx
@@ -1,6 +1,7 @@
 /**
  * Tests for ProfileGrid component
  */
+import { makeProfile } from "@/test/fixtures/profile";
 import { render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Profile } from "../profile-context";
@@ -12,50 +13,30 @@ global.fetch = mockFetch;
 
 // Mock profile data
 const mockProfiles: Profile[] = [
-  {
+  makeProfile({
     id: "profile-1",
     userId: "user-1",
     name: "Admin User",
-    type: "admin",
-    ageGroup: "adult",
-    color: "#3b82f6",
-    avatar: {
-      type: "initials",
-      value: "AU",
-      backgroundColor: "#3b82f6",
-    },
-    pinEnabled: false,
-    isActive: true,
-  },
-  {
+    avatar: { type: "initials", value: "AU", backgroundColor: "#3b82f6" },
+  }),
+  makeProfile({
     id: "profile-2",
     userId: "user-1",
     name: "Child User",
     type: "standard",
     ageGroup: "child",
     color: "#22c55e",
-    avatar: {
-      type: "emoji",
-      value: "👦",
-    },
-    pinEnabled: false,
-    isActive: true,
-  },
-  {
+    avatar: { type: "emoji", value: "👦" },
+  }),
+  makeProfile({
     id: "profile-3",
     userId: "user-1",
     name: "Teen User",
     type: "standard",
     ageGroup: "teen",
     color: "#a855f7",
-    avatar: {
-      type: "initials",
-      value: "TU",
-      backgroundColor: "#a855f7",
-    },
-    pinEnabled: false,
-    isActive: true,
-  },
+    avatar: { type: "initials", value: "TU", backgroundColor: "#a855f7" },
+  }),
 ];
 
 const mockStats = {

--- a/src/components/profiles/__tests__/profile-switcher.test.tsx
+++ b/src/components/profiles/__tests__/profile-switcher.test.tsx
@@ -1,6 +1,7 @@
 /**
  * Tests for ProfileSwitcher component
  */
+import { makeProfile } from "@/test/fixtures/profile";
 import { type ReactNode } from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -30,18 +31,14 @@ vi.stubGlobal("localStorage", {
 
 // Mock profiles data
 const mockProfiles: Profile[] = [
-  {
+  makeProfile({
     id: "profile-admin-1",
     userId: "user-1",
     name: "Admin User",
-    type: "admin",
-    ageGroup: "adult",
-    color: "#3b82f6",
     avatar: { type: "initials", value: "AU" },
     pinEnabled: true,
-    isActive: true,
-  },
-  {
+  }),
+  makeProfile({
     id: "profile-standard-1",
     userId: "user-1",
     name: "Child User",
@@ -49,10 +46,8 @@ const mockProfiles: Profile[] = [
     ageGroup: "child",
     color: "#22c55e",
     avatar: { type: "emoji", value: "👦" },
-    pinEnabled: false,
-    isActive: true,
-  },
-  {
+  }),
+  makeProfile({
     id: "profile-teen-1",
     userId: "user-1",
     name: "Teen User",
@@ -61,8 +56,7 @@ const mockProfiles: Profile[] = [
     color: "#a855f7",
     avatar: { type: "initials", value: "TU" },
     pinEnabled: true,
-    isActive: true,
-  },
+  }),
 ];
 
 function renderWithProvider(component: ReactNode) {

--- a/src/components/settings/__tests__/settings-form.test.tsx
+++ b/src/components/settings/__tests__/settings-form.test.tsx
@@ -5,6 +5,7 @@
  * for the active profile.
  */
 import { useProfile } from "@/components/profiles/profile-context";
+import { makeProfile } from "@/test/fixtures/profile";
 import { makeUserSettings } from "@/test/fixtures/user-settings";
 import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -41,17 +42,12 @@ const ACTIVE_PROFILE_ID = "profile-active-1";
 function mockActiveProfile(id: string | null) {
   vi.mocked(useProfile).mockReturnValue({
     activeProfile: id
-      ? {
+      ? makeProfile({
           id,
           userId: "user-1",
           name: "Active",
-          type: "admin",
-          ageGroup: "adult",
-          color: "#3b82f6",
           avatar: { type: "initials", value: "A" },
-          pinEnabled: false,
-          isActive: true,
-        }
+        })
       : null,
     allProfiles: [],
     viewMode: "profile",

--- a/src/components/tasks/__tests__/profile-scoped-task-list.test.tsx
+++ b/src/components/tasks/__tests__/profile-scoped-task-list.test.tsx
@@ -7,6 +7,7 @@ import {
   ProfileProvider,
   useProfile,
 } from "@/components/profiles/profile-context";
+import { makeProfile } from "@/test/fixtures/profile";
 import { type ReactNode } from "react";
 import { act, fireEvent, render, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -23,18 +24,13 @@ vi.mock("../task-list", () => ({
 const mockTaskList = vi.mocked(TaskList);
 
 const mockProfiles: Profile[] = [
-  {
+  makeProfile({
     id: "profile-admin-1",
     userId: "user-1",
     name: "Admin",
-    type: "admin",
-    ageGroup: "adult",
-    color: "#3b82f6",
     avatar: { type: "initials", value: "AU" },
-    pinEnabled: false,
-    isActive: true,
-  },
-  {
+  }),
+  makeProfile({
     id: "profile-kid-1",
     userId: "user-1",
     name: "Kid",
@@ -42,9 +38,7 @@ const mockProfiles: Profile[] = [
     ageGroup: "child",
     color: "#22c55e",
     avatar: { type: "emoji", value: "👦" },
-    pinEnabled: false,
-    isActive: true,
-  },
+  }),
 ];
 
 const mockFetch = vi.fn();

--- a/src/test/fixtures/__tests__/profile.test.ts
+++ b/src/test/fixtures/__tests__/profile.test.ts
@@ -1,0 +1,147 @@
+import type { Profile as AppProfile } from "@/components/profiles/profile-context";
+import type {
+  Profile as PrismaProfile,
+  ProfileSettings as PrismaProfileSettings,
+} from "@/generated/prisma/client";
+import { describe, expect, expectTypeOf, it } from "vitest";
+import {
+  makePrismaProfile,
+  makeProfile,
+  makeProfileSettings,
+} from "../profile";
+
+/**
+ * Locks in the contract of the shared Profile / ProfileSettings test
+ * fixtures. Issue #371: adding one field to `Profile` / `ProfileSettings`
+ * forced near-identical edits across ~13 test files. The factories collapse
+ * that to a single edit here.
+ */
+describe("makeProfile", () => {
+  it("returns sensible defaults assignable to the app-level Profile", () => {
+    const profile = makeProfile();
+
+    expect(profile.id).toBe("profile-1");
+    expect(profile.userId).toBe("test-user-123");
+    expect(profile.name).toBe("Test Profile");
+    expect(profile.type).toBe("admin");
+    expect(profile.ageGroup).toBe("adult");
+    expect(profile.color).toBe("#3b82f6");
+    expect(profile.pinEnabled).toBe(false);
+    expect(profile.isActive).toBe(true);
+    expect(profile.avatar).toEqual({
+      type: "initials",
+      value: "TP",
+      backgroundColor: "#3b82f6",
+    });
+
+    // Type-level check: assignable to the app Profile interface.
+    expectTypeOf(profile).toMatchTypeOf<AppProfile>();
+  });
+
+  it("merges overrides on top of defaults", () => {
+    const profile = makeProfile({
+      id: "p-7",
+      name: "Child User",
+      type: "standard",
+      ageGroup: "child",
+      pinEnabled: true,
+    });
+
+    expect(profile.id).toBe("p-7");
+    expect(profile.name).toBe("Child User");
+    expect(profile.type).toBe("standard");
+    expect(profile.ageGroup).toBe("child");
+    expect(profile.pinEnabled).toBe(true);
+    // Untouched defaults remain
+    expect(profile.color).toBe("#3b82f6");
+    expect(profile.isActive).toBe(true);
+  });
+
+  it("accepts a nested avatar override without forcing the caller to repeat unrelated fields", () => {
+    const profile = makeProfile({
+      avatar: { type: "emoji", value: "👧" },
+    });
+
+    expect(profile.avatar).toEqual({ type: "emoji", value: "👧" });
+  });
+
+  it("does not include Prisma-only security fields", () => {
+    const profile = makeProfile();
+    expect(profile).not.toHaveProperty("pinHash");
+    expect(profile).not.toHaveProperty("failedPinAttempts");
+    expect(profile).not.toHaveProperty("pinLockedUntil");
+  });
+});
+
+describe("makePrismaProfile", () => {
+  it("returns sensible defaults assignable to the Prisma Profile row", () => {
+    const profile = makePrismaProfile();
+
+    expect(profile.id).toBe("profile-1");
+    expect(profile.userId).toBe("test-user-123");
+    expect(profile.name).toBe("Test Profile");
+    expect(profile.type).toBe("admin");
+    expect(profile.ageGroup).toBe("adult");
+    expect(profile.pinEnabled).toBe(false);
+    expect(profile.failedPinAttempts).toBe(0);
+    expect(profile.pinLockedUntil).toBeNull();
+    expect(profile.pinHash).toBeNull();
+    expect(profile.isActive).toBe(true);
+    expect(profile.createdAt).toBeInstanceOf(Date);
+    expect(profile.updatedAt).toBeInstanceOf(Date);
+
+    // The factory returns a value assignable to the Prisma row, so it can
+    // be handed directly to `mockResolvedValue` / `mockReturnValue`.
+    expectTypeOf(profile).toMatchTypeOf<PrismaProfile>();
+  });
+
+  it("merges overrides — including PIN security fields", () => {
+    const lockedUntil = new Date("2030-01-01T00:00:00Z");
+    const profile = makePrismaProfile({
+      pinHash: "$2b$10$hash",
+      pinEnabled: true,
+      failedPinAttempts: 3,
+      pinLockedUntil: lockedUntil,
+    });
+
+    expect(profile.pinHash).toBe("$2b$10$hash");
+    expect(profile.pinEnabled).toBe(true);
+    expect(profile.failedPinAttempts).toBe(3);
+    expect(profile.pinLockedUntil).toBe(lockedUntil);
+  });
+});
+
+describe("makeProfileSettings", () => {
+  it("returns defaults aligned with the schema @default(...) values", () => {
+    const settings = makeProfileSettings();
+
+    expect(settings.id).toBe("profile-settings-1");
+    expect(settings.profileId).toBe("profile-1");
+    expect(settings.defaultTaskListId).toBeNull();
+    expect(settings.showCompletedTasks).toBe(false);
+    expect(settings.taskSortOrder).toBe("dueDate");
+    expect(settings.theme).toBe("light");
+    expect(settings.language).toBe("en");
+    expect(settings.enableNotifications).toBe(false);
+    expect(settings.notificationTime).toBeNull();
+
+    expectTypeOf(settings).toMatchTypeOf<PrismaProfileSettings>();
+  });
+
+  it("merges overrides on top of defaults", () => {
+    const settings = makeProfileSettings({
+      theme: "dark",
+      enableNotifications: true,
+      notificationTime: "09:30",
+      taskSortOrder: "priority",
+    });
+
+    expect(settings.theme).toBe("dark");
+    expect(settings.enableNotifications).toBe(true);
+    expect(settings.notificationTime).toBe("09:30");
+    expect(settings.taskSortOrder).toBe("priority");
+    // Untouched defaults remain
+    expect(settings.profileId).toBe("profile-1");
+    expect(settings.showCompletedTasks).toBe(false);
+  });
+});

--- a/src/test/fixtures/profile.ts
+++ b/src/test/fixtures/profile.ts
@@ -1,0 +1,118 @@
+/**
+ * Shared `Profile` / `ProfileSettings` test fixtures.
+ *
+ * Before these factories, ~13 test files each inlined the full Profile shape
+ * (`type`, `ageGroup`, `color`, `avatar`, `pinEnabled`, …) and the API-route
+ * tests inlined the full Prisma row (additionally `pinHash`,
+ * `failedPinAttempts`, `pinLockedUntil`, `createdAt`, `updatedAt`). Adding one
+ * column to `Profile` therefore required identical edits across every one of
+ * those literals — a single one-line schema change fanning out into many
+ * test diffs, plus a merge conflict in every concurrent PR.
+ *
+ * Two factories with distinct names express the boundary cleanly:
+ *
+ * - `makeProfile()` returns the lightweight app-level `Profile` from
+ *   `profile-context.tsx` — used by component, page, and provider tests.
+ * - `makePrismaProfile()` returns the full Prisma row (avatar typed as the
+ *   schema's `JsonValue`) — used by API-route tests where the handler reads
+ *   the underlying `Profile` model directly.
+ *
+ * `makeProfileSettings()` returns the Prisma `ProfileSettings` row; defaults
+ * mirror the `@default(...)` values in `schema.prisma`.
+ *
+ * Issue #371.
+ */
+import type {
+  Profile as AppProfile,
+  ProfileAvatar,
+} from "@/components/profiles/profile-context";
+import type {
+  Profile as PrismaProfile,
+  ProfileSettings as PrismaProfileSettings,
+} from "@/generated/prisma/client";
+
+/**
+ * App-level `Profile` (the shape `ProfileProvider` hands to consumers). The
+ * sensitive PIN columns (`pinHash`, `failedPinAttempts`, `pinLockedUntil`)
+ * are deliberately absent — the API never returns them to the client.
+ */
+export type MockProfile = AppProfile;
+
+const DEFAULT_AVATAR: ProfileAvatar = {
+  type: "initials",
+  value: "TP",
+  backgroundColor: "#3b82f6",
+};
+
+/**
+ * Build an app-level `Profile` for tests. Defaults mirror the `@default(...)`
+ * values in `schema.prisma`; pass `overrides` for fields under test.
+ */
+export function makeProfile(overrides: Partial<MockProfile> = {}): MockProfile {
+  return {
+    id: "profile-1",
+    userId: "test-user-123",
+    name: "Test Profile",
+    type: "admin",
+    ageGroup: "adult",
+    color: "#3b82f6",
+    avatar: DEFAULT_AVATAR,
+    pinEnabled: false,
+    isActive: true,
+    ...overrides,
+  };
+}
+
+/**
+ * Build a full Prisma `Profile` row for tests. Includes the PIN security
+ * columns (`pinHash`, `failedPinAttempts`, `pinLockedUntil`) that
+ * `makeProfile()` omits.
+ *
+ * The return type is the Prisma row (avatar typed as `JsonValue`) so callers
+ * can drop the result directly into places that expect a `Profile` row, e.g.
+ * `mockPrisma.profile.findUnique.mockResolvedValue(makePrismaProfile())`.
+ * Tests that need to assert on avatar fields can narrow with `as
+ * ProfileAvatar`.
+ */
+export function makePrismaProfile(
+  overrides: Partial<PrismaProfile> = {}
+): PrismaProfile {
+  return {
+    id: "profile-1",
+    userId: "test-user-123",
+    name: "Test Profile",
+    type: "admin",
+    ageGroup: "adult",
+    color: "#3b82f6",
+    avatar: { ...DEFAULT_AVATAR },
+    pinHash: null,
+    pinEnabled: false,
+    failedPinAttempts: 0,
+    pinLockedUntil: null,
+    isActive: true,
+    createdAt: new Date("2024-01-01T00:00:00Z"),
+    updatedAt: new Date("2024-01-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+/**
+ * Build a Prisma `ProfileSettings` row for tests. Defaults mirror the
+ * `@default(...)` values in `schema.prisma`.
+ */
+export function makeProfileSettings(
+  overrides: Partial<PrismaProfileSettings> = {}
+): PrismaProfileSettings {
+  return {
+    id: "profile-settings-1",
+    profileId: "profile-1",
+    defaultTaskListId: null,
+    showCompletedTasks: false,
+    taskSortOrder: "dueDate",
+    theme: "light",
+    language: "en",
+    enableNotifications: false,
+    notificationTime: null,
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## Summary

Eliminates the "one new Profile field forces ~13 near-identical test diffs" problem by introducing factories under `src/test/fixtures/profile.ts`:

- `makeProfile()` — app-level Profile (lightweight, UI-facing). Used by component / page / provider tests.
- `makePrismaProfile()` — full Prisma row including PIN security columns (`pinHash`, `failedPinAttempts`, `pinLockedUntil`, `createdAt`, `updatedAt`). Used by API route tests.
- `makeProfileSettings()` — Prisma ProfileSettings row; defaults mirror `@default(...)` in `schema.prisma`.

Plan: `.claude/plans/fixture-factory-profile-371.md`

## Changes

**Phase 1 — factory + unit tests** (`55bfba2`)
- `src/test/fixtures/profile.ts` + `src/test/fixtures/__tests__/profile.test.ts` (8 tests covering defaults, override merging, and type-level assignability against `AppProfile` / `PrismaProfile` / `PrismaProfileSettings`).

**Phase 2 — app-level component tests** (`281443b`)
- Migrated 10 test files (`-174 / +72 lines`): `profile-grid`, `profile-context`, `profile-card`, `profile-switcher`, `give-points-modal`, `pin-settings`, `profile-scoped-task-list`, `settings-form`, `profiles/page`, `profiles/[id]/settings/page`.

**Phase 3 — API route tests + legacy fixtures** (`d7fb149`)
- `src/app/api/profiles/__tests__/fixtures.ts` rewritten as a thin pass-through to the factory (named exports preserved for backwards compatibility).
- `src/app/api/profiles/__tests__/route.test.ts` — five `createdProfile` literals collapsed to `makePrismaProfile({...})` spreads.
- `src/app/api/profiles/[id]/give-points/__tests__/route.test.ts` — inline `mockSecondAdmin` literal converted.
- The reset-pin test consumes the static fixtures via spread overrides and now picks up the factory indirectly.

## Test plan

- [x] `pnpm test` — 2338 tests pass across 147 files
- [x] `pnpm check-types` — clean
- [x] `pnpm lint:fix && pnpm format:fix` — no errors (only pre-existing warnings unrelated to this PR)
- [x] Phase 1 fixture tests in isolation
- [x] Phase 2 file batch (253 tests)
- [x] Phase 3 API route batch (117 tests)

## Out of scope (deferred follow-ups)

- Session/auth mock factory — current inline mocks are small enough that fan-out cost is marginal; defer until needed.
- Google API payload factories — mentioned in #371 as future scope.
- Deriving `UserSettings` defaults + Zod schema from a single source — tracked separately as #372.
- `pin-setup-modal.test.tsx`, `pin-entry-modal.test.tsx` — receive profile data via props from parent mocks; not affected by the fan-out problem.

Closes #371

🤖 Generated with [Claude Code](https://claude.com/claude-code)