### PR TITLE
feat(cache): visibility-change cleanup sweep (#290 sub-task 2)

### DIFF
--- a/.claude/plans/event-cache-visibility-sweep-290.md
+++ b/.claude/plans/event-cache-visibility-sweep-290.md
@@ -1,0 +1,146 @@
+# Event-cache background visibility-change sweep — issue #290 (sub-task 2)
+
+Tracking issue: [#290](https://github.com/BenSeymourODB/next-digital-wall-calendar/issues/290).
+Predecessors:
+
+- `.claude/plans/event-cache-rework-218.md` (#218 / PR #258 — per-event TTL, upsert, in-memory fallback).
+- `.claude/plans/event-cache-lru-eviction-290.md` (#290 sub-task 1 / PR #377 — LRU on `QuotaExceededError`).
+
+## Slice
+
+This plan covers **only the second of #290's three sub-tasks**: background
+`visibilitychange` cleanup sweep. Sub-task 3 (TTL wired to user settings)
+will ship in a separate PR once the `useUserSettings.mutate` bus pattern
+(PR #344 / issue #337) is exercised by another consumer.
+
+## Goal
+
+When the tab returns to `visible` after being hidden — typically the
+wall-mounted calendar coming back from screensaver, or a profile switch
+re-mounting the calendar — proactively evict rows whose `cachedAt + TTL`
+has elapsed. The existing read-time eviction in `getAll` already prevents
+stale rows from surfacing, but on a cold cache (no read since the rows
+went stale) the entries linger in IndexedDB and contribute toward the
+storage quota. The sweep is **additive**: it must not change `getAll`'s
+semantics, and must be idempotent with read-time eviction.
+
+## Design decisions
+
+### Sweep contract
+
+Add `sweepExpired(now: number): Promise<number>` to `EventStore`:
+
+- Walks the store, deletes rows where `now - cachedAt >= TTL`.
+- Returns the number of rows actually evicted.
+- Same eviction rule as `getAll`'s side effect — by design, calling
+  `sweepExpired` then `getAll` is observationally identical to calling
+  `getAll` alone.
+
+`now` is injected for the same reason the existing API takes it: tests
+need deterministic time without monkey-patching `Date.now`.
+
+### Backend-specific implementation
+
+- **`InMemoryEventStore`** — iterate `this.rows`, delete by id, count.
+  Same loop the existing `getAll` does, factored to share neither code
+  (small enough not to need it) nor allocation patterns.
+- **`IndexedDBEventStore`** — open a cursor on the `cachedAt` index
+  ascending. For each row whose `cachedAt + TTL <= now`, `cursor.delete()`
+  and continue. Stop as soon as we see a row whose `cachedAt` is fresh
+  enough that no further row can be expired (the index is ascending in
+  `cachedAt`, so this is the cutoff). Resolution is deferred to
+  `transaction.oncomplete` so the promise only settles after the
+  deletes actually commit — same pattern PR #377 added to `evictOldest`.
+
+### Trigger
+
+A small `useEventCacheVisibilitySweep` hook in `src/hooks/`:
+
+- Calls `eventCache.sweepExpired()` once on mount when the document is
+  already visible (covers the first-load case for a calendar that
+  opens straight into the wall-mounted view).
+- Adds a `visibilitychange` listener; on `document.visibilityState === 'visible'`
+  fires the sweep.
+- Removes the listener on unmount.
+- Swallows errors via `logger.error` — the sweep is best-effort; if it
+  fails the cache is still consistent (read-time eviction is the
+  belt-and-braces).
+
+`CalendarProvider` opts into the hook in its initialization effect —
+that's the existing seam where `eventCache.getEvents`/`saveEvents` are
+already wired, so no new lifecycle is introduced.
+
+### Logging
+
+`logger.event("event-cache.visibility-swept", {context}, { evicted })`
+**only when `evicted > 0`** — a zero-row sweep is uninteresting noise.
+Matches the bar set by sub-task 1's `event-cache.lru-evicted` event.
+
+## Phases
+
+### Phase 1 — `EventStore.sweepExpired` + unit tests
+
+- Extend the `EventStore` interface with `sweepExpired(now)`.
+- Implement on `InMemoryEventStore` (mirror `getAll`'s expiry rule).
+- Implement on `IndexedDBEventStore` using a cursor on the `cachedAt`
+  index; deletes are committed before the promise resolves.
+- Tests (vitest):
+  - `sweepExpired(now)` removes only rows whose `cachedAt + TTL <= now`.
+  - Returns the actual evicted count.
+  - Is a no-op (returns 0) when nothing is stale.
+  - Co-existence with `getAll`: sweeping first does not double-count
+    when `getAll` later also runs.
+  - Co-existence with `evictOldest`: a sweep that has already removed
+    a row makes `evictOldest` return one fewer than the original count.
+
+### Phase 2 — `EventCache.sweepExpired` + tests
+
+- Public method on `EventCache` that delegates to the active store via
+  the existing `withFallback` helper.
+- Emits `logger.event` only when `evicted > 0`.
+- Tests:
+  - Returns the evicted count.
+  - Emits the event when rows were swept; does NOT emit on a zero-row
+    sweep.
+  - Falls back to the in-memory store when the active store throws
+    (uses the existing flaky-store fixture pattern from
+    `event-cache.test.ts`).
+
+### Phase 3 — `useEventCacheVisibilitySweep` + wire into CalendarProvider
+
+- New `src/hooks/useEventCacheVisibilitySweep.ts`:
+  - Effect runs once: if `document.visibilityState === 'visible'`, fire
+    one sweep on mount.
+  - Adds a `visibilitychange` listener that fires a sweep on transition
+    to `visible`.
+  - Cleanup removes the listener.
+  - All sweep calls are fire-and-forget; errors are logged.
+- Test the hook in isolation (RTL + `vi.spyOn(eventCache, 'sweepExpired')`
+  - manual `document.dispatchEvent(new Event('visibilitychange'))`).
+- Call the hook at the top of `CalendarProvider`.
+
+## Acceptance criteria mapping
+
+From the issue body (sub-task 2):
+
+- [x] On `document.visibilitychange === 'visible'`, sweep expired rows
+      proactively
+- [x] Idempotent with read-time eviction — calling `getAll` after a
+      sweep does not double-count nor surface deleted rows
+- [x] Defaults preserved for existing users — sweep is invisible until
+      stale rows exist
+
+Out of scope (will land separately under #290):
+
+- TTL wired to user settings (sub-task 3 — waits on PR #344-style
+  consumer of `useUserSettings.mutate`)
+
+## Non-goals
+
+- Persisting a "last sweep at" stamp across reloads. The read-time
+  eviction handles any rows that age past TTL between sweeps, so a
+  cross-reload memory is unnecessary.
+- A periodic timer-driven sweep. `visibilitychange` covers the
+  long-hide → return case, which is the empirically interesting one
+  on a wall-mounted calendar; adding a timer multiplies wakeups
+  without measurable benefit.

--- a/src/components/providers/CalendarProvider.tsx
+++ b/src/components/providers/CalendarProvider.tsx
@@ -1,11 +1,8 @@
 "use client";
 
 import type { CalendarsResponse } from "@/app/api/calendar/calendars/route";
-<<<<<<< claude/ecstatic-mayer-64A3Z
 import { useEventCacheVisibilitySweep } from "@/hooks/useEventCacheVisibilitySweep";
-=======
 import { useProfileOptional } from "@/components/profiles/profile-context";
->>>>>>> main
 import { useLocalStorage } from "@/hooks/useLocalStorage";
 import { type TTimeFormat, useUserSettings } from "@/hooks/useUserSettings";
 import {

--- a/src/components/providers/CalendarProvider.tsx
+++ b/src/components/providers/CalendarProvider.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { CalendarsResponse } from "@/app/api/calendar/calendars/route";
+import { useEventCacheVisibilitySweep } from "@/hooks/useEventCacheVisibilitySweep";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
 import { type TTimeFormat, useUserSettings } from "@/hooks/useUserSettings";
 import {
@@ -214,6 +215,11 @@ export function CalendarProvider({
    */
   initialAgendaMode?: boolean;
 }) {
+  // Sweep expired IndexedDB cache rows on tab return to visible (#290
+  // sub-task 2). Lives at provider scope so the cleanup follows the
+  // calendar lifecycle, not any single view.
+  useEventCacheVisibilitySweep();
+
   // Use NextAuth session for authentication
   const { data: session, status } = useSession();
   const isAuthenticated = status === "authenticated";

--- a/src/hooks/__tests__/useEventCacheVisibilitySweep.test.tsx
+++ b/src/hooks/__tests__/useEventCacheVisibilitySweep.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * Tests for useEventCacheVisibilitySweep — #290 sub-task 2 trigger.
+ */
+import { eventCache } from "@/lib/event-cache";
+import { logger } from "@/lib/logger";
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useEventCacheVisibilitySweep } from "../useEventCacheVisibilitySweep";
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    error: vi.fn(),
+    log: vi.fn(),
+    event: vi.fn(),
+    dependency: vi.fn(),
+  },
+}));
+
+/**
+ * jsdom's `document.visibilityState` is a getter on `Document.prototype`. Tests
+ * need to flip it between renders, so install a configurable override and
+ * restore it afterwards.
+ */
+function stubVisibilityState(value: DocumentVisibilityState) {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => value,
+  });
+}
+
+const originalVisibilityDescriptor = Object.getOwnPropertyDescriptor(
+  Document.prototype,
+  "visibilityState"
+);
+
+describe("useEventCacheVisibilitySweep", () => {
+  let sweepSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    sweepSpy = vi.spyOn(eventCache, "sweepExpired").mockResolvedValue(0);
+  });
+
+  afterEach(() => {
+    sweepSpy.mockRestore();
+    if (originalVisibilityDescriptor) {
+      Object.defineProperty(
+        Document.prototype,
+        "visibilityState",
+        originalVisibilityDescriptor
+      );
+    }
+    vi.mocked(logger.error).mockClear();
+  });
+
+  it("sweeps once on mount when the document is already visible", () => {
+    stubVisibilityState("visible");
+
+    renderHook(() => useEventCacheVisibilitySweep());
+
+    expect(sweepSpy).toHaveBeenCalledOnce();
+  });
+
+  it("does NOT sweep on mount when the document is hidden", () => {
+    stubVisibilityState("hidden");
+
+    renderHook(() => useEventCacheVisibilitySweep());
+
+    // Hidden → visible transition will fire the listener; mount-time doesn't.
+    expect(sweepSpy).not.toHaveBeenCalled();
+  });
+
+  it("sweeps when visibility transitions to visible after being hidden", async () => {
+    stubVisibilityState("hidden");
+    renderHook(() => useEventCacheVisibilitySweep());
+
+    // Simulate the tab coming back: flip the state, dispatch the event.
+    stubVisibilityState("visible");
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    expect(sweepSpy).toHaveBeenCalledOnce();
+  });
+
+  it("does not sweep when visibility transitions to hidden", () => {
+    stubVisibilityState("visible");
+    renderHook(() => useEventCacheVisibilitySweep());
+    // Clear the mount-time call so we can isolate the transition.
+    sweepSpy.mockClear();
+
+    stubVisibilityState("hidden");
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    expect(sweepSpy).not.toHaveBeenCalled();
+  });
+
+  it("removes the listener on unmount", () => {
+    stubVisibilityState("visible");
+    const { unmount } = renderHook(() => useEventCacheVisibilitySweep());
+    sweepSpy.mockClear();
+
+    unmount();
+
+    // After unmount, a visibilitychange event must not fire the sweep.
+    stubVisibilityState("visible");
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(sweepSpy).not.toHaveBeenCalled();
+  });
+
+  it("logs and swallows errors from the sweep — does not crash the host", async () => {
+    sweepSpy.mockRejectedValueOnce(new Error("idb gone"));
+    stubVisibilityState("visible");
+
+    expect(() =>
+      renderHook(() => useEventCacheVisibilitySweep())
+    ).not.toThrow();
+
+    // The error path is async; flush microtasks so the .catch() runs.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(logger.error).toHaveBeenCalled();
+    const [errArg] = vi.mocked(logger.error).mock.calls[0]!;
+    expect((errArg as Error).message).toBe("idb gone");
+  });
+});

--- a/src/hooks/useEventCacheVisibilitySweep.ts
+++ b/src/hooks/useEventCacheVisibilitySweep.ts
@@ -1,0 +1,44 @@
+"use client";
+
+import { eventCache } from "@/lib/event-cache";
+import { logger } from "@/lib/logger";
+import { useEffect } from "react";
+
+/**
+ * Drives the background visibility-change cleanup sweep for the IndexedDB
+ * event cache (#290 sub-task 2). On mount — and again every time the tab
+ * transitions back to `visible` after being hidden — fires a single
+ * `eventCache.sweepExpired()` to evict rows whose TTL has elapsed. The
+ * read-time eviction in `EventCache.getEvents` still handles whatever
+ * surfaces during a fetch; this hook is the cold-cache complement so a
+ * long-idle wall-mounted calendar doesn't accumulate stale entries.
+ *
+ * Errors from the sweep are logged and swallowed — the cache stays
+ * consistent because the read-time path is independent of this sweep.
+ */
+export function useEventCacheVisibilitySweep(): void {
+  useEffect(() => {
+    const runSweep = () => {
+      eventCache.sweepExpired().catch((error: unknown) => {
+        logger.error(error as Error, {
+          context: "useEventCacheVisibilitySweep",
+        });
+      });
+    };
+
+    if (document.visibilityState === "visible") {
+      runSweep();
+    }
+
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        runSweep();
+      }
+    };
+
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () => {
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, []);
+}

--- a/src/lib/__tests__/event-cache.test.ts
+++ b/src/lib/__tests__/event-cache.test.ts
@@ -213,6 +213,25 @@ describe("InMemoryEventStore", () => {
       expect(sweptCount).toBe(1);
       expect(visible.map((e) => e.id)).toEqual(["fresh"]);
     });
+
+    it("co-exists with evictOldest — sweep first leaves fewer rows for evictOldest", async () => {
+      // Spec'd in `.claude/plans/event-cache-visibility-sweep-290.md` (Phase 1
+      // Tests): a row swept for expiry should not also be counted by a later
+      // `evictOldest(N)` call. Catches a future regression that re-adds rows
+      // to the recency index after sweep, or vice versa.
+      const now = 10_000_000;
+      await store.put([makeEvent("stale")], now - EVENT_CACHE_TTL_MS - 1);
+      await store.put([makeEvent("fresh1")], now - 2_000);
+      await store.put([makeEvent("fresh2")], now - 1_000);
+
+      const swept = await store.sweepExpired(now);
+      const evicted = await store.evictOldest(5);
+
+      expect(swept).toBe(1);
+      // Only the two fresh rows remain, so evictOldest can only take 2,
+      // not 3 (which it would if the swept row were still in the store).
+      expect(evicted).toBe(2);
+    });
   });
 });
 

--- a/src/lib/__tests__/event-cache.test.ts
+++ b/src/lib/__tests__/event-cache.test.ts
@@ -153,6 +153,67 @@ describe("InMemoryEventStore", () => {
       expect(await store.evictOldest(5)).toBe(0);
     });
   });
+
+  describe("sweepExpired (#290 — visibility-sweep support)", () => {
+    it("removes only rows whose cachedAt is past the TTL", async () => {
+      const now = 10_000_000;
+      const stale = now - EVENT_CACHE_TTL_MS - 1;
+      const fresh = now - 1_000;
+      await store.put([makeEvent("stale1"), makeEvent("stale2")], stale);
+      await store.put([makeEvent("fresh1")], fresh);
+
+      const evicted = await store.sweepExpired(now);
+
+      expect(evicted).toBe(2);
+      // Confirm the underlying map dropped the stale rows: peek with a `now`
+      // close to their original cachedAt — only fresh1 should remain.
+      const remaining = await store.getAll(stale + 10);
+      expect(remaining.map((e) => e.id)).toEqual(["fresh1"]);
+    });
+
+    it("treats a row whose age is exactly the TTL as expired (matches getAll)", async () => {
+      const now = 10_000_000;
+      // getAll's predicate is `now - cachedAt < TTL`, so a row at exactly
+      // `now - TTL` falls out. sweepExpired must agree to stay idempotent
+      // with read-time eviction.
+      await store.put([makeEvent("edge")], now - EVENT_CACHE_TTL_MS);
+
+      const evicted = await store.sweepExpired(now);
+
+      expect(evicted).toBe(1);
+      expect(await store.getAll(now)).toEqual([]);
+    });
+
+    it("is a no-op (returns 0) when no rows are stale", async () => {
+      const now = 10_000_000;
+      await store.put([makeEvent("a"), makeEvent("b")], now - 1_000);
+
+      expect(await store.sweepExpired(now)).toBe(0);
+
+      const remaining = await store.getAll(now);
+      expect(remaining.map((e) => e.id).sort()).toEqual(["a", "b"]);
+    });
+
+    it("returns 0 when the store is empty", async () => {
+      expect(await store.sweepExpired(10_000_000)).toBe(0);
+    });
+
+    it("is idempotent with a follow-up getAll — no double-eviction", async () => {
+      const now = 10_000_000;
+      const stale = now - EVENT_CACHE_TTL_MS - 1;
+      await store.put([makeEvent("stale")], stale);
+      await store.put([makeEvent("fresh")], now - 1_000);
+
+      const sweptCount = await store.sweepExpired(now);
+      // The stale row is already gone — getAll has nothing more to evict.
+      // Asserting on the returned event ids is the strongest observable
+      // signal we can get without poking the internal map.
+      const visible = await store.getAll(now);
+
+      expect(sweptCount).toBe(1);
+      expect(visible.map((e) => e.id)).toEqual(["fresh"]);
+    });
+  });
 });
 
 describe("EventCache facade", () => {
@@ -209,6 +270,7 @@ describe("EventCache facade", () => {
       getAll: vi.fn(async () => []),
       clear: vi.fn(async () => {}),
       evictOldest: vi.fn(async () => 0),
+      sweepExpired: vi.fn(async () => 0),
     };
     const flakyCache = new EventCache(flaky);
 
@@ -244,6 +306,7 @@ describe("EventCache facade", () => {
           }
           return count;
         }),
+        sweepExpired: vi.fn(async () => 0),
       };
 
       const c = new EventCache(store);
@@ -269,6 +332,7 @@ describe("EventCache facade", () => {
         getAll: vi.fn(async () => []),
         clear: vi.fn(async () => {}),
         evictOldest: vi.fn(async (count: number) => count),
+        sweepExpired: vi.fn(async () => 0),
       };
 
       const c = new EventCache(store);
@@ -295,6 +359,7 @@ describe("EventCache facade", () => {
         getAll: vi.fn(async () => []),
         clear: vi.fn(async () => {}),
         evictOldest: vi.fn(async (count: number) => count),
+        sweepExpired: vi.fn(async () => 0),
       };
 
       const c = new EventCache(store);
@@ -323,6 +388,7 @@ describe("EventCache facade", () => {
         getAll: vi.fn(async () => []),
         clear: vi.fn(async () => {}),
         evictOldest: vi.fn(async () => 0),
+        sweepExpired: vi.fn(async () => 0),
       };
 
       const c = new EventCache(store);
@@ -356,6 +422,7 @@ describe("EventCache facade", () => {
         getAll: vi.fn(async () => []),
         clear: vi.fn(async () => {}),
         evictOldest: vi.fn(async (count: number) => count),
+        sweepExpired: vi.fn(async () => 0),
       };
 
       const c = new EventCache(store);
@@ -378,6 +445,7 @@ describe("EventCache facade", () => {
         getAll: vi.fn(async () => []),
         clear: vi.fn(async () => {}),
         evictOldest: vi.fn(async () => 0),
+        sweepExpired: vi.fn(async () => 0),
       };
 
       const c = new EventCache(store);
@@ -385,6 +453,92 @@ describe("EventCache facade", () => {
 
       // Goes straight to the in-memory fallback path; no eviction attempted.
       expect(store.evictOldest).not.toHaveBeenCalled();
+      expect((c as unknown as { hasFallenBack: boolean }).hasFallenBack).toBe(
+        true
+      );
+    });
+  });
+
+  describe("visibility sweep (#290 sub-task 2)", () => {
+    beforeEach(() => {
+      vi.mocked(logger.event).mockClear();
+    });
+
+    it("delegates sweepExpired to the active store with the current time", async () => {
+      const sweepSpy = vi.spyOn(store, "sweepExpired");
+      await cache.sweepExpired();
+
+      expect(sweepSpy).toHaveBeenCalledOnce();
+      const [now] = sweepSpy.mock.calls[0]!;
+      expect(now).toBeTypeOf("number");
+      expect(now).toBeGreaterThan(0);
+    });
+
+    it("returns the count of rows the store actually evicted", async () => {
+      const swept: EventStore = {
+        put: vi.fn(async () => {}),
+        getAll: vi.fn(async () => []),
+        clear: vi.fn(async () => {}),
+        evictOldest: vi.fn(async () => 0),
+        sweepExpired: vi.fn(async () => 7),
+      };
+      const c = new EventCache(swept);
+      expect(await c.sweepExpired()).toBe(7);
+    });
+
+    it("emits a structured logger.event when rows were swept", async () => {
+      const swept: EventStore = {
+        put: vi.fn(async () => {}),
+        getAll: vi.fn(async () => []),
+        clear: vi.fn(async () => {}),
+        evictOldest: vi.fn(async () => 0),
+        sweepExpired: vi.fn(async () => 3),
+      };
+      const c = new EventCache(swept);
+      await c.sweepExpired();
+
+      // Pin the measurements bucket to the third positional arg, the way
+      // sub-task 1's `event-cache.lru-evicted` does. A future refactor that
+      // swaps properties and measurements around will fail this test.
+      expect(logger.event).toHaveBeenCalledWith(
+        "event-cache.visibility-swept",
+        { context: "EventCache.sweepExpired" },
+        { evicted: 3 }
+      );
+    });
+
+    it("does NOT emit logger.event when zero rows were swept", async () => {
+      // A zero-row sweep on every visibility transition would be unmissable
+      // noise on a wall-mounted calendar (which goes hidden/visible many
+      // times a day). The contract is: log only when there is signal.
+      const swept: EventStore = {
+        put: vi.fn(async () => {}),
+        getAll: vi.fn(async () => []),
+        clear: vi.fn(async () => {}),
+        evictOldest: vi.fn(async () => 0),
+        sweepExpired: vi.fn(async () => 0),
+      };
+      const c = new EventCache(swept);
+      await c.sweepExpired();
+
+      expect(logger.event).not.toHaveBeenCalled();
+    });
+
+    it("falls back to the in-memory store when the active store rejects", async () => {
+      const flaky: EventStore = {
+        put: vi.fn(async () => {}),
+        getAll: vi.fn(async () => []),
+        clear: vi.fn(async () => {}),
+        evictOldest: vi.fn(async () => 0),
+        sweepExpired: vi.fn(async () => {
+          throw new Error("idb dead");
+        }),
+      };
+      const c = new EventCache(flaky);
+      // The InMemoryEventStore the facade swaps in has nothing to sweep, so
+      // the resolved count is 0 — the assertion that matters is that the
+      // call did not surface the error.
+      await expect(c.sweepExpired()).resolves.toBe(0);
       expect((c as unknown as { hasFallenBack: boolean }).hasFallenBack).toBe(
         true
       );
@@ -399,6 +553,7 @@ describe("EventCache facade", () => {
       getAll: vi.fn(),
       clear: vi.fn(),
       evictOldest: vi.fn(async () => 0),
+      sweepExpired: vi.fn(async () => 0),
     };
     const deadCache = new EventCache(new InMemoryEventStore());
     // Force the cache into a state where the active store is the failing one.

--- a/src/lib/event-cache.ts
+++ b/src/lib/event-cache.ts
@@ -398,6 +398,12 @@ export class EventCache {
    */
   async sweepExpired(): Promise<number> {
     return this.withFallback(async (store) => {
+      // `Date.now()` is sampled inside the callback so a `withFallback` retry
+      // on the in-memory store uses a fresh `now`. Unlike `putWithLruRetry`'s
+      // re-sample (where the new timestamp ends up persisted as the row's
+      // recency stamp), this one only affects which rows are considered
+      // expired — and a slightly later `now` can only ever sweep at least
+      // as many rows, never fewer, so the asymmetry is harmless.
       const evicted = await store.sweepExpired(Date.now());
       if (evicted > 0) {
         logger.event(

--- a/src/lib/event-cache.ts
+++ b/src/lib/event-cache.ts
@@ -45,6 +45,14 @@ export interface EventStore {
    * Used by `EventCache` to recover from `QuotaExceededError` (#290).
    */
   evictOldest(count: number): Promise<number>;
+  /**
+   * Remove every row whose age (`now - cachedAt`) is at least
+   * `EVENT_CACHE_TTL_MS`. Resolves with the count of rows removed.
+   * Used by `EventCache` for the visibility-change cleanup sweep
+   * (#290 sub-task 2). Idempotent with the same expiry filter applied
+   * in `getAll`.
+   */
+  sweepExpired(now: number): Promise<number>;
 }
 
 /**
@@ -97,6 +105,19 @@ export class InMemoryEventStore implements EventStore {
       this.rows.delete(id);
     }
     return toEvict.length;
+  }
+
+  async sweepExpired(now: number): Promise<number> {
+    let evicted = 0;
+    // Predicate mirrors `getAll`'s expiry check (`now - cachedAt < TTL` keeps
+    // fresh) so a row at exactly the TTL boundary expires under both paths.
+    for (const [id, row] of this.rows) {
+      if (now - row.cachedAt >= EVENT_CACHE_TTL_MS) {
+        this.rows.delete(id);
+        evicted += 1;
+      }
+    }
+    return evicted;
   }
 }
 
@@ -240,6 +261,40 @@ export class IndexedDBEventStore implements EventStore {
       transaction.onerror = () => reject(transaction.error);
     });
   }
+
+  async sweepExpired(now: number): Promise<number> {
+    await this.init();
+    if (!this.db) {
+      throw new Error("Database not initialized");
+    }
+    return new Promise((resolve, reject) => {
+      const transaction = this.db!.transaction([STORE_NAME], "readwrite");
+      const objectStore = transaction.objectStore(STORE_NAME);
+      const index = objectStore.index("cachedAt");
+      // Ascending cursor over `cachedAt`: we can stop as soon as we see a
+      // row that's still fresh, because the index is sorted by `cachedAt`
+      // and every subsequent row has a larger (= more recent) timestamp.
+      const cursorRequest = index.openCursor(null, "next");
+      let evicted = 0;
+      cursorRequest.onsuccess = () => {
+        const cursor = cursorRequest.result;
+        if (!cursor) return;
+        const row = cursor.value as CachedEventRow;
+        if (now - row.cachedAt < EVENT_CACHE_TTL_MS) {
+          // Cutoff reached — every later row in the cursor is also fresh.
+          return;
+        }
+        cursor.delete();
+        evicted += 1;
+        cursor.continue();
+      };
+      cursorRequest.onerror = () => reject(cursorRequest.error);
+      // Resolution deferred to transaction.oncomplete so the count reflects
+      // committed deletes — same pattern as `evictOldest` above.
+      transaction.oncomplete = () => resolve(evicted);
+      transaction.onerror = () => reject(transaction.error);
+    });
+  }
 }
 
 /**
@@ -327,6 +382,32 @@ export class EventCache {
       async (store) => store.getAll(Date.now()),
       "EventCache.getEvents"
     );
+  }
+
+  /**
+   * Proactively evict expired rows from the active store and resolve with
+   * the count removed. Intended for the visibility-change cleanup sweep
+   * (#290 sub-task 2): on a cold cache where no read has occurred since
+   * rows went stale, read-time eviction (`getAll`) cannot reclaim that
+   * space until the next refresh. Idempotent with the same expiry rule
+   * applied in `getAll`, so it is safe to interleave with reads.
+   *
+   * Emits a structured `logger.event` only when rows were actually
+   * evicted — a zero-row sweep happens on every visibility transition
+   * for a tab with no stale rows and is uninteresting noise.
+   */
+  async sweepExpired(): Promise<number> {
+    return this.withFallback(async (store) => {
+      const evicted = await store.sweepExpired(Date.now());
+      if (evicted > 0) {
+        logger.event(
+          "event-cache.visibility-swept",
+          { context: "EventCache.sweepExpired" },
+          { evicted }
+        );
+      }
+      return evicted;
+    }, "EventCache.sweepExpired");
   }
 
   private async withFallback<T>(


### PR DESCRIPTION
## Summary

- Adds `EventStore.sweepExpired(now)` on both `InMemoryEventStore` (iteration + delete-by-id) and `IndexedDBEventStore` (ascending cursor on the `cachedAt` index, short-circuiting at the first still-fresh row). Expiry predicate matches `getAll`'s side-effect eviction so the two paths stay idempotent.
- Exposes `EventCache.sweepExpired()` on the facade via `withFallback`, emitting `logger.event("event-cache.visibility-swept", …)` only when rows were actually evicted — a zero-row sweep happens on every visibility transition for a clean tab and would be unmissable noise on the wall-mounted use case.
- New `useEventCacheVisibilitySweep` hook installs a `visibilitychange` listener; sweeps on mount if `visibilityState === 'visible'` (cold-load case) and again on every transition back to `visible`. Wired into `CalendarProvider`.

## Plan

Linked plan: `.claude/plans/event-cache-visibility-sweep-290.md`
Project: https://github.com/users/BenSeymourODB/projects/1

This is **sub-task 2 of #290**. Sub-task 1 shipped in PR #377; sub-task 3 (TTL wired to user settings) stays deferred — that one wants the `useUserSettings.mutate` bus pattern (PR #344) exercised by another consumer first.

## Test plan

- [x] Unit: `InMemoryEventStore.sweepExpired` removes only stale rows, returns the count, no-ops when nothing is stale, edge case at exactly `now - TTL` matches `getAll`'s predicate, idempotent with a follow-up `getAll`
- [x] Unit: `EventCache.sweepExpired` delegates with `Date.now()`, returns the count, emits the structured event only when `evicted > 0`, falls back to in-memory on store failure
- [x] Hook: sweeps on mount when visible, doesn't on mount when hidden, sweeps on hidden→visible transition, no-op on visible→hidden, listener removed on unmount, errors are caught + logged not thrown
- [x] Full suite green: 2346 tests, 147 files (+16 vs main baseline)
- [x] `pnpm lint:fix && pnpm format:fix && pnpm check-types` clean

Closes part of #290 (sub-task 2 only — issue stays open for sub-task 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UsiH7iRa7JXisXUEdnkGHU)_