### PR TITLE
fix(rewards): reset all fetched fields on GET /api/points failure (#385)

### DIFF
--- a/src/components/rewards/__tests__/points-context.test.tsx
+++ b/src/components/rewards/__tests__/points-context.test.tsx
@@ -111,6 +111,174 @@ describe("usePoints", () => {
     expect(result.current.totalPoints).toBe(0);
   });
 
+  it("resets all fetched fields to defaults when refreshPoints non-OK response follows a successful fetch", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            totalPoints: 50,
+            enabled: true,
+            defaultTaskPoints: 25,
+            showPointsOnCompletion: false,
+          }),
+      })
+      .mockResolvedValueOnce({ ok: false, status: 500 });
+
+    const { result } = renderHook(() => usePoints(), {
+      wrapper: makeWrapper("profile-1"),
+    });
+
+    await waitFor(() => {
+      expect(result.current.totalPoints).toBe(50);
+      expect(result.current.isEnabled).toBe(true);
+      expect(result.current.defaultTaskPoints).toBe(25);
+      expect(result.current.showPointsOnCompletion).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.refreshPoints();
+    });
+
+    expect(result.current.totalPoints).toBe(0);
+    expect(result.current.isEnabled).toBe(false);
+    expect(result.current.defaultTaskPoints).toBe(10);
+    expect(result.current.showPointsOnCompletion).toBe(true);
+  });
+
+  it("resets all fetched fields to defaults when refreshPoints throws after a successful fetch", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            totalPoints: 50,
+            enabled: true,
+            defaultTaskPoints: 25,
+            showPointsOnCompletion: false,
+          }),
+      })
+      .mockRejectedValueOnce(new Error("network down"));
+
+    const { result } = renderHook(() => usePoints(), {
+      wrapper: makeWrapper("profile-1"),
+    });
+
+    await waitFor(() => {
+      expect(result.current.defaultTaskPoints).toBe(25);
+      expect(result.current.showPointsOnCompletion).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.refreshPoints();
+    });
+
+    expect(result.current.totalPoints).toBe(0);
+    expect(result.current.isEnabled).toBe(false);
+    expect(result.current.defaultTaskPoints).toBe(10);
+    expect(result.current.showPointsOnCompletion).toBe(true);
+  });
+
+  it("resets all fetched fields to defaults when a profile-switch GET returns non-OK", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            totalPoints: 50,
+            enabled: true,
+            defaultTaskPoints: 25,
+            showPointsOnCompletion: false,
+          }),
+      })
+      .mockResolvedValueOnce({ ok: false, status: 500 });
+
+    function Probe() {
+      const { defaultTaskPoints, showPointsOnCompletion, totalPoints } =
+        usePoints();
+      return (
+        <div>
+          <div data-testid="total">{totalPoints}</div>
+          <div data-testid="dtp">{defaultTaskPoints}</div>
+          <div data-testid="spoc">{String(showPointsOnCompletion)}</div>
+        </div>
+      );
+    }
+
+    const { rerender, getByTestId } = render(
+      <PointsProvider profileId="profile-1">
+        <Probe />
+      </PointsProvider>
+    );
+
+    await waitFor(() => {
+      expect(getByTestId("dtp").textContent).toBe("25");
+      expect(getByTestId("spoc").textContent).toBe("false");
+    });
+
+    rerender(
+      <PointsProvider profileId="profile-2">
+        <Probe />
+      </PointsProvider>
+    );
+
+    await waitFor(() => {
+      expect(getByTestId("total").textContent).toBe("0");
+      expect(getByTestId("dtp").textContent).toBe("10");
+      expect(getByTestId("spoc").textContent).toBe("true");
+    });
+  });
+
+  it("resets all fetched fields to defaults when a profile-switch GET throws", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            totalPoints: 50,
+            enabled: true,
+            defaultTaskPoints: 25,
+            showPointsOnCompletion: false,
+          }),
+      })
+      .mockRejectedValueOnce(new Error("network down"));
+
+    function Probe() {
+      const { defaultTaskPoints, showPointsOnCompletion, totalPoints } =
+        usePoints();
+      return (
+        <div>
+          <div data-testid="total">{totalPoints}</div>
+          <div data-testid="dtp">{defaultTaskPoints}</div>
+          <div data-testid="spoc">{String(showPointsOnCompletion)}</div>
+        </div>
+      );
+    }
+
+    const { rerender, getByTestId } = render(
+      <PointsProvider profileId="profile-1">
+        <Probe />
+      </PointsProvider>
+    );
+
+    await waitFor(() => {
+      expect(getByTestId("dtp").textContent).toBe("25");
+      expect(getByTestId("spoc").textContent).toBe("false");
+    });
+
+    rerender(
+      <PointsProvider profileId="profile-2">
+        <Probe />
+      </PointsProvider>
+    );
+
+    await waitFor(() => {
+      expect(getByTestId("total").textContent).toBe("0");
+      expect(getByTestId("dtp").textContent).toBe("10");
+      expect(getByTestId("spoc").textContent).toBe("true");
+    });
+  });
+
   it("awardPoints POSTs the payload and updates totalPoints from the response", async () => {
     mockFetch
       .mockResolvedValueOnce({

--- a/src/components/rewards/points-context.tsx
+++ b/src/components/rewards/points-context.tsx
@@ -97,6 +97,12 @@ export function PointsProvider({ profileId, children }: PointsProviderProps) {
       return;
     }
     const controller = new AbortController();
+    const resetToDefaults = () => {
+      setFetchedTotal(0);
+      setFetchedEnabled(false);
+      setFetchedDefaultTaskPoints(DEFAULT_TASK_POINTS);
+      setFetchedShowPointsOnCompletion(DEFAULT_SHOW_POINTS_ON_COMPLETION);
+    };
     const run = async () => {
       try {
         const response = await fetch(
@@ -105,8 +111,7 @@ export function PointsProvider({ profileId, children }: PointsProviderProps) {
         );
         if (controller.signal.aborted) return;
         if (!response.ok) {
-          setFetchedTotal(0);
-          setFetchedEnabled(false);
+          resetToDefaults();
           return;
         }
         const data = (await response.json()) as PointsApiResponse;
@@ -122,8 +127,7 @@ export function PointsProvider({ profileId, children }: PointsProviderProps) {
       } catch (error) {
         if ((error as Error).name === "AbortError") return;
         logger.error(error as Error, { context: "FetchPointsFailed" });
-        setFetchedTotal(0);
-        setFetchedEnabled(false);
+        resetToDefaults();
       }
     };
     run();
@@ -137,14 +141,19 @@ export function PointsProvider({ profileId, children }: PointsProviderProps) {
     if (!profileId) {
       return;
     }
+    const resetToDefaults = () => {
+      setFetchedTotal(0);
+      setFetchedEnabled(false);
+      setFetchedDefaultTaskPoints(DEFAULT_TASK_POINTS);
+      setFetchedShowPointsOnCompletion(DEFAULT_SHOW_POINTS_ON_COMPLETION);
+    };
     try {
       const response = await fetch(
         `/api/points?profileId=${encodeURIComponent(profileId)}`
       );
       if (activeProfileIdRef.current !== profileId) return;
       if (!response.ok) {
-        setFetchedTotal(0);
-        setFetchedEnabled(false);
+        resetToDefaults();
         return;
       }
       const data = (await response.json()) as PointsApiResponse;
@@ -160,8 +169,7 @@ export function PointsProvider({ profileId, children }: PointsProviderProps) {
     } catch (error) {
       logger.error(error as Error, { context: "FetchPointsFailed" });
       if (activeProfileIdRef.current !== profileId) return;
-      setFetchedTotal(0);
-      setFetchedEnabled(false);
+      resetToDefaults();
     }
   };
 


### PR DESCRIPTION
## Summary

- Both GET error paths in `PointsContext` (initial fetch `useEffect` and `refreshPoints`, with non-OK and network-throw branches each) now reset all four fetched fields (`totalPoints`, `enabled`, `defaultTaskPoints`, `showPointsOnCompletion`) instead of only the first two — so a transient 500 mid-session can't leave stale per-user reward values exposed while `isEnabled === false`.
- Each handler defines a local `resetToDefaults()` to keep the four resets in lockstep across both error branches.

## Plan

No standalone plan file — this is a small, scoped follow-up filed from a PR-review finding on #326.
Project: https://github.com/users/BenSeymourODB/projects/1

## Test plan

- [x] New unit test: failing `refreshPoints` (non-OK) after a successful fetch with custom `defaultTaskPoints`/`showPointsOnCompletion` resets all four fields to defaults
- [x] New unit test: throwing `refreshPoints` after a successful fetch resets all four fields to defaults
- [x] New unit test: profile-switch (`useEffect` rerun) whose GET returns non-OK resets all four fields
- [x] New unit test: profile-switch whose GET throws resets all four fields
- [x] Existing PointsContext tests still pass (18/18 in this file)
- [x] Full suite: `pnpm test` — 2478/2478 green
- [x] `pnpm lint:fix && pnpm format:fix && pnpm check-types` — clean

Closes #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ks1qJKpvvPAUvbTQQdtU6C)_