### PR TITLE
feat(auth): singleflight wrapper for session token refresh (#216)

### DIFF
--- a/.claude/plans/auth-token-refresh-singleflight-216.md
+++ b/.claude/plans/auth-token-refresh-singleflight-216.md
@@ -1,0 +1,92 @@
+# Plan: Singleflight Google OAuth token-refresh (#216)
+
+## Context
+
+Two concurrent NextAuth `session` callbacks for the same Google account with an
+expired access token both race the refresh path: each decrypts the stored
+refresh token, each POSTs to `oauth2.googleapis.com/token`, and each calls
+`prisma.account.update`. The second `update()` clobbers the first. If Google
+rotates the refresh token on refresh, only one of the two new ciphertexts wins
+the write and the loser is left holding a stale token — surfacing later as a
+bogus `RefreshTokenError` and an unnecessary re-sign-in.
+
+Issue #216's first acceptance criterion: **5 concurrent expired-token requests →
+exactly one OAuth refresh hits the network (and one DB write).**
+
+## History — why this is a thin wrapper, not a replacement
+
+The original 2026-05-03 design (PR #252) extracted a self-contained
+`token-refresh.ts` owning the HTTP round-trip, the DB update, and the cache in
+one module. While that PR was open, `main` landed a substantial auth refactor:
+
+- **#215** — refresh tokens encrypted at rest (`crypto/token-cipher.ts`).
+- **#315 / #348** — refresh errors classified `terminal` vs `transient`
+  (`refresh-error-classifier.ts`), with the session-callback path factored into
+  `refresh-session-tokens.ts` returning a `RefreshOutcome` discriminated union.
+- **#217** — `fetchWithRetry` wrapping the OAuth round-trip
+  (`refresh-google-token.ts`).
+
+Replaying the original module on current `main` would silently regress
+encryption-at-rest and terminal/transient classification. PR #252 was therefore
+**closed as architecturally superseded** (per its in-depth review,
+`pullrequestreview-4453877881`), and the singleflight concept reimplemented as a
+thin wrapper around the existing `refreshGoogleSessionTokensIfNeeded` rather
+than a replacement for it. The underlying race is still real on `main` — the
+orchestrator has no concurrent-call de-duplication — so the work is still
+wanted.
+
+## Design
+
+### `src/lib/auth/token-refresh-singleflight.ts`
+
+A module-level `Map<string, Promise<RefreshOutcome>>` keyed by
+`account.providerAccountId`. `getOrStartSessionRefresh(userId, account, deps)`:
+
+- returns the in-flight promise if one exists for the key (collapse);
+- otherwise calls `refreshGoogleSessionTokensIfNeeded(userId, account, deps)`,
+  attaches a `.finally()` that purges the slot, stores the pending promise, and
+  returns it.
+
+The slot is purged on **both** success and failure so a transient outage never
+pins it; the next caller can retry. Because the orchestrator resolves (rather
+than rejects) for terminal/transient outcomes, those clear the slot too.
+
+A `__resetSessionRefreshSingleflightCache()` helper (NODE_ENV-gated to a no-op
+in production) clears the cache for test isolation.
+
+### `src/lib/auth/auth.ts`
+
+Single-line swap in the `session` callback:
+`await refreshGoogleSessionTokensIfNeeded(...)` →
+`await getOrStartSessionRefresh(...)`. All decrypt → fetch → re-encrypt → DB
+write → classify behaviour and the terminal-error `session.error` handling are
+preserved unchanged.
+
+## Tests — `src/lib/auth/__tests__/token-refresh-singleflight.test.ts`
+
+1. 5 concurrent same-account calls → exactly 1 refresh + 1 DB write.
+2. 3 distinct `providerAccountId`s → 3 refreshes (different keys don't collapse).
+3. All concurrent awaiters see the same outcome on a transient rejection.
+4. Slot released after success → a later call refreshes again.
+5. Slot released after a transient failure → next call retries and succeeds.
+6. `null` refresh_token → `terminal-error`; cache still purges so a follow-up
+   valid call refreshes (no pollution).
+7. `TokenRefreshed` telemetry fires exactly once for collapsed callers.
+8. Refresh error is logged exactly once for collapsed callers.
+
+Plus a `not-expired` short-circuit guard (no network round-trip).
+
+Concurrency is forced with a deferred promise so all callers overlap on the
+same cache slot before any resolves.
+
+## Out of scope (tracked separately)
+
+- Idle-session timeout (sliding `maxAge`, wall-display preserve mode) — #216
+  stays open to track that half.
+- Unifying `/api/auth/refresh-token` with the singleflight queue — #285.
+- Cross-process refresh dedupe for multi-instance deployments — #286.
+
+## Verification
+
+`pnpm test:run src/lib/auth/__tests__/`, then
+`pnpm lint:fix && pnpm format:fix && pnpm check-types`.

--- a/src/lib/auth/__tests__/token-refresh-singleflight.test.ts
+++ b/src/lib/auth/__tests__/token-refresh-singleflight.test.ts
@@ -100,10 +100,18 @@ describe("getOrStartSessionRefresh (singleflight #216)", () => {
     expect(deps.prisma.account.update).toHaveBeenCalledTimes(1);
   });
 
-  it("does not collapse calls for distinct providerAccountIds", async () => {
-    const deps = makeDeps();
+  it("does not collapse calls for distinct providerAccountIds (true in-flight concurrency)", async () => {
+    // Hold every flight open with a shared gate so all three slots coexist in
+    // the inflight Map simultaneously before any resolves. Without the gate
+    // the test only proves serial independence (one slot purges before the
+    // next sets), which would miss a bug where two truly concurrent flights
+    // for different keys shared state.
+    const gate = deferred<GoogleRefreshedTokens>();
+    const deps = makeDeps({
+      refreshGoogleAccessToken: vi.fn().mockReturnValue(gate.promise),
+    });
 
-    const outcomes = await Promise.all([
+    const calls = [
       getOrStartSessionRefresh(
         "user-a",
         makeAccount({ providerAccountId: "google-a" }),
@@ -119,18 +127,25 @@ describe("getOrStartSessionRefresh (singleflight #216)", () => {
         makeAccount({ providerAccountId: "google-c" }),
         deps
       ),
-    ]);
+    ];
+
+    // All three flights are in-flight at this point; the gate hasn't fired.
+    // refreshGoogleAccessToken must already have been called 3× (once per
+    // distinct slot) — proving no collapse — even though zero have resolved.
+    expect(deps.refreshGoogleAccessToken).toHaveBeenCalledTimes(3);
+
+    gate.resolve({ access_token: "new-access-token", expires_in: 3600 });
+    const outcomes = await Promise.all(calls);
 
     expect(outcomes).toEqual([
       { kind: "refreshed" },
       { kind: "refreshed" },
       { kind: "refreshed" },
     ]);
-    expect(deps.refreshGoogleAccessToken).toHaveBeenCalledTimes(3);
     expect(deps.prisma.account.update).toHaveBeenCalledTimes(3);
   });
 
-  it("delivers the same rejection outcome to every concurrent awaiter", async () => {
+  it("delivers the same transient-error outcome to every concurrent awaiter (errors are classified, not thrown)", async () => {
     const err = new GoogleTokenRefreshError(503, {
       error: "service_unavailable",
     });

--- a/src/lib/auth/__tests__/token-refresh-singleflight.test.ts
+++ b/src/lib/auth/__tests__/token-refresh-singleflight.test.ts
@@ -1,0 +1,259 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GoogleTokenRefreshError } from "../refresh-google-token";
+import type { GoogleRefreshedTokens } from "../refresh-google-token";
+import type {
+  GoogleAccountForRefresh,
+  RefreshSessionDeps,
+} from "../refresh-session-tokens";
+import {
+  __resetSessionRefreshSingleflightCache,
+  getOrStartSessionRefresh,
+} from "../token-refresh-singleflight";
+
+const FIXED_NOW = 1_700_000_000_000; // milliseconds
+const EXPIRED_AT = Math.floor(FIXED_NOW / 1000) - 60; // 60 s in the past
+const FRESH_AT = Math.floor(FIXED_NOW / 1000) + 3600; // 1 h in the future
+const USER_ID = "user-test";
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason: unknown) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function makeDeps(
+  overrides: Partial<RefreshSessionDeps> = {}
+): RefreshSessionDeps {
+  const successTokens: GoogleRefreshedTokens = {
+    access_token: "new-access-token",
+    expires_in: 3600,
+  };
+  return {
+    prisma: { account: { update: vi.fn().mockResolvedValue(undefined) } },
+    refreshGoogleAccessToken: vi.fn().mockResolvedValue(successTokens),
+    encryptToken: vi.fn((s: string | null | undefined) =>
+      s == null ? null : `v1:enc(${s})`
+    ),
+    decryptToken: vi.fn((s: string | null | undefined) => {
+      if (s == null) return null;
+      return s.startsWith("v1:enc(") ? s.slice(7, -1) : s;
+    }),
+    logger: { error: vi.fn(), event: vi.fn() },
+    googleClientId: "test-client-id",
+    googleClientSecret: "test-client-secret",
+    now: () => FIXED_NOW,
+    ...overrides,
+  };
+}
+
+function makeAccount(
+  overrides: Partial<GoogleAccountForRefresh> = {}
+): GoogleAccountForRefresh {
+  return {
+    providerAccountId: "google-user-1",
+    refresh_token: "v1:enc(refresh-token-plaintext)",
+    expires_at: EXPIRED_AT,
+    ...overrides,
+  };
+}
+
+describe("getOrStartSessionRefresh (singleflight #216)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    __resetSessionRefreshSingleflightCache();
+  });
+
+  afterEach(() => {
+    __resetSessionRefreshSingleflightCache();
+  });
+
+  it("collapses 5 concurrent calls for one account onto a single refresh + DB write", async () => {
+    // Hold the OAuth round-trip in-flight so all 5 callers overlap on the same
+    // cache slot before any of them resolves.
+    const gate = deferred<GoogleRefreshedTokens>();
+    const deps = makeDeps({
+      refreshGoogleAccessToken: vi.fn().mockReturnValue(gate.promise),
+    });
+    const account = makeAccount();
+
+    const calls = Array.from({ length: 5 }, () =>
+      getOrStartSessionRefresh(USER_ID, account, deps)
+    );
+
+    gate.resolve({ access_token: "new-access-token", expires_in: 3600 });
+    const outcomes = await Promise.all(calls);
+
+    expect(outcomes).toEqual(
+      Array.from({ length: 5 }, () => ({ kind: "refreshed" }))
+    );
+    expect(deps.refreshGoogleAccessToken).toHaveBeenCalledTimes(1);
+    expect(deps.prisma.account.update).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not collapse calls for distinct providerAccountIds", async () => {
+    const deps = makeDeps();
+
+    const outcomes = await Promise.all([
+      getOrStartSessionRefresh(
+        "user-a",
+        makeAccount({ providerAccountId: "google-a" }),
+        deps
+      ),
+      getOrStartSessionRefresh(
+        "user-b",
+        makeAccount({ providerAccountId: "google-b" }),
+        deps
+      ),
+      getOrStartSessionRefresh(
+        "user-c",
+        makeAccount({ providerAccountId: "google-c" }),
+        deps
+      ),
+    ]);
+
+    expect(outcomes).toEqual([
+      { kind: "refreshed" },
+      { kind: "refreshed" },
+      { kind: "refreshed" },
+    ]);
+    expect(deps.refreshGoogleAccessToken).toHaveBeenCalledTimes(3);
+    expect(deps.prisma.account.update).toHaveBeenCalledTimes(3);
+  });
+
+  it("delivers the same rejection outcome to every concurrent awaiter", async () => {
+    const err = new GoogleTokenRefreshError(503, {
+      error: "service_unavailable",
+    });
+    const gate = deferred<GoogleRefreshedTokens>();
+    const deps = makeDeps({
+      refreshGoogleAccessToken: vi.fn().mockReturnValue(gate.promise),
+    });
+    const account = makeAccount();
+
+    const calls = Array.from({ length: 5 }, () =>
+      getOrStartSessionRefresh(USER_ID, account, deps)
+    );
+
+    gate.reject(err);
+    const outcomes = await Promise.all(calls);
+
+    // A transient outage resolves to the same `transient-error` for all five —
+    // it is classified, not thrown, so no awaiter sees a different result.
+    expect(outcomes).toEqual(
+      Array.from({ length: 5 }, () => ({ kind: "transient-error", error: err }))
+    );
+    expect(deps.refreshGoogleAccessToken).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases the slot after success so a later call refreshes again", async () => {
+    const deps = makeDeps();
+    const account = makeAccount();
+
+    const first = await getOrStartSessionRefresh(USER_ID, account, deps);
+    const second = await getOrStartSessionRefresh(USER_ID, account, deps);
+
+    expect(first).toEqual({ kind: "refreshed" });
+    expect(second).toEqual({ kind: "refreshed" });
+    // Two sequential (non-overlapping) calls each get their own round-trip
+    // because the slot is purged in `.finally()`.
+    expect(deps.refreshGoogleAccessToken).toHaveBeenCalledTimes(2);
+  });
+
+  it("releases the slot after a transient failure so the next call can retry", async () => {
+    const refreshGoogleAccessToken = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError("fetch failed"))
+      .mockResolvedValueOnce({ access_token: "recovered", expires_in: 3600 });
+    const deps = makeDeps({ refreshGoogleAccessToken });
+    const account = makeAccount();
+
+    const first = await getOrStartSessionRefresh(USER_ID, account, deps);
+    const second = await getOrStartSessionRefresh(USER_ID, account, deps);
+
+    expect(first.kind).toBe("transient-error");
+    expect(second).toEqual({ kind: "refreshed" });
+    expect(refreshGoogleAccessToken).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not pollute the cache when the account has no refresh_token", async () => {
+    const deps = makeDeps();
+
+    const first = await getOrStartSessionRefresh(
+      USER_ID,
+      makeAccount({ refresh_token: null }),
+      deps
+    );
+    expect(first.kind).toBe("terminal-error");
+    expect(deps.refreshGoogleAccessToken).not.toHaveBeenCalled();
+
+    // The slot purged even though the outcome was terminal, so a subsequent
+    // call with a valid token still refreshes rather than being short-circuited.
+    const second = await getOrStartSessionRefresh(USER_ID, makeAccount(), deps);
+    expect(second).toEqual({ kind: "refreshed" });
+    expect(deps.refreshGoogleAccessToken).toHaveBeenCalledTimes(1);
+  });
+
+  it("emits the TokenRefreshed telemetry event exactly once for collapsed callers", async () => {
+    const gate = deferred<GoogleRefreshedTokens>();
+    const deps = makeDeps({
+      refreshGoogleAccessToken: vi.fn().mockReturnValue(gate.promise),
+    });
+    const account = makeAccount();
+
+    const calls = Array.from({ length: 5 }, () =>
+      getOrStartSessionRefresh(USER_ID, account, deps)
+    );
+    gate.resolve({ access_token: "new-access-token", expires_in: 3600 });
+    await Promise.all(calls);
+
+    expect(deps.logger.event).toHaveBeenCalledTimes(1);
+    expect(deps.logger.event).toHaveBeenCalledWith("TokenRefreshed", {
+      userId: USER_ID,
+    });
+  });
+
+  it("logs the refresh error exactly once for collapsed callers", async () => {
+    const err = new GoogleTokenRefreshError(503, {
+      error: "service_unavailable",
+    });
+    const gate = deferred<GoogleRefreshedTokens>();
+    const deps = makeDeps({
+      refreshGoogleAccessToken: vi.fn().mockReturnValue(gate.promise),
+    });
+    const account = makeAccount();
+
+    const calls = Array.from({ length: 5 }, () =>
+      getOrStartSessionRefresh(USER_ID, account, deps)
+    );
+    gate.reject(err);
+    await Promise.all(calls);
+
+    expect(deps.logger.error).toHaveBeenCalledTimes(1);
+    expect(deps.logger.error).toHaveBeenCalledWith(err, {
+      context: "TokenRefreshTransientFailure",
+      userId: USER_ID,
+    });
+  });
+
+  it("short-circuits a not-expired account without a network round-trip", async () => {
+    const deps = makeDeps();
+    const outcome = await getOrStartSessionRefresh(
+      USER_ID,
+      makeAccount({ expires_at: FRESH_AT }),
+      deps
+    );
+    expect(outcome).toEqual({ kind: "not-expired" });
+    expect(deps.refreshGoogleAccessToken).not.toHaveBeenCalled();
+    expect(deps.prisma.account.update).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -10,8 +10,8 @@ import Google from "next-auth/providers/google";
 import { PrismaAdapter } from "@auth/prisma-adapter";
 import { encryptLinkedAccount } from "./link-account";
 import { refreshGoogleAccessToken } from "./refresh-google-token";
-import { refreshGoogleSessionTokensIfNeeded } from "./refresh-session-tokens";
 import { lastSix, shouldAllowSignIn } from "./sign-in-guard";
+import { getOrStartSessionRefresh } from "./token-refresh-singleflight";
 
 // Fail fast on a missing / misconfigured encryption key. Without this, the
 // per-request `encryptToken` call in the session callback throws, gets caught,
@@ -113,19 +113,19 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       // Returns a terminal-error outcome only for genuine Google revocation /
       // missing refresh-token / undecryptable ciphertext — transient failures
       // leave the session untouched so the next callback retries (#315).
-      const outcome = await refreshGoogleSessionTokensIfNeeded(
-        user.id,
-        googleAccount,
-        {
-          prisma,
-          refreshGoogleAccessToken,
-          encryptToken,
-          decryptToken,
-          logger,
-          googleClientId: process.env.GOOGLE_CLIENT_ID!,
-          googleClientSecret: process.env.GOOGLE_CLIENT_SECRET!,
-        }
-      );
+      //
+      // Wrapped in the singleflight cache (#216) so concurrent session
+      // callbacks for the same account collapse onto one OAuth round-trip and
+      // one DB write instead of racing each other's `prisma.account.update`.
+      const outcome = await getOrStartSessionRefresh(user.id, googleAccount, {
+        prisma,
+        refreshGoogleAccessToken,
+        encryptToken,
+        decryptToken,
+        logger,
+        googleClientId: process.env.GOOGLE_CLIENT_ID!,
+        googleClientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+      });
 
       if (outcome.kind === "terminal-error") {
         session.error = "RefreshTokenError";

--- a/src/lib/auth/token-refresh-singleflight.ts
+++ b/src/lib/auth/token-refresh-singleflight.ts
@@ -30,7 +30,14 @@ export function getOrStartSessionRefresh(
   account: GoogleAccountForRefresh,
   deps: RefreshSessionDeps
 ): Promise<RefreshOutcome> {
-  const key = account.providerAccountId;
+  // Prefix with the provider. The `Account` table's unique constraint is on
+  // `(provider, providerAccountId)`, not on `providerAccountId` alone — two
+  // numerically identical IDs across different OAuth providers (none today,
+  // app is Google-only, but defensive against future provider additions or
+  // accidental re-use of this module from another wrapper) must not share an
+  // in-flight slot. Hardcoded literal because this module wraps the
+  // Google-specific orchestrator `refreshGoogleSessionTokensIfNeeded`.
+  const key = `google:${account.providerAccountId}`;
   const existing = inflight.get(key);
   if (existing) return existing;
 

--- a/src/lib/auth/token-refresh-singleflight.ts
+++ b/src/lib/auth/token-refresh-singleflight.ts
@@ -1,0 +1,59 @@
+import {
+  type GoogleAccountForRefresh,
+  type RefreshOutcome,
+  type RefreshSessionDeps,
+  refreshGoogleSessionTokensIfNeeded,
+} from "./refresh-session-tokens";
+
+/**
+ * Per-account singleflight cache for the session-callback refresh path (#216).
+ *
+ * Two concurrent `auth()` invocations on an expired access token otherwise
+ * race: both decrypt the same refresh token, both POST to Google's token
+ * endpoint, and both `prisma.account.update` — the second clobbering the
+ * first. If Google rotates the refresh token, only one of the two new
+ * ciphertexts wins the write and the loser is left holding a stale token.
+ *
+ * This wrapper collapses concurrent callers for the same account onto a single
+ * in-flight promise so exactly one OAuth round-trip and one DB write happen per
+ * stale token, regardless of how many concurrent requests trigger it.
+ *
+ * It is a thin layer over `refreshGoogleSessionTokensIfNeeded` — all of the
+ * decrypt → refresh → re-encrypt → DB-write → classify behaviour (and the
+ * transient/terminal `RefreshOutcome` union the session callback branches on)
+ * lives in that orchestrator, unchanged. This module only adds de-duplication.
+ */
+const inflight = new Map<string, Promise<RefreshOutcome>>();
+
+export function getOrStartSessionRefresh(
+  userId: string,
+  account: GoogleAccountForRefresh,
+  deps: RefreshSessionDeps
+): Promise<RefreshOutcome> {
+  const key = account.providerAccountId;
+  const existing = inflight.get(key);
+  if (existing) return existing;
+
+  // Purge the slot in `.finally()` so it clears on both success and failure —
+  // a transient outage must not pin the slot, or the next caller could never
+  // retry. Because `refreshGoogleSessionTokensIfNeeded` resolves (rather than
+  // rejects) for terminal/transient outcomes, the slot also clears for those.
+  const pending = refreshGoogleSessionTokensIfNeeded(
+    userId,
+    account,
+    deps
+  ).finally(() => {
+    inflight.delete(key);
+  });
+  inflight.set(key, pending);
+  return pending;
+}
+
+/**
+ * Test-only escape hatch to clear the module-level cache between cases.
+ * NODE_ENV-gated so an accidental production call is a no-op.
+ */
+export function __resetSessionRefreshSingleflightCache(): void {
+  if (process.env.NODE_ENV === "production") return;
+  inflight.clear();
+}


### PR DESCRIPTION
Follow-up to the now-closed **#252**, reimplementing its singleflight concept on top of current `main` exactly as that PR's in-depth review ([`pullrequestreview-4453877881`](https://github.com/BenSeymourODB/next-digital-wall-calendar/pull/252#pullrequestreview-4453877881)) recommended.

## Why

The review confirmed that #252 was architecturally superseded by the PR #348 auth refactor — but that the underlying race it set out to fix is **still real on `main`**. `refreshGoogleSessionTokensIfNeeded` has no concurrent-call de-duplication: two simultaneous `auth()` invocations on an expired token both decrypt the same refresh token, both POST to `oauth2.googleapis.com/token`, and both `prisma.account.update` (the second clobbering the first). If Google rotates the refresh token, only one of the two new ciphertexts wins the write. Issue #216's first acceptance criterion ("5 concurrent expired-token requests → exactly one OAuth refresh hits the network") was not satisfied.

The review's recommendation: **close #252** (done) and **open a small follow-up** that adds singleflight as a thin wrapper around `refreshGoogleSessionTokensIfNeeded` on current `main`, rather than replacing it. This PR is that follow-up.

## What lands

### `src/lib/auth/token-refresh-singleflight.ts`

A module-level `Map<string, Promise<RefreshOutcome>>` keyed by `account.providerAccountId`. `getOrStartSessionRefresh(userId, account, deps)` returns the in-flight promise if one exists, otherwise calls the orchestrator and stores the pending promise with a `.finally()` that purges the slot on **both** success and failure (a transient outage must not pin the slot). A NODE_ENV-gated `__resetSessionRefreshSingleflightCache()` helper supports test isolation.

This is purely additive — all decrypt → fetch → re-encrypt → DB-write → classify behaviour stays in `refreshGoogleSessionTokensIfNeeded`, preserving encryption at rest (#215) and terminal/transient classification (#315).

### `src/lib/auth/auth.ts`

Single-line swap in the `session` callback: `await refreshGoogleSessionTokensIfNeeded(...)` → `await getOrStartSessionRefresh(...)`. All other behaviour (terminal-error sets `session.error = "RefreshTokenError"`) preserved.

### `src/lib/auth/__tests__/token-refresh-singleflight.test.ts`

The 8 tests from #252 ported to the wrapper, plus a `not-expired` short-circuit guard:

1. 5 concurrent same-account calls → exactly **1** refresh + **1** DB write.
2. 3 distinct `providerAccountId`s → 3 refreshes (different keys don't collapse).
3. All concurrent awaiters see the same outcome on a transient rejection.
4. Slot released after success → a later call refreshes again.
5. Slot released after transient failure → next call retries and succeeds.
6. `null` refresh_token → `terminal-error`; cache still purges (no pollution).
7. `TokenRefreshed` telemetry fires **exactly once** for collapsed callers.
8. Refresh error logged **exactly once** for collapsed callers.

Concurrency is forced with a deferred promise so all callers overlap on the same cache slot before any resolves.

### `.claude/plans/auth-token-refresh-singleflight-216.md`

Carried forward from #252 (~85% reused per the review), with the Phase-2 "wire into the session callback" section updated for the wrapper substitution.

## Out of scope (tracked separately)

- Idle-session timeout — #216 stays open to track that half.
- Unifying `/api/auth/refresh-token` with the queue — #285.
- Cross-process refresh dedupe for multi-instance deployments — #286.

## Test plan

- [x] `pnpm test:run src/lib/auth/__tests__/token-refresh-singleflight.test.ts` — **9 / 9 passing**
- [x] `pnpm test:run src/lib/auth/__tests__/` — **115 / 115 passing**
- [x] `pnpm lint:fix` — 0 errors (6 pre-existing warnings on unrelated files)
- [x] `pnpm format:fix` clean
- [x] `pnpm check-types` clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01MfDZnLi97zVN2mor9CnRWf)_