### PR TITLE
feat(calendar): fold AgendaCalendar search into AgendaList (#264)

### DIFF
--- a/.claude/plans/fold-agenda-search-264.md
+++ b/.claude/plans/fold-agenda-search-264.md
@@ -29,8 +29,11 @@ removing it.
 Move `filterEventsBySearch` into a new pure module
 `src/components/calendar/agenda-helpers.ts`. Both `AgendaCalendar.tsx` and
 `AgendaList.tsx` import from there. The helper is already heavily tested in
-`agenda-helpers.test.ts` (which currently imports from `AgendaCalendar`); the
-test file moves its import to the new module path with no test changes.
+`agenda-helpers.test.ts` (which currently imports from `AgendaCalendar`). To
+keep the diff minimal and avoid touching the existing test file, the
+implementation re-exports `filterEventsBySearch` from `AgendaCalendar.tsx`,
+so `agenda-helpers.test.ts` continues to import from `../AgendaCalendar`
+unchanged.
 
 We do **not** also relocate `sortEventsByStartTime` / `groupEventsByColor` /
 `groupEventsByDate` / `parseDateKey` / `capitalize` / `getColorClasses`. Those
@@ -72,9 +75,21 @@ days).
 
 - `aria-label="Search events"` on the input.
 - `aria-label="Clear search"` on the clear button.
-- `role="status"` sr-only live region announces match count while typing.
+- `aria-live="polite" aria-atomic="true"` on an sr-only `<p>` announces the
+  match count while typing. (Functionally equivalent to `role="status"`,
+  which is just syntactic sugar for the same ARIA implicit live region.)
 - `aria-hidden="true"` on the visible match-count span so the live region is
   the sole announcement vector.
+
+### Resetting search on date navigation
+
+`AgendaList` keeps `searchQuery` in local component state. When the user
+navigates to the next/previous day or week, `DayCalendar` and `WeekCalendar`
+re-render with new `rangeStart`/`rangeEnd` props but the `AgendaList`
+component instance is preserved, so the search query would silently carry
+over. The call sites in `DayCalendar.tsx` and `WeekCalendar.tsx` set
+`key={rangeStart.toISOString()}` on `<AgendaList>` so React remounts it on
+navigation and the search query (plus any open modal) resets cleanly.
 
 ## TDD plan
 

--- a/.claude/plans/fold-agenda-search-264.md
+++ b/.claude/plans/fold-agenda-search-264.md
@@ -1,0 +1,114 @@
+# Fold AgendaCalendar search into AgendaList day/week agenda mode (#264)
+
+## Context
+
+After PR #195 (day/week agenda toggle), the production `ViewSwitcher` no longer
+mounts the search-driven `AgendaCalendar`; day/week agenda mode renders the
+slimmer `AgendaList`. The search input, match count, and clear control that
+landed in PR #144 only live on `/test/calendar?view=agenda`. Users have lost a
+visible capability.
+
+## Goal
+
+Port the search input UI from `AgendaCalendar` into `AgendaList` so day and
+week agenda mode filter their rendered events by query the same way
+`AgendaCalendar` does, without changing the legacy `AgendaCalendar` UX or
+removing it.
+
+## Out of scope
+
+- Retiring `AgendaCalendar.tsx`. `/test/calendar?view=agenda` still mounts it,
+  and removal is tracked separately.
+- Replacing the per-view header search affordance the calendar surface already
+  ships elsewhere; this is strictly the agenda-mode-internal filter.
+
+## Design
+
+### Shared helper
+
+Move `filterEventsBySearch` into a new pure module
+`src/components/calendar/agenda-helpers.ts`. Both `AgendaCalendar.tsx` and
+`AgendaList.tsx` import from there. The helper is already heavily tested in
+`agenda-helpers.test.ts` (which currently imports from `AgendaCalendar`); the
+test file moves its import to the new module path with no test changes.
+
+We do **not** also relocate `sortEventsByStartTime` / `groupEventsByColor` /
+`groupEventsByDate` / `parseDateKey` / `capitalize` / `getColorClasses`. Those
+helpers exist in subtly different forms in both files already, and merging
+them is bigger than this issue. Keeping the refactor surface tight.
+
+### AgendaList search UI
+
+Add local state `searchQuery` and a `<div>` wrapping a `<Input type="search">`
+plus an absolutely-positioned `<Search>` icon and (when active) a clear `<X>`
+button. Mirror `AgendaCalendar`'s structure exactly: testids
+`agenda-list-search-input`, `agenda-list-search-clear`,
+`agenda-list-search-match-count`, `agenda-list-search-status` (sr-only live
+region). Tabular-nums match count to the right of the input. Use the same
+case-insensitive substring filter on title / description / attendee name.
+
+Order of filtering inside the component: window by `[rangeStart, rangeEnd]`
+first, then apply the search query, then group. This matches AgendaCalendar's
+"window then search" pattern and keeps results scoped to the user's current
+day/week.
+
+### Empty-state semantics
+
+`AgendaList` currently shows the single `emptyLabel` empty state when
+`windowed.length === 0`. After the change, the two states are distinct:
+
+- `windowed.length === 0` → render `emptyLabel` (existing behaviour; the
+  caller already provides a contextual label like "No events on Monday").
+- `windowed.length > 0 && filtered.length === 0` (search active, no matches)
+  → render `No events match "<query>"` inside the same bordered card.
+
+The search input is always visible when `windowed.length > 0`, so the user can
+clear the search from the no-matches state. We do **not** show the input on
+the "no events in range" state (consistent with AgendaCalendar's pattern of
+only meaningful search after data exists; avoids a dead control on empty
+days).
+
+### Accessibility
+
+- `aria-label="Search events"` on the input.
+- `aria-label="Clear search"` on the clear button.
+- `role="status"` sr-only live region announces match count while typing.
+- `aria-hidden="true"` on the visible match-count span so the live region is
+  the sole announcement vector.
+
+## TDD plan
+
+Write tests first, all in `__tests__/AgendaList.test.tsx`:
+
+1. **renders search input and clear button**: input is visible when events
+   are in range; clear button appears once a query is typed and clears the
+   query on click.
+2. **filters by title / description / attendee** (single happy-path test
+   covering all three fields via separate assertions inside one `it` block,
+   since the underlying helper is exhaustively covered in
+   `agenda-helpers.test.ts`).
+3. **shows distinct no-matches empty state**: typing a non-matching query
+   renders `No events match "<query>"` and does **not** render any
+   `agenda-list-group` elements; clearing brings the results back.
+4. **keeps existing in-range empty state when no events exist at all**:
+   typing while `events=[]` keeps the contextual `emptyLabel` and does not
+   render the no-matches card.
+5. **live region announces match count**: after typing, the sr-only status
+   region contains the human-readable match count phrasing.
+
+Existing tests must continue to pass unchanged.
+
+## Phases
+
+Single phase — the change is small enough to deliver and commit as one slice.
+
+1. Add `src/components/calendar/agenda-helpers.ts` exporting
+   `filterEventsBySearch`.
+2. Update `AgendaCalendar.tsx` and `agenda-helpers.test.ts` to import from
+   the new module (`AgendaCalendar.tsx` keeps re-exporting if any other call
+   site relied on the old path — none currently does, but a grep confirms
+   before deletion).
+3. Add the search UI + state to `AgendaList.tsx` and the empty-state branch.
+4. Add the new `AgendaList.test.tsx` cases.
+5. Run `pnpm lint:fix && pnpm format:fix && pnpm check-types && pnpm test`.
+6. Commit, push, open draft PR, Sonnet review, address comments, mark ready.

--- a/src/components/calendar/AgendaCalendar.tsx
+++ b/src/components/calendar/AgendaCalendar.tsx
@@ -9,6 +9,7 @@ import { useRef, useState } from "react";
 import { format, isAfter, isBefore, startOfDay } from "date-fns";
 import { Search, X } from "lucide-react";
 import { EventDetailModal } from "./EventDetailModal";
+import { filterEventsBySearch } from "./agenda-helpers";
 
 /**
  * Filter events for the next N days from today
@@ -29,23 +30,10 @@ function filterEventsForNextNDays(events: IEvent[], days: number): IEvent[] {
   });
 }
 
-/**
- * Filter events whose title, description, or attendee name contains the
- * query (case-insensitive). An empty/whitespace-only query returns the
- * list unchanged.
- */
-export function filterEventsBySearch(
-  events: IEvent[],
-  query: string
-): IEvent[] {
-  const normalized = query.trim().toLowerCase();
-  if (!normalized) return events;
-  return events.filter((event) => {
-    const haystack =
-      `${event.title} ${event.description ?? ""} ${event.user?.name ?? ""}`.toLowerCase();
-    return haystack.includes(normalized);
-  });
-}
+// `filterEventsBySearch` lives in ./agenda-helpers so AgendaList can share it.
+// Re-exported here so `agenda-helpers.test.ts` (and any historical importer)
+// keeps working through this module.
+export { filterEventsBySearch } from "./agenda-helpers";
 
 /**
  * Sort events by start time

--- a/src/components/calendar/AgendaList.tsx
+++ b/src/components/calendar/AgendaList.tsx
@@ -1,10 +1,14 @@
 "use client";
 
 import { useCalendar } from "@/components/providers/CalendarProvider";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import type { IEvent, TEventColor } from "@/types/calendar";
 import { useRef, useState } from "react";
 import { format, isAfter, isBefore } from "date-fns";
+import { Search, X } from "lucide-react";
 import { EventDetailModal } from "./EventDetailModal";
+import { filterEventsBySearch } from "./agenda-helpers";
 
 /**
  * Reusable agenda renderer extracted from AgendaCalendar so the Day and
@@ -193,6 +197,7 @@ export function AgendaList({
 }: AgendaListProps) {
   const { use24HourFormat, agendaModeGroupBy, getAccessRole } = useCalendar();
   const [selectedEvent, setSelectedEvent] = useState<IEvent | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
   const triggerRef = useRef<HTMLElement | SVGElement | null>(null);
 
   const openModal = (event: IEvent, trigger: HTMLElement) => {
@@ -215,26 +220,117 @@ export function AgendaList({
     );
   }
 
+  const filtered = filterEventsBySearch(windowed, searchQuery);
+  const searchActive = searchQuery.trim().length > 0;
+  const noMatches = searchActive && filtered.length === 0;
+  const matchCount = filtered.length;
   const colorGroups =
-    agendaModeGroupBy === "color" ? groupByColor(windowed) : null;
+    !noMatches && agendaModeGroupBy === "color" ? groupByColor(filtered) : null;
 
   return (
-    <div
-      className="border-border bg-card max-h-[calc(100vh-280px)] overflow-y-auto rounded-lg border"
-      data-testid="agenda-list"
-    >
-      {agendaModeGroupBy === "color" && colorGroups ? (
-        <div className="space-y-6 p-4">
-          {COLOR_ORDER.filter((color) => colorGroups.has(color)).map(
-            (color) => {
-              const colorEvents = colorGroups.get(color) ?? [];
-              return (
+    <div className="space-y-3" data-testid="agenda-list-wrapper">
+      <div className="flex items-center gap-3">
+        <div className="relative flex-1">
+          <Search
+            className="text-muted-foreground pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2"
+            aria-hidden="true"
+          />
+          <Input
+            type="search"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="Search events by title, description, or attendee…"
+            aria-label="Search events"
+            data-testid="agenda-list-search-input"
+            className="pr-9 pl-9"
+          />
+          {searchActive && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              onClick={() => setSearchQuery("")}
+              aria-label="Clear search"
+              data-testid="agenda-list-search-clear"
+              className="text-muted-foreground hover:text-foreground absolute top-1/2 right-1 h-7 w-7 -translate-y-1/2"
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          )}
+        </div>
+        {searchActive && (
+          <span
+            className="text-muted-foreground shrink-0 text-xs tabular-nums"
+            data-testid="agenda-list-search-match-count"
+            aria-hidden="true"
+          >
+            {matchCount} {matchCount === 1 ? "match" : "matches"}
+          </span>
+        )}
+      </div>
+
+      {/* Live region announces result count while the user types. Visually
+          hidden so it doesn't displace other UI. */}
+      <p
+        aria-live="polite"
+        aria-atomic="true"
+        className="sr-only"
+        data-testid="agenda-list-search-status"
+      >
+        {searchActive
+          ? `${matchCount} ${matchCount === 1 ? "event matches" : "events match"} "${searchQuery.trim()}"`
+          : ""}
+      </p>
+
+      <div
+        className="border-border bg-card max-h-[calc(100vh-280px)] overflow-y-auto rounded-lg border"
+        data-testid="agenda-list"
+      >
+        {noMatches ? (
+          <div
+            className="text-muted-foreground py-12 text-center"
+            data-testid="agenda-list-search-no-matches"
+          >
+            <p>No events match &ldquo;{searchQuery.trim()}&rdquo;</p>
+          </div>
+        ) : agendaModeGroupBy === "color" && colorGroups ? (
+          <div className="space-y-6 p-4">
+            {COLOR_ORDER.filter((color) => colorGroups.has(color)).map(
+              (color) => {
+                const colorEvents = colorGroups.get(color) ?? [];
+                return (
+                  <AgendaGroup
+                    key={color}
+                    headerText={capitalize(color)}
+                    eventCount={colorEvents.length}
+                  >
+                    {colorEvents.map((event) => (
+                      <EventCard
+                        key={event.id}
+                        event={event}
+                        use24HourFormat={use24HourFormat}
+                        onClick={openModal}
+                      />
+                    ))}
+                  </AgendaGroup>
+                );
+              }
+            )}
+          </div>
+        ) : (
+          <div className="space-y-6 p-4">
+            {Array.from(groupByDate(filtered).entries())
+              .sort(
+                ([a], [b]) =>
+                  parseDateKey(a).getTime() - parseDateKey(b).getTime()
+              )
+              .map(([dateKey, dayEvents]) => (
                 <AgendaGroup
-                  key={color}
-                  headerText={capitalize(color)}
-                  eventCount={colorEvents.length}
+                  key={dateKey}
+                  headerText={format(parseDateKey(dateKey), "EEEE, MMMM d")}
+                  eventCount={dayEvents.length}
                 >
-                  {colorEvents.map((event) => (
+                  {dayEvents.map((event) => (
                     <EventCard
                       key={event.id}
                       event={event}
@@ -243,35 +339,10 @@ export function AgendaList({
                     />
                   ))}
                 </AgendaGroup>
-              );
-            }
-          )}
-        </div>
-      ) : (
-        <div className="space-y-6 p-4">
-          {Array.from(groupByDate(windowed).entries())
-            .sort(
-              ([a], [b]) =>
-                parseDateKey(a).getTime() - parseDateKey(b).getTime()
-            )
-            .map(([dateKey, dayEvents]) => (
-              <AgendaGroup
-                key={dateKey}
-                headerText={format(parseDateKey(dateKey), "EEEE, MMMM d")}
-                eventCount={dayEvents.length}
-              >
-                {dayEvents.map((event) => (
-                  <EventCard
-                    key={event.id}
-                    event={event}
-                    use24HourFormat={use24HourFormat}
-                    onClick={openModal}
-                  />
-                ))}
-              </AgendaGroup>
-            ))}
-        </div>
-      )}
+              ))}
+          </div>
+        )}
+      </div>
 
       <EventDetailModal
         event={selectedEvent}

--- a/src/components/calendar/DayCalendar.tsx
+++ b/src/components/calendar/DayCalendar.tsx
@@ -218,7 +218,11 @@ export function DayCalendar() {
       )}
 
       {agendaMode ? (
+        // Key on the day boundary so React remounts AgendaList on prev/next
+        // navigation. Without this, AgendaList's local searchQuery state
+        // would silently carry over from one day to the next.
         <AgendaList
+          key={startOfDay(selectedDate).toISOString()}
           events={dayEvents}
           rangeStart={startOfDay(selectedDate)}
           rangeEnd={endOfDay(selectedDate)}

--- a/src/components/calendar/WeekCalendar.tsx
+++ b/src/components/calendar/WeekCalendar.tsx
@@ -197,7 +197,11 @@ export function WeekCalendar() {
       )}
 
       {agendaMode ? (
+        // Key on the week start so React remounts AgendaList on prev/next
+        // week navigation. Without this, AgendaList's local searchQuery
+        // state would silently carry over from one week to the next.
         <AgendaList
+          key={weekStart.toISOString()}
           events={weekEvents}
           rangeStart={weekStart}
           rangeEnd={weekEnd}

--- a/src/components/calendar/__tests__/AgendaList.test.tsx
+++ b/src/components/calendar/__tests__/AgendaList.test.tsx
@@ -229,7 +229,7 @@ describe("AgendaList", () => {
       expect(titles).toEqual(["Dentist Appointment"]);
     });
 
-    it("renders a 'no matches' empty state when the query matches nothing in range", async () => {
+    it("renders a 'no matches' empty state when the query matches nothing in range, and restores the list on clear", async () => {
       const user = userEvent.setup();
       renderList({ events: [morning, afternoon], ...range });
 
@@ -244,6 +244,29 @@ describe("AgendaList", () => {
       ).toHaveTextContent(/nothing-matches/);
       // The contextual range-empty state must not also appear.
       expect(screen.queryByTestId("agenda-list-empty")).toBeNull();
+
+      // Clearing a non-matching query brings the original events back.
+      await user.click(screen.getByTestId("agenda-list-search-clear"));
+      expect(screen.queryByTestId("agenda-list-search-no-matches")).toBeNull();
+      const titles = screen
+        .getAllByTestId("agenda-list-event-title")
+        .map((el) => el.textContent);
+      expect(titles.sort()).toEqual(["Dentist Appointment", "Soccer Practice"]);
+    });
+
+    it("filters events by query when grouped by color", async () => {
+      const user = userEvent.setup();
+      renderList(
+        { events: [morning, afternoon], ...range },
+        { agendaModeGroupBy: "color" }
+      );
+
+      await user.type(screen.getByTestId("agenda-list-search-input"), "soccer");
+
+      const titles = screen
+        .getAllByTestId("agenda-list-event-title")
+        .map((el) => el.textContent);
+      expect(titles).toEqual(["Soccer Practice"]);
     });
 
     it("shows and uses the clear-search control once a query is typed", async () => {

--- a/src/components/calendar/__tests__/AgendaList.test.tsx
+++ b/src/components/calendar/__tests__/AgendaList.test.tsx
@@ -10,6 +10,7 @@ import {
 import { makeCalendarContext } from "@/test/fixtures/calendar-context";
 import type { IEvent, IUser, TEventColor } from "@/types/calendar";
 import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 import { AgendaList } from "../AgendaList";
 
@@ -149,6 +150,135 @@ describe("AgendaList", () => {
     });
 
     expect(screen.getByText("Nothing scheduled today")).toBeInTheDocument();
+  });
+
+  describe("search input (#264 — fold AgendaCalendar search into day/week agenda mode)", () => {
+    const morning = makeEvent(
+      "morning",
+      "2026-05-04T09:00:00.000Z",
+      "2026-05-04T10:00:00.000Z",
+      {
+        title: "Dentist Appointment",
+        description: "Annual cleaning",
+        user: user("u1", "Emma"),
+      }
+    );
+    const afternoon = makeEvent(
+      "afternoon",
+      "2026-05-04T14:00:00.000Z",
+      "2026-05-04T15:00:00.000Z",
+      {
+        title: "Soccer Practice",
+        description: "Bring water bottle",
+        user: user("u2", "Dad"),
+      }
+    );
+    const range = {
+      rangeStart: new Date("2026-05-04T00:00:00.000Z"),
+      rangeEnd: new Date("2026-05-04T23:59:59.999Z"),
+    };
+
+    it("renders the search input when events are in range", () => {
+      renderList({ events: [morning, afternoon], ...range });
+      expect(
+        screen.getByTestId("agenda-list-search-input")
+      ).toBeInTheDocument();
+    });
+
+    it("does not render the search input when no events are in range", () => {
+      renderList({ events: [], ...range });
+      expect(screen.queryByTestId("agenda-list-search-input")).toBeNull();
+    });
+
+    it("filters events by title (case-insensitive substring)", async () => {
+      const user = userEvent.setup();
+      renderList({ events: [morning, afternoon], ...range });
+
+      await user.type(screen.getByTestId("agenda-list-search-input"), "soccer");
+
+      const titles = screen
+        .getAllByTestId("agenda-list-event-title")
+        .map((el) => el.textContent);
+      expect(titles).toEqual(["Soccer Practice"]);
+    });
+
+    it("filters events by description (case-insensitive substring)", async () => {
+      const user = userEvent.setup();
+      renderList({ events: [morning, afternoon], ...range });
+
+      await user.type(
+        screen.getByTestId("agenda-list-search-input"),
+        "cleaning"
+      );
+
+      const titles = screen
+        .getAllByTestId("agenda-list-event-title")
+        .map((el) => el.textContent);
+      expect(titles).toEqual(["Dentist Appointment"]);
+    });
+
+    it("filters events by attendee (user) name", async () => {
+      const user = userEvent.setup();
+      renderList({ events: [morning, afternoon], ...range });
+
+      await user.type(screen.getByTestId("agenda-list-search-input"), "Emma");
+
+      const titles = screen
+        .getAllByTestId("agenda-list-event-title")
+        .map((el) => el.textContent);
+      expect(titles).toEqual(["Dentist Appointment"]);
+    });
+
+    it("renders a 'no matches' empty state when the query matches nothing in range", async () => {
+      const user = userEvent.setup();
+      renderList({ events: [morning, afternoon], ...range });
+
+      await user.type(
+        screen.getByTestId("agenda-list-search-input"),
+        "nothing-matches"
+      );
+
+      expect(screen.queryByTestId("agenda-list-group")).toBeNull();
+      expect(
+        screen.getByTestId("agenda-list-search-no-matches")
+      ).toHaveTextContent(/nothing-matches/);
+      // The contextual range-empty state must not also appear.
+      expect(screen.queryByTestId("agenda-list-empty")).toBeNull();
+    });
+
+    it("shows and uses the clear-search control once a query is typed", async () => {
+      const user = userEvent.setup();
+      renderList({ events: [morning, afternoon], ...range });
+
+      // Clear button starts hidden
+      expect(screen.queryByTestId("agenda-list-search-clear")).toBeNull();
+
+      await user.type(screen.getByTestId("agenda-list-search-input"), "soccer");
+
+      const clear = screen.getByTestId("agenda-list-search-clear");
+      await user.click(clear);
+
+      // Both events visible again after clearing.
+      const titles = screen
+        .getAllByTestId("agenda-list-event-title")
+        .map((el) => el.textContent);
+      expect(titles.sort()).toEqual(["Dentist Appointment", "Soccer Practice"]);
+      expect(screen.queryByTestId("agenda-list-search-clear")).toBeNull();
+    });
+
+    it("renders a match count and an sr-only live region announcing it", async () => {
+      const user = userEvent.setup();
+      renderList({ events: [morning, afternoon], ...range });
+
+      await user.type(screen.getByTestId("agenda-list-search-input"), "soccer");
+
+      expect(
+        screen.getByTestId("agenda-list-search-match-count")
+      ).toHaveTextContent("1 match");
+      expect(screen.getByTestId("agenda-list-search-status")).toHaveTextContent(
+        /1 event matches "soccer"/
+      );
+    });
   });
 
   it("collapses empty time gaps — does not render any hour-grid scaffolding", () => {

--- a/src/components/calendar/__tests__/DayCalendar.test.tsx
+++ b/src/components/calendar/__tests__/DayCalendar.test.tsx
@@ -552,5 +552,61 @@ describe("DayCalendar", () => {
       await user.click(screen.getByTestId("day-calendar-next"));
       expect(contextValue.setSelectedDate).toHaveBeenCalledTimes(1);
     });
+
+    // The AgendaList stays mounted as the same component instance when the
+    // user navigates day-by-day; without a remount, a search query typed on
+    // one day would silently carry over to the next. Keying AgendaList on
+    // the day forces a remount and clears search state.
+    it("clears the AgendaList search query when the selected day changes", async () => {
+      const userEv = userEvent.setup();
+      const dayA = startOfDay(new Date(2026, 3, 15));
+      const dayB = startOfDay(new Date(2026, 3, 16));
+      const eventA = createMockEvent({
+        id: "a",
+        title: "SoccerPractice",
+        startDate: at(dayA, 10),
+        endDate: at(dayA, 11),
+      });
+      const eventB = createMockEvent({
+        id: "b",
+        title: "OtherEvent",
+        startDate: at(dayB, 10),
+        endDate: at(dayB, 11),
+      });
+
+      const { rerender } = render(
+        <CalendarContext.Provider
+          value={createMockContext({
+            agendaMode: true,
+            selectedDate: dayA,
+            events: [eventA, eventB],
+          })}
+        >
+          <DayCalendar />
+        </CalendarContext.Provider>
+      );
+      await userEv.type(
+        screen.getByTestId("agenda-list-search-input"),
+        "soccer"
+      );
+      expect(screen.getByTestId("agenda-list-search-input")).toHaveValue(
+        "soccer"
+      );
+
+      rerender(
+        <CalendarContext.Provider
+          value={createMockContext({
+            agendaMode: true,
+            selectedDate: dayB,
+            events: [eventA, eventB],
+          })}
+        >
+          <DayCalendar />
+        </CalendarContext.Provider>
+      );
+
+      expect(screen.getByTestId("agenda-list-search-input")).toHaveValue("");
+      expect(screen.getByText("OtherEvent")).toBeInTheDocument();
+    });
   });
 });

--- a/src/components/calendar/__tests__/WeekCalendar.test.tsx
+++ b/src/components/calendar/__tests__/WeekCalendar.test.tsx
@@ -559,5 +559,66 @@ describe("WeekCalendar", () => {
       await user.click(screen.getByTestId("week-calendar-next"));
       expect(contextValue.setSelectedDate).toHaveBeenCalledTimes(1);
     });
+
+    // Keying AgendaList on the week start forces a remount on week
+    // navigation, clearing the local search query so it doesn't carry
+    // silently into the next week.
+    it("clears the AgendaList search query when the selected week changes", async () => {
+      const userEv = userEvent.setup();
+      const dateInWeekA = new Date(2026, 3, 15); // Wed
+      const dateInWeekB = new Date(2026, 3, 22); // Wed, +1 week
+      const weekAStart = startOfWeek(dateInWeekA, {
+        weekStartsOn: WEEK_STARTS_ON,
+      });
+      const weekBStart = startOfWeek(dateInWeekB, {
+        weekStartsOn: WEEK_STARTS_ON,
+      });
+      const eventA = createMockEvent({
+        id: "a",
+        title: "SoccerPractice",
+        startDate: midday(addDays(weekAStart, 1)).toISOString(),
+        endDate: midday(addDays(weekAStart, 1)).toISOString(),
+      });
+      const eventB = createMockEvent({
+        id: "b",
+        title: "OtherEvent",
+        startDate: midday(addDays(weekBStart, 1)).toISOString(),
+        endDate: midday(addDays(weekBStart, 1)).toISOString(),
+      });
+
+      const { rerender } = render(
+        <CalendarContext.Provider
+          value={createMockContext({
+            agendaMode: true,
+            selectedDate: dateInWeekA,
+            events: [eventA, eventB],
+          })}
+        >
+          <WeekCalendar />
+        </CalendarContext.Provider>
+      );
+      await userEv.type(
+        screen.getByTestId("agenda-list-search-input"),
+        "soccer"
+      );
+      expect(screen.getByTestId("agenda-list-search-input")).toHaveValue(
+        "soccer"
+      );
+
+      rerender(
+        <CalendarContext.Provider
+          value={createMockContext({
+            agendaMode: true,
+            selectedDate: dateInWeekB,
+            events: [eventA, eventB],
+          })}
+        >
+          <WeekCalendar />
+        </CalendarContext.Provider>
+      );
+
+      expect(screen.getByTestId("agenda-list-search-input")).toHaveValue("");
+      expect(screen.getByText("OtherEvent")).toBeInTheDocument();
+    });
   });
 });

--- a/src/components/calendar/agenda-helpers.ts
+++ b/src/components/calendar/agenda-helpers.ts
@@ -1,0 +1,23 @@
+import type { IEvent } from "@/types/calendar";
+
+/**
+ * Filter events whose title, description, or attendee name contains the
+ * query (case-insensitive). An empty/whitespace-only query returns the
+ * list unchanged.
+ *
+ * Shared between `AgendaCalendar` (the legacy `/test/calendar?view=agenda`
+ * renderer) and `AgendaList` (the production day/week agenda-mode renderer)
+ * so search behaves identically on both surfaces.
+ */
+export function filterEventsBySearch(
+  events: IEvent[],
+  query: string
+): IEvent[] {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) return events;
+  return events.filter((event) => {
+    const haystack =
+      `${event.title} ${event.description ?? ""} ${event.user?.name ?? ""}`.toLowerCase();
+    return haystack.includes(normalized);
+  });
+}


### PR DESCRIPTION
## Summary

- Restore the search input that day/week agenda mode lost in PR #195 — title / description / attendee substring filter, clear control, match count, sr-only live region — by porting it from `AgendaCalendar` into `AgendaList`.
- Extract `filterEventsBySearch` into a shared `agenda-helpers.ts` module so both renderers depend on one implementation. `AgendaCalendar.tsx` re-exports it for back-compat with the existing `agenda-helpers.test.ts` (no test changes required).
- Distinguish the two empty states: contextual `emptyLabel` when no events fall in the range (search input hidden — no dead control), and `No events match "<query>"` when a search returns nothing in a non-empty range (search input stays mounted so the user can clear).
- Key the `AgendaList` element on `rangeStart` at both call sites (`DayCalendar.tsx`, `WeekCalendar.tsx`) so React remounts it on prev/next navigation — prevents a search query typed on one day/week from silently carrying over.

## Plan

Linked plan: `.claude/plans/fold-agenda-search-264.md`
Project: https://github.com/users/BenSeymourODB/projects/1

## Review feedback addressed (round 1)

- **Suggestion 1** (UX): key `AgendaList` on `rangeStart` at both call sites — DayCalendar.tsx, WeekCalendar.tsx (Option A from review).
- **Suggestion 2** (test gap): added a search + color-groupBy test in `AgendaList.test.tsx`.
- **Suggestion 3** (test gap): extended the no-matches empty-state test to click the clear control and assert events return.
- **Nit 2** (plan divergence): updated `.claude/plans/fold-agenda-search-264.md` to reflect `aria-live="polite" aria-atomic="true"` and the re-export-based migration of `agenda-helpers.test.ts`.

**Deferred:**

- **Nit 1** (Webkit double clear control): pre-existing identical concern in `AgendaCalendar`. Filed as #411 to fix in both components together via a single global CSS rule.

## Merge resolution

Main advanced past PR #391's original base. Merged `origin/main` (commit `4052f56`) and resolved conflicts in `AgendaList.tsx` / `DayCalendar.tsx` / `WeekCalendar.tsx`:

- `AgendaList.tsx`: integrated this PR's search input with main's new `agendaModeGroupBy === "category"` branch (from PR #257). Both color and category groupings now drive off the search-`filtered` list, and both stay gated on `!noMatches` so the dedicated no-match empty state short-circuits all groupings.
- `DayCalendar.tsx` / `WeekCalendar.tsx`: kept main's `AnimatedSwap` slide-animation wrapper (from PR #299) and moved the `key={…}` prop onto the `AgendaList` child inside the swap.
- `DayCalendar.test.tsx` / `WeekCalendar.test.tsx`: the search-reset assertions now query inside `animated-swap-incoming`, since the slide animation keeps the previous `AgendaList` mounted as the outgoing snapshot during the transition.

## Test plan

- [x] `pnpm test` — 2532 / 2532 passing
- [x] `pnpm lint:fix` — 0 errors (6 pre-existing warnings in untouched files)
- [x] `pnpm format:fix` — clean
- [x] `pnpm check-types` — clean
- [ ] Manual: open `/calendar?view=day&agenda=1` and `/calendar?view=week&agenda=1`, type into the search box, confirm filtering, clear, no-matches behaviour, and that navigating to the next day/week clears the query (matches `/test/calendar?view=agenda`). Cross-check that the `agendaModeGroupBy="category"` branch in `AgendaList` also honours the search query.

## Out of scope

Full retirement of `AgendaCalendar.tsx`. `/test/calendar?view=agenda` still mounts the legacy renderer; removing the file is tracked separately.

Closes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)