### PR TITLE
refactor(calendar): require weekStartsOn on all helpers (#352)

### DIFF
--- a/src/components/calendar/__tests__/SimpleCalendar.test.tsx
+++ b/src/components/calendar/__tests__/SimpleCalendar.test.tsx
@@ -2,7 +2,7 @@ import {
   CalendarContext,
   type ICalendarContext,
 } from "@/components/providers/CalendarProvider";
-import { getShortWeekdayLabels } from "@/lib/calendar-helpers";
+import { WEEK_STARTS_ON, getShortWeekdayLabels } from "@/lib/calendar-helpers";
 import { makeCalendarContext } from "@/test/fixtures/calendar-context";
 import { createMockEvent } from "@/test/fixtures/calendar-event";
 import type { IEvent } from "@/types/calendar";
@@ -228,7 +228,7 @@ describe("SimpleCalendar", () => {
   describe("Weekday headers", () => {
     it("renders weekday headers in WEEK_STARTS_ON order", () => {
       renderWithContext();
-      const labels = getShortWeekdayLabels();
+      const labels = getShortWeekdayLabels(WEEK_STARTS_ON);
       const rendered = labels.map((label) => screen.getByText(label));
       // Each label should appear, in document order matching the array.
       rendered.forEach((el, i) => {
@@ -337,7 +337,7 @@ describe("SimpleCalendar", () => {
       renderWithContext();
       const headers = screen.getAllByRole("columnheader");
       expect(headers).toHaveLength(7);
-      const labels = getShortWeekdayLabels();
+      const labels = getShortWeekdayLabels(WEEK_STARTS_ON);
       headers.forEach((header, i) => {
         expect(header).toHaveTextContent(labels[i]);
       });

--- a/src/components/calendar/__tests__/WeekCalendar.test.tsx
+++ b/src/components/calendar/__tests__/WeekCalendar.test.tsx
@@ -15,7 +15,7 @@ import {
   startOfWeek,
   subWeeks,
 } from "date-fns";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { WeekCalendar } from "../WeekCalendar";
 
 /**
@@ -159,6 +159,43 @@ describe("WeekCalendar", () => {
     });
   });
 
+  describe("current-week predicate respects weekStartDay", () => {
+    // Regression: #352. WeekCalendar.isCurrentWeek must use the user's
+    // weekStartDay so the Today button toggles enabled/disabled on the
+    // Sun→Mon (or Sat→Sun) boundary, not on a hard-coded WEEK_STARTS_ON.
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("disables Today when today and selectedDate share a Monday-first week but not a Sunday-first one", () => {
+      // Today = Sun Apr 19 2026, selectedDate = Fri Apr 17 2026.
+      // - Sunday-first: today ∈ [Sun Apr 19 – Sat Apr 25]; selectedDate ∈ [Sun Apr 12 – Sat Apr 18] → different weeks.
+      // - Monday-first: today ∈ [Mon Apr 13 – Sun Apr 19]; selectedDate ∈ same week → same week.
+      vi.setSystemTime(new Date(2026, 3, 19, 12, 0, 0));
+      const selectedDate = new Date(2026, 3, 17, 12, 0, 0);
+
+      renderWithContext({ selectedDate, weekStartDay: 1 });
+
+      expect(screen.getByTestId("week-calendar-today-btn")).toBeDisabled();
+    });
+
+    it("enables Today when today and selectedDate share a Sunday-first week but fall in different Monday-first weeks", () => {
+      // Today = Sat Apr 18 2026, selectedDate = Sun Apr 12 2026.
+      // - Sunday-first: today ∈ [Sun Apr 12 – Sat Apr 18]; selectedDate ∈ same week → same week.
+      // - Monday-first: today ∈ [Mon Apr 13 – Sun Apr 19]; selectedDate ∈ [Mon Apr 6 – Sun Apr 12] → different weeks.
+      vi.setSystemTime(new Date(2026, 3, 18, 12, 0, 0));
+      const selectedDate = new Date(2026, 3, 12, 12, 0, 0);
+
+      renderWithContext({ selectedDate, weekStartDay: 1 });
+
+      expect(screen.getByTestId("week-calendar-today-btn")).toBeEnabled();
+    });
+  });
+
   describe("Navigation", () => {
     it("navigates to previous week", async () => {
       const selectedDate = midday(new Date(2026, 3, 15));
@@ -194,7 +231,7 @@ describe("WeekCalendar", () => {
   describe("Weekday grid", () => {
     it("renders 7 day columns with weekday labels in WEEK_STARTS_ON order", () => {
       renderWithContext();
-      for (const label of getShortWeekdayLabels()) {
+      for (const label of getShortWeekdayLabels(WEEK_STARTS_ON)) {
         expect(
           screen.getAllByText(label, { exact: true }).length
         ).toBeGreaterThan(0);

--- a/src/components/calendar/__tests__/WeekCalendar.test.tsx
+++ b/src/components/calendar/__tests__/WeekCalendar.test.tsx
@@ -3,6 +3,7 @@ import {
   type ICalendarContext,
 } from "@/components/providers/CalendarProvider";
 import { WEEK_STARTS_ON, getShortWeekdayLabels } from "@/lib/calendar-helpers";
+import { __resetUseDateNowForTests } from "@/lib/hooks/use-date-now";
 import { makeCalendarContext } from "@/test/fixtures/calendar-context";
 import { createMockEvent } from "@/test/fixtures/calendar-event";
 import { render, screen } from "@testing-library/react";
@@ -163,11 +164,16 @@ describe("WeekCalendar", () => {
     // Regression: #352. WeekCalendar.isCurrentWeek must use the user's
     // weekStartDay so the Today button toggles enabled/disabled on the
     // Sun→Mon (or Sat→Sun) boundary, not on a hard-coded WEEK_STARTS_ON.
+    //
+    // `useTodayStartOfDay` caches the day at module load, so each test
+    // resets the cache after `vi.setSystemTime` to pull the fake clock —
+    // same pattern as `midnight-rollover.test.tsx`.
     beforeEach(() => {
       vi.useFakeTimers();
     });
 
     afterEach(() => {
+      __resetUseDateNowForTests();
       vi.useRealTimers();
     });
 
@@ -176,6 +182,7 @@ describe("WeekCalendar", () => {
       // - Sunday-first: today ∈ [Sun Apr 19 – Sat Apr 25]; selectedDate ∈ [Sun Apr 12 – Sat Apr 18] → different weeks.
       // - Monday-first: today ∈ [Mon Apr 13 – Sun Apr 19]; selectedDate ∈ same week → same week.
       vi.setSystemTime(new Date(2026, 3, 19, 12, 0, 0));
+      __resetUseDateNowForTests();
       const selectedDate = new Date(2026, 3, 17, 12, 0, 0);
 
       renderWithContext({ selectedDate, weekStartDay: 1 });
@@ -188,6 +195,7 @@ describe("WeekCalendar", () => {
       // - Sunday-first: today ∈ [Sun Apr 12 – Sat Apr 18]; selectedDate ∈ same week → same week.
       // - Monday-first: today ∈ [Mon Apr 13 – Sun Apr 19]; selectedDate ∈ [Mon Apr 6 – Sun Apr 12] → different weeks.
       vi.setSystemTime(new Date(2026, 3, 18, 12, 0, 0));
+      __resetUseDateNowForTests();
       const selectedDate = new Date(2026, 3, 12, 12, 0, 0);
 
       renderWithContext({ selectedDate, weekStartDay: 1 });

--- a/src/lib/__tests__/calendar-helpers.test.ts
+++ b/src/lib/__tests__/calendar-helpers.test.ts
@@ -43,12 +43,12 @@ describe("rangeText", () => {
   const testDate = new Date(2024, 2, 15); // March 15, 2024
 
   it("returns correct range for month view", () => {
-    const result = rangeText("month", testDate);
+    const result = rangeText("month", testDate, WEEK_STARTS_ON);
     expect(result).toBe("Mar 1, 2024 - Mar 31, 2024");
   });
 
   it("returns correct range for week view", () => {
-    const result = rangeText("week", testDate);
+    const result = rangeText("week", testDate, WEEK_STARTS_ON);
     // March 15, 2024 is a Friday; Sunday-first week is Mar 10 – Mar 16.
     expect(result).toBe("Mar 10, 2024 - Mar 16, 2024");
   });
@@ -60,22 +60,26 @@ describe("rangeText", () => {
   });
 
   it("returns single date for day view", () => {
-    const result = rangeText("day", testDate);
+    const result = rangeText("day", testDate, WEEK_STARTS_ON);
     expect(result).toBe("Mar 15, 2024");
   });
 
   it("returns correct range for year view", () => {
-    const result = rangeText("year", testDate);
+    const result = rangeText("year", testDate, WEEK_STARTS_ON);
     expect(result).toBe("Jan 1, 2024 - Dec 31, 2024");
   });
 
   it("returns single date for clock view (12-hour period of selected day)", () => {
-    const result = rangeText("clock", testDate);
+    const result = rangeText("clock", testDate, WEEK_STARTS_ON);
     expect(result).toBe("Mar 15, 2024");
   });
 
   it("returns error for unknown view", () => {
-    const result = rangeText("unknown" as TCalendarView, testDate);
+    const result = rangeText(
+      "unknown" as TCalendarView,
+      testDate,
+      WEEK_STARTS_ON
+    );
     expect(result).toBe("Error while formatting");
   });
 });
@@ -143,17 +147,17 @@ describe("getEventsCount", () => {
   ];
 
   it("counts events for the same day", () => {
-    const count = getEventsCount(events, testDate, "day");
+    const count = getEventsCount(events, testDate, "day", WEEK_STARTS_ON);
     expect(count).toBe(2);
   });
 
   it("counts events for the same month", () => {
-    const count = getEventsCount(events, testDate, "month");
+    const count = getEventsCount(events, testDate, "month", WEEK_STARTS_ON);
     expect(count).toBe(3);
   });
 
   it("counts events for the same day in clock view", () => {
-    const count = getEventsCount(events, testDate, "clock");
+    const count = getEventsCount(events, testDate, "clock", WEEK_STARTS_ON);
     expect(count).toBe(2);
   });
 
@@ -164,7 +168,9 @@ describe("getEventsCount", () => {
       createMockEvent({ id: "same-week", startDate: "2024-03-10T10:00:00" }),
       createMockEvent({ id: "next-week", startDate: "2024-03-17T10:00:00" }),
     ];
-    expect(getEventsCount(weekEvents, testDate, "week")).toBe(1);
+    expect(getEventsCount(weekEvents, testDate, "week", WEEK_STARTS_ON)).toBe(
+      1
+    );
   });
 
   it("counts events for the same week with Monday-first weekStartsOn=1", () => {
@@ -229,7 +235,7 @@ describe("groupEvents", () => {
 describe("getCalendarCells", () => {
   it("returns cells for a full month grid", () => {
     const date = new Date(2024, 2, 15); // March 2024
-    const cells = getCalendarCells(date);
+    const cells = getCalendarCells(date, WEEK_STARTS_ON);
 
     // Should always be a complete grid (multiple of 7)
     expect(cells.length % 7).toBe(0);
@@ -241,7 +247,7 @@ describe("getCalendarCells", () => {
 
   it("marks current month cells correctly", () => {
     const date = new Date(2024, 2, 15);
-    const cells = getCalendarCells(date);
+    const cells = getCalendarCells(date, WEEK_STARTS_ON);
 
     const currentMonthCells = cells.filter((c) => c.currentMonth);
     currentMonthCells.forEach((cell) => {
@@ -251,7 +257,7 @@ describe("getCalendarCells", () => {
 
   it("includes previous month cells", () => {
     const date = new Date(2024, 2, 1); // March 2024 starts on Friday
-    const cells = getCalendarCells(date);
+    const cells = getCalendarCells(date, WEEK_STARTS_ON);
 
     // First cell should be from previous month (if March doesn't start on WEEK_STARTS_ON)
     const prevMonthCells = cells.filter(
@@ -262,7 +268,7 @@ describe("getCalendarCells", () => {
 
   it("starts the grid on WEEK_STARTS_ON", () => {
     const date = new Date(2024, 2, 15); // March 2024
-    const cells = getCalendarCells(date);
+    const cells = getCalendarCells(date, WEEK_STARTS_ON);
     expect(cells[0].date.getDay()).toBe(WEEK_STARTS_ON);
   });
 
@@ -395,7 +401,11 @@ describe("getEventsForWeek", () => {
       }),
     ];
 
-    const result = getEventsForWeek(events, new Date(2024, 2, 13));
+    const result = getEventsForWeek(
+      events,
+      new Date(2024, 2, 13),
+      WEEK_STARTS_ON
+    );
     expect(result.length).toBe(2);
   });
 
@@ -456,7 +466,8 @@ describe("getEventsForWeek", () => {
 
     const result = getEventsForWeek(
       [saturdayMorning, saturdayAfternoon, saturdayLateNight],
-      new Date(2024, 2, 13)
+      new Date(2024, 2, 13),
+      WEEK_STARTS_ON
     );
     const ids = result.map((e) => e.id).sort();
     expect(ids).toEqual(["sat-afternoon", "sat-late", "sat-morning"]);
@@ -472,7 +483,8 @@ describe("getEventsForWeek", () => {
     });
     const result = getEventsForWeek(
       [nextSundayMidnight],
-      new Date(2024, 2, 13)
+      new Date(2024, 2, 13),
+      WEEK_STARTS_ON
     );
     expect(result).toEqual([]);
   });
@@ -485,7 +497,11 @@ describe("getEventsForWeek", () => {
       startDate: "2024-03-09T23:30:00",
       endDate: "2024-03-09T23:59:00",
     });
-    const result = getEventsForWeek([priorSaturdayLate], new Date(2024, 2, 13));
+    const result = getEventsForWeek(
+      [priorSaturdayLate],
+      new Date(2024, 2, 13),
+      WEEK_STARTS_ON
+    );
     expect(result).toEqual([]);
   });
 
@@ -497,7 +513,11 @@ describe("getEventsForWeek", () => {
       startDate: "2024-03-14T22:00:00",
       endDate: "2024-03-16T15:00:00",
     });
-    const result = getEventsForWeek([spanning], new Date(2024, 2, 13));
+    const result = getEventsForWeek(
+      [spanning],
+      new Date(2024, 2, 13),
+      WEEK_STARTS_ON
+    );
     expect(result.map((e) => e.id)).toEqual(["span"]);
   });
 
@@ -511,7 +531,11 @@ describe("getEventsForWeek", () => {
       startDate: "2024-03-16T14:00:00",
       endDate: "2024-03-18T09:00:00",
     });
-    const result = getEventsForWeek([spanningOut], new Date(2024, 2, 13));
+    const result = getEventsForWeek(
+      [spanningOut],
+      new Date(2024, 2, 13),
+      WEEK_STARTS_ON
+    );
     expect(result.map((e) => e.id)).toEqual(["span-out"]);
   });
 
@@ -541,7 +565,7 @@ describe("getEventsForWeek", () => {
       }),
     ];
 
-    const result = getEventsForWeek(events, referenceDate);
+    const result = getEventsForWeek(events, referenceDate, WEEK_STARTS_ON);
     expect(result.map((e) => e.id).sort()).toEqual([
       "sat-afternoon",
       "sat-late-night",
@@ -569,7 +593,7 @@ describe("getEventsForWeek", () => {
       }),
     ];
 
-    const result = getEventsForWeek(events, referenceDate);
+    const result = getEventsForWeek(events, referenceDate, WEEK_STARTS_ON);
     expect(result).toEqual([]);
   });
 });
@@ -630,19 +654,19 @@ describe("getEventsForYear", () => {
 
 describe("getWeekDates", () => {
   it("returns 7 dates for a week", () => {
-    const result = getWeekDates(new Date(2024, 2, 15));
+    const result = getWeekDates(new Date(2024, 2, 15), WEEK_STARTS_ON);
     expect(result.length).toBe(7);
   });
 
   it("starts week on WEEK_STARTS_ON", () => {
-    const result = getWeekDates(new Date(2024, 2, 15));
+    const result = getWeekDates(new Date(2024, 2, 15), WEEK_STARTS_ON);
     expect(result[0].getDay()).toBe(WEEK_STARTS_ON);
   });
 
   it("returns consecutive days covering a full week", () => {
     // March 15, 2024 is a Friday. With Sunday-first (WEEK_STARTS_ON = 0),
     // the week runs from Sun Mar 10 through Sat Mar 16.
-    const result = getWeekDates(new Date(2024, 2, 15));
+    const result = getWeekDates(new Date(2024, 2, 15), WEEK_STARTS_ON);
     const isoDates = result.map((d) => d.toISOString().slice(0, 10));
     expect(isoDates).toEqual([
       "2024-03-10",
@@ -675,7 +699,7 @@ describe("getShortWeekdayLabels", () => {
   it("returns labels in correct rotation order", () => {
     // Documents expected output for WEEK_STARTS_ON = 0 (Sunday-first).
     // Update this alongside WEEK_STARTS_ON if the default ever changes.
-    expect(getShortWeekdayLabels()).toEqual([
+    expect(getShortWeekdayLabels(WEEK_STARTS_ON)).toEqual([
       "Sun",
       "Mon",
       "Tue",
@@ -748,7 +772,7 @@ describe("getEventsByMode (clock)", () => {
   ];
 
   it("returns events for the selected day in clock view", () => {
-    const result = getEventsByMode(events, "clock", testDate);
+    const result = getEventsByMode(events, "clock", testDate, WEEK_STARTS_ON);
     const ids = result.map((e) => e.id).sort();
     expect(ids).toEqual(["today-1", "today-2"]);
   });

--- a/src/lib/__tests__/calendar-keyboard.test.ts
+++ b/src/lib/__tests__/calendar-keyboard.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { WEEK_STARTS_ON } from "../calendar-helpers";
 import {
   type CalendarKeyboardAction,
   applyCalendarKeyboardAction,
@@ -60,50 +61,74 @@ describe("applyCalendarKeyboardAction", () => {
   const anchor = new Date(2026, 3, 15);
 
   it("PREVIOUS_DAY subtracts one day", () => {
-    const result = applyCalendarKeyboardAction(anchor, {
-      type: "PREVIOUS_DAY",
-    });
+    const result = applyCalendarKeyboardAction(
+      anchor,
+      { type: "PREVIOUS_DAY" },
+      WEEK_STARTS_ON
+    );
     expect(result.toDateString()).toBe(new Date(2026, 3, 14).toDateString());
   });
 
   it("NEXT_DAY adds one day", () => {
-    const result = applyCalendarKeyboardAction(anchor, { type: "NEXT_DAY" });
+    const result = applyCalendarKeyboardAction(
+      anchor,
+      { type: "NEXT_DAY" },
+      WEEK_STARTS_ON
+    );
     expect(result.toDateString()).toBe(new Date(2026, 3, 16).toDateString());
   });
 
   it("PREVIOUS_WEEK subtracts seven days", () => {
-    const result = applyCalendarKeyboardAction(anchor, {
-      type: "PREVIOUS_WEEK",
-    });
+    const result = applyCalendarKeyboardAction(
+      anchor,
+      { type: "PREVIOUS_WEEK" },
+      WEEK_STARTS_ON
+    );
     expect(result.toDateString()).toBe(new Date(2026, 3, 8).toDateString());
   });
 
   it("NEXT_WEEK adds seven days", () => {
-    const result = applyCalendarKeyboardAction(anchor, { type: "NEXT_WEEK" });
+    const result = applyCalendarKeyboardAction(
+      anchor,
+      { type: "NEXT_WEEK" },
+      WEEK_STARTS_ON
+    );
     expect(result.toDateString()).toBe(new Date(2026, 3, 22).toDateString());
   });
 
-  it("WEEK_START defaults to Sunday-start when weekStartsOn is omitted (WEEK_STARTS_ON = 0)", () => {
+  it("WEEK_START with weekStartsOn=0 moves a Wednesday back to the preceding Sunday", () => {
     // Wed Apr 15 → Sun Apr 12
-    const result = applyCalendarKeyboardAction(anchor, { type: "WEEK_START" });
+    const result = applyCalendarKeyboardAction(
+      anchor,
+      { type: "WEEK_START" },
+      0
+    );
     expect(result.toDateString()).toBe(new Date(2026, 3, 12).toDateString());
   });
 
-  it("WEEK_END defaults to Saturday-end when weekStartsOn is omitted", () => {
+  it("WEEK_END with weekStartsOn=0 moves a Wednesday forward to the following Saturday", () => {
     // Wed Apr 15 → Sat Apr 18
-    const result = applyCalendarKeyboardAction(anchor, { type: "WEEK_END" });
+    const result = applyCalendarKeyboardAction(anchor, { type: "WEEK_END" }, 0);
     expect(result.toDateString()).toBe(new Date(2026, 3, 18).toDateString());
   });
 
   it("WEEK_START is idempotent when already on the first day of the week (Sunday-start)", () => {
     const sunday = new Date(2026, 3, 12);
-    const result = applyCalendarKeyboardAction(sunday, { type: "WEEK_START" });
+    const result = applyCalendarKeyboardAction(
+      sunday,
+      { type: "WEEK_START" },
+      0
+    );
     expect(result.toDateString()).toBe(sunday.toDateString());
   });
 
   it("WEEK_END is idempotent when already on the last day of the week (Sunday-start)", () => {
     const saturday = new Date(2026, 3, 18);
-    const result = applyCalendarKeyboardAction(saturday, { type: "WEEK_END" });
+    const result = applyCalendarKeyboardAction(
+      saturday,
+      { type: "WEEK_END" },
+      0
+    );
     expect(result.toDateString()).toBe(saturday.toDateString());
   });
 
@@ -174,47 +199,69 @@ describe("applyCalendarKeyboardAction", () => {
   });
 
   it("PREVIOUS_MONTH subtracts one month", () => {
-    const result = applyCalendarKeyboardAction(anchor, {
-      type: "PREVIOUS_MONTH",
-    });
+    const result = applyCalendarKeyboardAction(
+      anchor,
+      { type: "PREVIOUS_MONTH" },
+      WEEK_STARTS_ON
+    );
     expect(result.toDateString()).toBe(new Date(2026, 2, 15).toDateString());
   });
 
   it("NEXT_MONTH adds one month", () => {
-    const result = applyCalendarKeyboardAction(anchor, { type: "NEXT_MONTH" });
+    const result = applyCalendarKeyboardAction(
+      anchor,
+      { type: "NEXT_MONTH" },
+      WEEK_STARTS_ON
+    );
     expect(result.toDateString()).toBe(new Date(2026, 4, 15).toDateString());
   });
 
   it("PREVIOUS_YEAR subtracts one year", () => {
-    const result = applyCalendarKeyboardAction(anchor, {
-      type: "PREVIOUS_YEAR",
-    });
+    const result = applyCalendarKeyboardAction(
+      anchor,
+      { type: "PREVIOUS_YEAR" },
+      WEEK_STARTS_ON
+    );
     expect(result.toDateString()).toBe(new Date(2025, 3, 15).toDateString());
   });
 
   it("NEXT_YEAR adds one year", () => {
-    const result = applyCalendarKeyboardAction(anchor, { type: "NEXT_YEAR" });
+    const result = applyCalendarKeyboardAction(
+      anchor,
+      { type: "NEXT_YEAR" },
+      WEEK_STARTS_ON
+    );
     expect(result.toDateString()).toBe(new Date(2027, 3, 15).toDateString());
   });
 
   it("PREVIOUS_DAY crosses month boundary at the start of a month", () => {
     const firstOfMonth = new Date(2026, 3, 1);
-    const result = applyCalendarKeyboardAction(firstOfMonth, {
-      type: "PREVIOUS_DAY",
-    });
+    const result = applyCalendarKeyboardAction(
+      firstOfMonth,
+      { type: "PREVIOUS_DAY" },
+      WEEK_STARTS_ON
+    );
     expect(result.toDateString()).toBe(new Date(2026, 2, 31).toDateString());
   });
 
   it("NEXT_MONTH handles the Jan 31 → Feb 28 truncation by clamping to the last valid day", () => {
     const jan31 = new Date(2027, 0, 31);
-    const result = applyCalendarKeyboardAction(jan31, { type: "NEXT_MONTH" });
+    const result = applyCalendarKeyboardAction(
+      jan31,
+      { type: "NEXT_MONTH" },
+      WEEK_STARTS_ON
+    );
     // 2027 is not a leap year → Feb 28
     expect(result.toDateString()).toBe(new Date(2027, 1, 28).toDateString());
   });
 
   it("preserves the hour and minute of the input", () => {
     const withTime = new Date(2026, 3, 15, 14, 30, 0, 0);
-    const result = applyCalendarKeyboardAction(withTime, { type: "NEXT_DAY" });
+    const result = applyCalendarKeyboardAction(
+      withTime,
+      { type: "NEXT_DAY" },
+      WEEK_STARTS_ON
+    );
     expect(result.getHours()).toBe(14);
     expect(result.getMinutes()).toBe(30);
   });

--- a/src/lib/calendar-helpers.ts
+++ b/src/lib/calendar-helpers.ts
@@ -36,13 +36,15 @@ import {
 const FORMAT_STRING = "MMM d, yyyy";
 
 /**
- * Project-wide default for which day a calendar week begins on.
+ * Project-wide reference for the default week-start day used by tests and
+ * documentation.
  *
  * 0 = Sunday, 1 = Monday, ..., 6 = Saturday (matches `date-fns` `Day`).
  *
- * Used as the fallback when a caller hasn't been wired through to the
- * user-selectable `weekStartDay` setting (#86). New code should prefer
- * reading `weekStartDay` from `CalendarProvider` over this constant.
+ * Production code must pass the user's `weekStartDay` from
+ * `CalendarProvider` to every helper that consumes it (#352); the value
+ * is exported here only so tests can reference the project default
+ * without re-deriving it.
  */
 export const WEEK_STARTS_ON: Day = 0;
 
@@ -86,13 +88,8 @@ const SHORT_WEEKDAY_LABELS = [
  * Returns the 7 short weekday labels (`"Sun"`…`"Sat"`) rotated so the
  * first entry corresponds to `weekStartsOn`. Use this for day-of-week
  * headers instead of hard-coding the array so every view agrees.
- *
- * `weekStartsOn` defaults to `WEEK_STARTS_ON` for callers that haven't
- * been wired through to the user-selectable setting yet (#86).
  */
-export const getShortWeekdayLabels = (
-  weekStartsOn: Day = WEEK_STARTS_ON
-): string[] => [
+export const getShortWeekdayLabels = (weekStartsOn: Day): string[] => [
   ...SHORT_WEEKDAY_LABELS.slice(weekStartsOn),
   ...SHORT_WEEKDAY_LABELS.slice(0, weekStartsOn),
 ];
@@ -100,7 +97,7 @@ export const getShortWeekdayLabels = (
 export function rangeText(
   view: TCalendarView,
   date: Date,
-  weekStartsOn: Day = WEEK_STARTS_ON
+  weekStartsOn: Day
 ): string {
   let start: Date;
   let end: Date;
@@ -148,7 +145,7 @@ export function getEventsCount(
   events: IEvent[],
   date: Date,
   view: TCalendarView,
-  weekStartsOn: Day = WEEK_STARTS_ON
+  weekStartsOn: Day
 ): number {
   const compareFns: Record<TCalendarView, (d1: Date, d2: Date) => boolean> = {
     day: isSameDay,
@@ -192,7 +189,7 @@ export function groupEvents(dayEvents: IEvent[]): IEvent[][] {
 
 export function getCalendarCells(
   selectedDate: Date,
-  weekStartsOn: Day = WEEK_STARTS_ON
+  weekStartsOn: Day
 ): ICalendarCell[] {
   const year = selectedDate.getFullYear();
   const month = selectedDate.getMonth();
@@ -382,10 +379,7 @@ export const getEventsForDay = (
     });
 };
 
-export const getWeekDates = (
-  date: Date,
-  weekStartsOn: Day = WEEK_STARTS_ON
-): Date[] => {
+export const getWeekDates = (date: Date, weekStartsOn: Day): Date[] => {
   const startDate = startOfWeek(date, { weekStartsOn });
   return Array.from({ length: 7 }, (_, i) => addDays(startDate, i));
 };
@@ -393,7 +387,7 @@ export const getWeekDates = (
 export const getEventsForWeek = (
   events: IEvent[],
   date: Date,
-  weekStartsOn: Day = WEEK_STARTS_ON
+  weekStartsOn: Day
 ): IEvent[] => {
   // Use startOfWeek/endOfWeek so the upper bound covers the last
   // millisecond of the last day (fix from PR #228 / issue #201). Indexing
@@ -479,7 +473,7 @@ export const getEventsByMode = (
   events: IEvent[],
   view: TCalendarView,
   selectedDate: Date,
-  weekStartsOn: Day = WEEK_STARTS_ON
+  weekStartsOn: Day
 ) => {
   switch (view) {
     case "day":

--- a/src/lib/calendar-keyboard.ts
+++ b/src/lib/calendar-keyboard.ts
@@ -10,7 +10,6 @@ import {
   subMonths,
   subYears,
 } from "date-fns";
-import { WEEK_STARTS_ON } from "./calendar-helpers";
 
 /**
  * Keyboard-driven navigation actions for the month grid.
@@ -62,15 +61,13 @@ export function keyboardEventToAction(
 /**
  * Apply a keyboard action to the currently-focused date.
  *
- * `weekStartsOn` controls the `WEEK_START`/`WEEK_END` actions only and
- * defaults to `WEEK_STARTS_ON` so callers that don't yet thread the
- * user's `weekStartDay` preference keep the previous Sunday-start
- * behaviour. All other actions are independent of the week boundary.
+ * `weekStartsOn` controls the `WEEK_START`/`WEEK_END` actions only;
+ * other actions are independent of the week boundary.
  */
 export function applyCalendarKeyboardAction(
   date: Date,
   action: CalendarKeyboardAction,
-  weekStartsOn: Day = WEEK_STARTS_ON
+  weekStartsOn: Day
 ): Date {
   switch (action.type) {
     case "PREVIOUS_DAY":


### PR DESCRIPTION
## Summary

- Production code already threads `weekStartDay` through every call site (`WeekCalendar`, `SimpleCalendar`, `MiniCalendarSidebar` — landed in PR #229). The `weekStartsOn: Day = WEEK_STARTS_ON` defaults on the helper signatures were the only remaining production references to `WEEK_STARTS_ON` outside the constant definition itself.
- Make `weekStartsOn` **required** on `getShortWeekdayLabels`, `rangeText`, `getEventsCount`, `getCalendarCells`, `getWeekDates`, `getEventsForWeek`, `getEventsByMode`, and `applyCalendarKeyboardAction`. Future callers can no longer silently fall back to Sunday-start.
- Add two `WeekCalendar` tests for the `isCurrentWeek` predicate at Monday-start week boundaries — covering the case where today and selectedDate share a Monday-first week but not a Sunday-first one (Today button disabled) and the inverse.

`WEEK_STARTS_ON` stays exported from `calendar-helpers.ts` so tests have a stable reference to the project default.

## Acceptance criteria (issue #352)

- [x] `WeekCalendar` derives `weekStart`, `weekEnd`, and the "current week" predicate from `useCalendar().weekStartDay` — already true on `main` after PR #229
- [x] No remaining production references to `WEEK_STARTS_ON` outside the constant definition itself — verified via `grep WEEK_STARTS_ON src/**/*.{ts,tsx}` (only `src/lib/calendar-helpers.ts:49` and test files remain)
- [x] Unit-test branch coverage for both starts on the affected helpers — `rangeText`, `getEventsCount`, `getCalendarCells`, `getWeekDates`, `getShortWeekdayLabels`, `getEventsForWeek`, `applyCalendarKeyboardAction.WEEK_START`/`WEEK_END` already had Sun/Mon pairs; this PR adds the missing `WeekCalendar.isCurrentWeek` Monday-start coverage
- [x] No regression in `e2e/week-day-views.spec.ts`

## Plan

No `.claude/plans/` file — the issue body was the spec; planning notes captured in the claim comment on #352.

Project: https://github.com/users/BenSeymourODB/projects/1

## Test plan

- [x] `pnpm test` — 2476 / 2476 passing across 153 files (was 2474; +2 new `WeekCalendar` tests)
- [x] `pnpm lint:fix` — 0 errors, 6 pre-existing warnings unrelated
- [x] `pnpm format:fix` — clean
- [x] `pnpm check-types` — clean

Closes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019XxpVyyY9L3E8uxPE6KWmT)_