### PR TITLE
chore(tasks): in-flight guard for TaskItem.handleToggle (#384)

### DIFF
--- a/src/components/tasks/__tests__/task-item.test.tsx
+++ b/src/components/tasks/__tests__/task-item.test.tsx
@@ -2,13 +2,7 @@
  * Tests for TaskItem component
  */
 import { type ReactNode } from "react";
-import {
-  act,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { PointsProvider } from "../../rewards/points-context";
@@ -569,7 +563,8 @@ describe("TaskItem", () => {
               showPointsOnCompletion: true,
             }),
         })
-        // POST /api/points/award (should fire exactly once)
+        // POST /api/points/award — should fire exactly once even though
+        // both clicks reach the checkbox.
         .mockResolvedValueOnce({
           ok: true,
           json: () =>
@@ -587,6 +582,7 @@ describe("TaskItem", () => {
         releaseToggle = resolve;
       });
       const onToggle = vi.fn().mockReturnValue(togglePromise);
+      const user = userEvent.setup();
 
       render(
         <TaskItem
@@ -603,52 +599,34 @@ describe("TaskItem", () => {
 
       const checkbox = screen.getByRole("checkbox");
 
-      // Two rapid synchronous clicks. The guard must drop the second one.
-      fireEvent.click(checkbox);
-      fireEvent.click(checkbox);
+      // Two concurrent clicks driven through userEvent's full pointer-event
+      // pipeline — avoids the jsdom/Radix edge case where a bare
+      // `fireEvent.click` might not route through `onCheckedChange`.
+      // The second click must early-return because the first set
+      // `inFlight.current = true` before its first `await`.
+      const clicks = Promise.all([user.click(checkbox), user.click(checkbox)]);
 
-      // The first click captured the in-flight slot; the second early-returns.
-      expect(onToggle).toHaveBeenCalledTimes(1);
-
-      // Release the in-flight toggle so the award path can run.
-      releaseToggle();
-
-      // Only one POST to /api/points/award should ever land.
+      // Yield until both pointer-event sequences have fired their click
+      // handlers. They cannot fully resolve yet because the first
+      // handleToggle is still awaiting our held `togglePromise`.
       await waitFor(() => {
-        const awardCalls = mockFetch.mock.calls.filter(
-          ([url]) =>
-            typeof url === "string" && url.includes("/api/points/award")
-        );
-        expect(awardCalls).toHaveLength(1);
+        expect(onToggle).toHaveBeenCalledTimes(1);
       });
 
-      expect(onToggle).toHaveBeenCalledTimes(1);
+      // Release the in-flight toggle and let both user.click() promises resolve.
+      releaseToggle();
+      await clicks;
+
+      // Only one POST to /api/points/award should ever land.
+      const awardCalls = mockFetch.mock.calls.filter(
+        ([url]) => typeof url === "string" && url.includes("/api/points/award")
+      );
+      expect(awardCalls).toHaveLength(1);
     });
 
     it("releases the in-flight guard between sequential clicks", async () => {
-      mockFetch
-        // GET /api/points (provider mount)
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () =>
-            Promise.resolve({
-              totalPoints: 50,
-              enabled: true,
-              defaultTaskPoints: 10,
-              showPointsOnCompletion: true,
-            }),
-        })
-        // POST /api/points/award — first click (incomplete → complete)
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () =>
-            Promise.resolve({
-              success: true,
-              newTotal: 60,
-              alreadyAwarded: false,
-            }),
-        });
-
+      // No PointsProvider — this test is purely about the guard's `finally`
+      // releasing between clicks, not about the award path.
       const onToggle = vi.fn().mockResolvedValue(undefined);
       const user = userEvent.setup();
 
@@ -656,17 +634,11 @@ describe("TaskItem", () => {
         <TaskItem
           task={createTask({ status: "needsAction" })}
           onToggle={onToggle}
-        />,
-        { wrapper: withPointsProvider("profile-1") }
+        />
       );
-
-      await waitFor(() => {
-        expect(mockFetch).toHaveBeenCalledTimes(1);
-      });
 
       const checkbox = screen.getByRole("checkbox");
 
-      // First click — completes the full handleToggle (toggle + award).
       await user.click(checkbox);
       await waitFor(() => {
         expect(onToggle).toHaveBeenCalledTimes(1);

--- a/src/components/tasks/__tests__/task-item.test.tsx
+++ b/src/components/tasks/__tests__/task-item.test.tsx
@@ -2,7 +2,13 @@
  * Tests for TaskItem component
  */
 import { type ReactNode } from "react";
-import { act, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { PointsProvider } from "../../rewards/points-context";
@@ -548,6 +554,129 @@ describe("TaskItem", () => {
       });
 
       expect(onToggle).toHaveBeenCalledTimes(1);
+    });
+
+    it("guards against double-click: handleToggle is single-flight", async () => {
+      mockFetch
+        // GET /api/points (provider mount)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              totalPoints: 50,
+              enabled: true,
+              defaultTaskPoints: 10,
+              showPointsOnCompletion: true,
+            }),
+        })
+        // POST /api/points/award (should fire exactly once)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              success: true,
+              newTotal: 60,
+              alreadyAwarded: false,
+            }),
+        });
+
+      // Hold the first onToggle pending so the second click arrives while
+      // the first handleToggle invocation is still in flight.
+      let releaseToggle: () => void = () => {};
+      const togglePromise = new Promise<void>((resolve) => {
+        releaseToggle = resolve;
+      });
+      const onToggle = vi.fn().mockReturnValue(togglePromise);
+
+      render(
+        <TaskItem
+          task={createTask({ status: "needsAction" })}
+          onToggle={onToggle}
+        />,
+        { wrapper: withPointsProvider("profile-1") }
+      );
+
+      // Wait for the points provider to settle so awardPoints is reachable.
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+      });
+
+      const checkbox = screen.getByRole("checkbox");
+
+      // Two rapid synchronous clicks. The guard must drop the second one.
+      fireEvent.click(checkbox);
+      fireEvent.click(checkbox);
+
+      // The first click captured the in-flight slot; the second early-returns.
+      expect(onToggle).toHaveBeenCalledTimes(1);
+
+      // Release the in-flight toggle so the award path can run.
+      releaseToggle();
+
+      // Only one POST to /api/points/award should ever land.
+      await waitFor(() => {
+        const awardCalls = mockFetch.mock.calls.filter(
+          ([url]) =>
+            typeof url === "string" && url.includes("/api/points/award")
+        );
+        expect(awardCalls).toHaveLength(1);
+      });
+
+      expect(onToggle).toHaveBeenCalledTimes(1);
+    });
+
+    it("releases the in-flight guard between sequential clicks", async () => {
+      mockFetch
+        // GET /api/points (provider mount)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              totalPoints: 50,
+              enabled: true,
+              defaultTaskPoints: 10,
+              showPointsOnCompletion: true,
+            }),
+        })
+        // POST /api/points/award — first click (incomplete → complete)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              success: true,
+              newTotal: 60,
+              alreadyAwarded: false,
+            }),
+        });
+
+      const onToggle = vi.fn().mockResolvedValue(undefined);
+      const user = userEvent.setup();
+
+      render(
+        <TaskItem
+          task={createTask({ status: "needsAction" })}
+          onToggle={onToggle}
+        />,
+        { wrapper: withPointsProvider("profile-1") }
+      );
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+      });
+
+      const checkbox = screen.getByRole("checkbox");
+
+      // First click — completes the full handleToggle (toggle + award).
+      await user.click(checkbox);
+      await waitFor(() => {
+        expect(onToggle).toHaveBeenCalledTimes(1);
+      });
+
+      // Second click after the first has settled — guard must have released.
+      await user.click(checkbox);
+      await waitFor(() => {
+        expect(onToggle).toHaveBeenCalledTimes(2);
+      });
     });
   });
 });

--- a/src/components/tasks/task-item.tsx
+++ b/src/components/tasks/task-item.tsx
@@ -23,7 +23,7 @@ import { usePointsOptional } from "@/components/rewards/points-context";
 import { Checkbox } from "@/components/ui/checkbox";
 import { logger } from "@/lib/logger";
 import { cn } from "@/lib/utils";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { type TaskWithMeta, formatDueDate } from "./types";
 
 export interface TaskItemProps {
@@ -42,38 +42,52 @@ export function TaskItem({ task, onToggle, disabled = false }: TaskItemProps) {
 
   const [animationPoints, setAnimationPoints] = useState<number | null>(null);
 
+  // Client-side double-click guard. The server's unique
+  // `(profileId, taskId, reason)` index already prevents double-credit, but
+  // dropping the second invocation here avoids a wasted round-trip and
+  // optimistic-UI flicker. Cleared in `finally` so an error path cannot
+  // permanently lock the item.
+  const inFlight = useRef(false);
+
   const handleToggle = async () => {
-    // Captured before the async toggle: React may re-render TaskItem
-    // with the updated task.status before this closure resumes, so we
-    // can't rely on `isCompleted` after the await to know the direction.
-    const wasCompleted = isCompleted;
-
-    // Always run the parent's toggle first — that's the source of truth
-    // for the task's status. Whatever happens with rewards is layered on
-    // top and must never replace the underlying toggle behaviour.
-    await Promise.resolve(onToggle());
-
-    // Award points only on the incomplete → complete transition.
-    if (wasCompleted) return;
-    if (!points || !points.isEnabled) return;
+    if (inFlight.current) return;
+    inFlight.current = true;
 
     try {
-      const result = await points.awardPoints(
-        points.defaultTaskPoints,
-        "task_completed",
-        { taskId: task.id, taskTitle: task.title }
-      );
+      // Captured before the async toggle: React may re-render TaskItem
+      // with the updated task.status before this closure resumes, so we
+      // can't rely on `isCompleted` after the await to know the direction.
+      const wasCompleted = isCompleted;
 
-      // alreadyAwarded means the server's unique index fired — re-completing
-      // the same task does not re-credit, so we suppress the animation too.
-      if (!result.alreadyAwarded && points.showPointsOnCompletion) {
-        setAnimationPoints(points.defaultTaskPoints);
+      // Always run the parent's toggle first — that's the source of truth
+      // for the task's status. Whatever happens with rewards is layered on
+      // top and must never replace the underlying toggle behaviour.
+      await Promise.resolve(onToggle());
+
+      // Award points only on the incomplete → complete transition.
+      if (wasCompleted) return;
+      if (!points || !points.isEnabled) return;
+
+      try {
+        const result = await points.awardPoints(
+          points.defaultTaskPoints,
+          "task_completed",
+          { taskId: task.id, taskTitle: task.title }
+        );
+
+        // alreadyAwarded means the server's unique index fired — re-completing
+        // the same task does not re-credit, so we suppress the animation too.
+        if (!result.alreadyAwarded && points.showPointsOnCompletion) {
+          setAnimationPoints(points.defaultTaskPoints);
+        }
+      } catch (error) {
+        logger.error(error as Error, {
+          context: "TaskAwardPointsFailed",
+          taskId: task.id,
+        });
       }
-    } catch (error) {
-      logger.error(error as Error, {
-        context: "TaskAwardPointsFailed",
-        taskId: task.id,
-      });
+    } finally {
+      inFlight.current = false;
     }
   };
 

--- a/src/components/tasks/task-item.tsx
+++ b/src/components/tasks/task-item.tsx
@@ -45,8 +45,7 @@ export function TaskItem({ task, onToggle, disabled = false }: TaskItemProps) {
   // Client-side double-click guard. The server's unique
   // `(profileId, taskId, reason)` index already prevents double-credit, but
   // dropping the second invocation here avoids a wasted round-trip and
-  // optimistic-UI flicker. Cleared in `finally` so an error path cannot
-  // permanently lock the item.
+  // optimistic-UI flicker.
   const inFlight = useRef(false);
 
   const handleToggle = async () => {


### PR DESCRIPTION
## Summary

- Adds a `useRef(false)` in-flight guard to `TaskItem.handleToggle` so a rapid second click while the first is still pending early-returns instead of firing a second `onToggle` + `awardPoints`.
- The guard is cleared in a `finally` block — an error in either the toggle or the award path can never permanently lock the item.
- Two new component tests pin the behaviour: a held-pending double-click verifies single-flight; sequential clicks verify the guard releases between calls.

## Plan

No standalone plan file — the issue body (#384) contains the full spec and acceptance criteria, including the exact `useRef` + try/finally shape.

Project: https://github.com/users/BenSeymourODB/projects/1

## Why this is worth doing even though the server-side index exists

The unique `(profileId, taskId, reason)` index already prevents the double-credit (the second `POST /api/points/award` returns `alreadyAwarded: true` and the existing test asserts the animation is suppressed). This change is purely additive client-side defense:

- One avoided network round-trip per double-click.
- No small window where two competing optimistic-UI states could flicker.
- The component's contract is now explicit — it no longer relies on an invariant that lives in `/api/points/award`.

## Acceptance criteria

- [x] `handleToggle` early-returns while a prior invocation is in flight
- [x] The guard is cleared in a `finally` so an error path doesn't permanently lock the item
- [x] New test: simulated double-click → `onToggle` and `awardPoints` each called exactly once
- [x] All existing TaskItem tests still pass

## Test plan

- [x] `pnpm vitest run src/components/tasks/__tests__/task-item.test.tsx` — 27/27 (was 25; +2 new)
- [x] `pnpm test:run` — 2476/2476 across 153 files
- [x] `pnpm lint:fix` — clean (6 pre-existing warnings on unrelated files)
- [x] `pnpm format:fix` — clean
- [x] `pnpm check-types` — clean

Closes #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QrgTcP41xCyzFz8X3uiumB)_