### PR TITLE
chore(calendar): PR #325 review follow-ups (#386)

### DIFF
--- a/.claude/plans/pr-325-followups-386.md
+++ b/.claude/plans/pr-325-followups-386.md
@@ -1,0 +1,109 @@
+# PR #325 Review Follow-ups (#386)
+
+## Summary
+
+Five observation-only findings surfaced during the PR #325 review. This plan delivers items 1, 2, 4, and 5; item 3 is deferred to the `#117 / #196` gapi-types retirement work.
+
+## Scope (in-session)
+
+### Item 5 — Delete dead `interface CalendarInfo` in calendars route test
+
+**File:** `src/app/api/calendar/calendars/__tests__/route.test.ts:45-56`
+
+The local interface is never referenced — the test file uses `CalendarsResponse` imported from `../route` for response parsing. Lint warning surfaces this on every touch.
+
+**Change:** delete lines 45-56 (interface + blank line). No tests change.
+
+### Item 4 — Unify validation-issues slice length
+
+**Files:**
+
+- `src/lib/google-calendar-schemas.ts:266` (constructor) — currently `.slice(0, 3)`
+- `src/app/api/calendar/events/route.ts:134` — currently `.slice(0, 5)`
+- `src/app/api/calendar/events/route.ts:609` — currently `.slice(0, 5)`
+- `src/app/api/calendar/calendars/route.ts` — uses `.slice(0, 5)` in the validation log path
+- `src/app/api/calendar/colors/route.ts` — uses `.slice(0, 5)` in the validation log path
+
+**Change:** add `export const VALIDATION_ISSUES_SUMMARY_COUNT = 5;` to `google-calendar-schemas.ts`. Update the constructor and all route callsites to use the const. The constructor's effective slice grows 3→5 — this is a string-message change only (no behaviour change in any code path that inspects `error.issues` directly), and aligns with the per-route structured log which is the dominant pattern.
+
+### Item 1 — Wire `GoogleApiErrorBodySchema` in via a typed helper
+
+**Files:**
+
+- `src/lib/google-calendar-schemas.ts` — add `parseGoogleErrorBody(unknown): GoogleApiErrorBody` helper.
+- `src/app/api/calendar/events/route.ts:110-115` — `fetchEventsFromCalendar` non-ok path.
+- `src/app/api/calendar/events/route.ts:671-677` — POST catch-all non-ok path.
+- `src/app/api/calendar/events/[id]/route.ts:130-137` — DELETE catch-all non-ok path.
+
+**Helper contract:** accepts arbitrary `unknown` (the `.json().catch(() => ({}))` result), runs `GoogleApiErrorBodySchema.safeParse`, and returns the parsed `GoogleApiErrorBody` on success or `{}` on failure. Never throws — the existing fallbacks (`?? "unknown"`, `|| "Failed to fetch events"`) preserve the current UX when Google sends garbage.
+
+**Why not throw on parse failure?** Routes already log the per-Google-status error and route off `response.status`; a malformed error body is a Google-side anomaly, not a route-handler failure mode. We want a soft fallback that closes the type-safety gap without changing observable behaviour.
+
+### Item 2 — Multi-calendar all-fail returns error status
+
+**File:** `src/app/api/calendar/events/route.ts:262-268`
+
+Today, the "all calendars failed" branch only fires when `calendarIds.length === 1`. A two-calendar request where both calendars fail returns 200 with `events: []` and a populated `errors[]` — a caller keying off the top-level status misses the failure entirely.
+
+**Change:** drop the `calendarIds.length === 1` guard. Unified logic:
+
+```ts
+if (errors.length === calendarIds.length && errors.length > 0) {
+  const statuses = errors.map((e) => e.status ?? 500);
+  const allSame = statuses.every((s) => s === statuses[0]);
+  return NextResponse.json(
+    { error: "Failed to fetch calendar events" },
+    { status: allSame ? statuses[0] : 502 }
+  );
+}
+```
+
+For single calendar, `statuses` has length 1, `allSame` is true, status is `statuses[0]` — identical to current behaviour, so the existing single-calendar 404/500/etc. tests remain green.
+
+For multi-calendar all-fail with the same Google status (e.g. both 502 from validation failure): returns 502.
+
+For multi-calendar all-fail with mixed statuses (one 404, one 502): returns 502, since the caller cannot generally pick one calendar's status as canonical.
+
+## Out of scope
+
+- **Item 3** — `event as gapi.client.calendar.Event` cast at the Zod/mapper boundary. Per the issue, this lives in the `#117 / #196` gapi-types retirement cluster. Touching it pulls in `lib/google-calendar.ts` and its callers, out of scope for a follow-up slice.
+
+## Test strategy (TDD)
+
+**Item 5:** no new tests; existing tests must stay green.
+
+**Item 4:** no new tests; existing `route.test.ts` and `google-calendar-schemas.test.ts` tests must stay green. The constructor's `Error.message` content is not asserted in any test today (confirmed via grep) so the 3→5 widening is safe.
+
+**Item 1:**
+
+- Add unit tests in `src/lib/__tests__/google-calendar-schemas.test.ts` for `parseGoogleErrorBody`:
+  - returns the parsed body on a canonical Google error envelope
+  - returns `{}` on completely unrelated shapes (`null`, `"string"`, `42`, `[]`)
+  - returns `{}` when `error` is the wrong type (string instead of object)
+  - returns the body unchanged when `error.message` is the only field
+- Existing route tests already exercise the consuming paths; they should pass unchanged because the helper preserves observable behaviour.
+
+**Item 2:**
+
+- Add tests to `src/app/api/calendar/events/__tests__/route.test.ts` under the existing multi-calendar `describe` block:
+  - 2 calendars, both fail with 502 (validation errors): returns 502 with the standard error body, errors[] still populated
+  - 2 calendars, both fail with mixed statuses (404 and 502): returns 502
+  - 2 calendars, both fail with the same status from Google (both 404): returns 404
+  - 1 calendar fail still returns its own status (existing test guarantees this; reaffirm)
+  - 2 calendars, one ok one fails: still 200 (existing partial-failure test guarantees this; reaffirm via the existing test passing)
+
+## Acceptance criteria mapping
+
+- [x] Item 1: helper added + wired (closes success/error validation asymmetry)
+- [x] Item 2: multi-calendar all-fail returns error status (route + test coverage)
+- [x] Item 4: single const for validation-issues slice length
+- [x] Item 5: dead interface deleted
+- [ ] Item 3: deferred — link in PR body to keep the tracking thread alive
+
+## Phases
+
+1. **Phase 1 (refactor):** items 4 + 5 — pure cleanup, no behaviour change.
+2. **Phase 2 (item 1):** `parseGoogleErrorBody` helper + wire into three route callsites. Tests first.
+3. **Phase 3 (item 2):** drop `calendarIds.length === 1` guard. Tests first.
+
+Each phase: `pnpm lint:fix && pnpm format:fix && pnpm check-types && pnpm test`, commit, push.

--- a/src/app/api/calendar/calendars/__tests__/route.test.ts
+++ b/src/app/api/calendar/calendars/__tests__/route.test.ts
@@ -42,19 +42,6 @@ vi.mock("@/lib/logger", () => ({
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
 
-// Type definitions for calendar list response
-interface CalendarInfo {
-  id: string;
-  summary: string;
-  summaryOverride?: string;
-  description?: string;
-  backgroundColor: string;
-  foregroundColor: string;
-  primary: boolean;
-  selected: boolean;
-  accessRole?: "freeBusyReader" | "reader" | "writer" | "owner";
-}
-
 describe("/api/calendar/calendars", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/app/api/calendar/calendars/route.ts
+++ b/src/app/api/calendar/calendars/route.ts
@@ -8,6 +8,7 @@ import {
   type GoogleCalendarListEntry,
   type GoogleCalendarListResponse,
   GoogleCalendarListResponseSchema,
+  VALIDATION_ISSUES_SUMMARY_COUNT,
   parseGoogleResponse,
 } from "@/lib/google-calendar-schemas";
 import { fetchWithRetry } from "@/lib/http/retry";
@@ -134,7 +135,7 @@ export async function GET() {
           endpoint: validationError.endpoint,
           userId: session.user.id,
           validationIssues: validationError.issues
-            .slice(0, 5)
+            .slice(0, VALIDATION_ISSUES_SUMMARY_COUNT)
             .map((i) => `${i.path.join(".") || "<root>"}: ${i.message}`)
             .join("; "),
         });

--- a/src/app/api/calendar/colors/route.ts
+++ b/src/app/api/calendar/colors/route.ts
@@ -9,6 +9,7 @@ import {
   type GoogleCalendarListEntry,
   type GoogleCalendarListResponse,
   GoogleCalendarListResponseSchema,
+  VALIDATION_ISSUES_SUMMARY_COUNT,
   parseGoogleResponse,
 } from "@/lib/google-calendar-schemas";
 import { fetchWithRetry } from "@/lib/http/retry";
@@ -104,7 +105,7 @@ export async function GET() {
           endpoint: validationError.endpoint,
           userId: session.user.id,
           validationIssues: validationError.issues
-            .slice(0, 5)
+            .slice(0, VALIDATION_ISSUES_SUMMARY_COUNT)
             .map((i) => `${i.path.join(".") || "<root>"}: ${i.message}`)
             .join("; "),
         });

--- a/src/app/api/calendar/events/[id]/route.ts
+++ b/src/app/api/calendar/events/[id]/route.ts
@@ -13,6 +13,7 @@
  * - `[id]`: the Google Calendar event id.
  */
 import { AuthError, getAccessToken, getSession } from "@/lib/auth";
+import { parseGoogleErrorBody } from "@/lib/google-calendar-schemas";
 import { fetchWithRetry } from "@/lib/http/retry";
 import { logger } from "@/lib/logger";
 import { NextRequest, NextResponse } from "next/server";
@@ -127,13 +128,15 @@ export async function DELETE(request: NextRequest, { params }: RouteContext) {
       return NextResponse.json({ error: "Event not found" }, { status: 404 });
     }
 
-    const errorBody = await response.json().catch(() => ({}));
+    const errorBody = parseGoogleErrorBody(
+      await response.json().catch(() => ({}))
+    );
     logger.error(new Error("Google Calendar delete failed"), {
       userId: session.user.id,
       calendarId,
       eventId,
       googleStatus: response.status,
-      googleError: errorBody?.error?.message ?? "unknown",
+      googleError: errorBody.error?.message ?? "unknown",
     });
 
     return NextResponse.json(

--- a/src/app/api/calendar/events/__tests__/route.test.ts
+++ b/src/app/api/calendar/events/__tests__/route.test.ts
@@ -598,6 +598,152 @@ describe("/api/calendar/events", () => {
         expect(status).toBe(200);
         expect(data.events[0].calendarId).toBe("primary");
       });
+
+      // Issue #386 item 2 — the original "all calendars failed" branch fired
+      // only when `calendarIds.length === 1`, so a multi-calendar all-fail
+      // request still returned 200 with empty events[] and a populated
+      // errors[]. A caller keying off the top-level status missed the
+      // failure entirely. Drop the single-calendar guard and surface an
+      // error status whenever every calendar in the request failed.
+      describe("multi-calendar all-fail returns an error status (#386 item 2)", () => {
+        it("returns the shared status when every calendar fails with the same Google status", async () => {
+          vi.mocked(getSession).mockResolvedValue(mockSession);
+          vi.mocked(getAccessToken).mockResolvedValue(
+            mockGoogleAccount.access_token!
+          );
+
+          // Both calendars 404 — the typical "two stale ids in the saved
+          // filter" scenario after a calendar share is revoked.
+          mockFetch
+            .mockResolvedValueOnce({
+              ok: false,
+              status: 404,
+              json: () => Promise.resolve({ error: "Calendar not found" }),
+            })
+            .mockResolvedValueOnce({
+              ok: false,
+              status: 404,
+              json: () => Promise.resolve({ error: "Calendar not found" }),
+            });
+
+          const request = createMockRequest(
+            "/api/calendar/events?calendarIds=stale-a%40group.calendar.google.com,stale-b%40group.calendar.google.com"
+          );
+          const response = await GET(request);
+          const { status, data } =
+            await parseResponse<ApiErrorResponse>(response);
+
+          expect(status).toBe(404);
+          expect(data.error).toBe("Failed to fetch calendar events");
+        });
+
+        it("returns 502 when every calendar fails with mixed Google statuses", async () => {
+          vi.mocked(getSession).mockResolvedValue(mockSession);
+          vi.mocked(getAccessToken).mockResolvedValue(
+            mockGoogleAccount.access_token!
+          );
+
+          // One 404 (stale id), one 502 (validation failure or upstream
+          // outage). The caller cannot generally pick one as canonical, so
+          // collapse to 502 — "we tried, nothing worked".
+          mockFetch
+            .mockResolvedValueOnce({
+              ok: false,
+              status: 404,
+              json: () => Promise.resolve({ error: "Calendar not found" }),
+            })
+            .mockResolvedValueOnce({
+              ok: true,
+              json: () =>
+                Promise.resolve({
+                  // Validation failure: missing required `id` on the event.
+                  items: [{ summary: "no id" }],
+                }),
+            });
+
+          const request = createMockRequest(
+            "/api/calendar/events?calendarIds=stale%40group.calendar.google.com,malformed%40group.calendar.google.com"
+          );
+          const response = await GET(request);
+          const { status, data } =
+            await parseResponse<ApiErrorResponse>(response);
+
+          expect(status).toBe(502);
+          expect(data.error).toBe("Failed to fetch calendar events");
+        });
+
+        it("returns 502 when every calendar fails with the same validation status", async () => {
+          vi.mocked(getSession).mockResolvedValue(mockSession);
+          vi.mocked(getAccessToken).mockResolvedValue(
+            mockGoogleAccount.access_token!
+          );
+
+          // Both calendars send malformed event lists (no `id`) — the
+          // "Google starts producing garbage across the whole calendar set"
+          // scenario the issue calls out.
+          mockFetch.mockResolvedValue({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                items: [{ summary: "no id" }],
+              }),
+          });
+
+          const request = createMockRequest(
+            "/api/calendar/events?calendarIds=cal-a%40group.calendar.google.com,cal-b%40group.calendar.google.com"
+          );
+          const response = await GET(request);
+          const { status, data } =
+            await parseResponse<ApiErrorResponse>(response);
+
+          expect(status).toBe(502);
+          expect(data.error).toBe("Failed to fetch calendar events");
+        });
+
+        it("still returns 200 for partial failure (one ok, one fails)", async () => {
+          vi.mocked(getSession).mockResolvedValue(mockSession);
+          vi.mocked(getAccessToken).mockResolvedValue(
+            mockGoogleAccount.access_token!
+          );
+
+          // Regression guard — the original partial-failure behaviour
+          // (events[] + errors[] + 200) must remain intact.
+          mockFetch
+            .mockResolvedValueOnce({
+              ok: true,
+              json: () =>
+                Promise.resolve({
+                  items: [
+                    {
+                      id: "evt-good",
+                      summary: "Good event",
+                      start: { dateTime: "2026-05-01T14:00:00Z" },
+                      end: { dateTime: "2026-05-01T15:00:00Z" },
+                    },
+                  ],
+                  summary: "Primary",
+                }),
+            })
+            .mockResolvedValueOnce({
+              ok: false,
+              status: 404,
+              json: () => Promise.resolve({ error: "Calendar not found" }),
+            });
+
+          const request = createMockRequest(
+            "/api/calendar/events?calendarIds=primary,stale%40group.calendar.google.com"
+          );
+          const response = await GET(request);
+          const { status, data } = await parseResponse<{
+            events: Array<{ id: string }>;
+            errors?: Array<{ calendarId: string; status?: number }>;
+          }>(response);
+
+          expect(status).toBe(200);
+          expect(data.events).toHaveLength(1);
+          expect(data.errors).toHaveLength(1);
+        });
+      });
     });
 
     describe("Zod validation of Google list responses (#277)", () => {

--- a/src/app/api/calendar/events/__tests__/route.test.ts
+++ b/src/app/api/calendar/events/__tests__/route.test.ts
@@ -613,17 +613,27 @@ describe("/api/calendar/events", () => {
           );
 
           // Both calendars 404 — the typical "two stale ids in the saved
-          // filter" scenario after a calendar share is revoked.
+          // filter" scenario after a calendar share is revoked. Mock body
+          // mirrors the real Google error envelope (`error.message` nested)
+          // so `parseGoogleErrorBody` exercises its happy path on the way
+          // through, not the empty-body fallback.
+          const notFoundBody = {
+            error: {
+              code: 404,
+              message: "Calendar not found",
+              status: "NOT_FOUND",
+            },
+          };
           mockFetch
             .mockResolvedValueOnce({
               ok: false,
               status: 404,
-              json: () => Promise.resolve({ error: "Calendar not found" }),
+              json: () => Promise.resolve(notFoundBody),
             })
             .mockResolvedValueOnce({
               ok: false,
               status: 404,
-              json: () => Promise.resolve({ error: "Calendar not found" }),
+              json: () => Promise.resolve(notFoundBody),
             });
 
           const request = createMockRequest(
@@ -643,14 +653,23 @@ describe("/api/calendar/events", () => {
             mockGoogleAccount.access_token!
           );
 
-          // One 404 (stale id), one 502 (validation failure or upstream
-          // outage). The caller cannot generally pick one as canonical, so
-          // collapse to 502 — "we tried, nothing worked".
+          // One 404 (stale id, HTTP-level failure), one 502 (Zod validation
+          // failure — `ok: true` body with missing required `id` maps to
+          // `status: 502` inside `fetchEventsFromCalendar`). The caller
+          // cannot generally pick one status as canonical, so we collapse
+          // to 502 — "we tried, nothing worked".
           mockFetch
             .mockResolvedValueOnce({
               ok: false,
               status: 404,
-              json: () => Promise.resolve({ error: "Calendar not found" }),
+              json: () =>
+                Promise.resolve({
+                  error: {
+                    code: 404,
+                    message: "Calendar not found",
+                    status: "NOT_FOUND",
+                  },
+                }),
             })
             .mockResolvedValueOnce({
               ok: true,

--- a/src/app/api/calendar/events/route.ts
+++ b/src/app/api/calendar/events/route.ts
@@ -270,9 +270,13 @@ export async function GET(request: NextRequest) {
     // collapse to 502 because we can't generally pick one as canonical.
     //
     // Single-calendar all-fail naturally falls through this branch with
-    // `statuses` of length 1, preserving the original 404/500/etc. wire
-    // behaviour. Issue #386 item 2.
-    if (errors.length === calendarIds.length && errors.length > 0) {
+    // `statuses` of length 1 (`every` is vacuously true), preserving the
+    // original 404/500/etc. wire behaviour. `calendarIds` is always
+    // non-empty by construction (`calendarIdsParam?.split(",")` yields a
+    // non-empty array if set, otherwise `[calendarId]` which defaults to
+    // `["primary"]`), so the `errors.length === calendarIds.length` check
+    // already implies a non-zero error count. Issue #386 item 2.
+    if (errors.length === calendarIds.length) {
       const statuses = errors.map((e) => e.status ?? 500);
       const allSame = statuses.every((s) => s === statuses[0]);
       return NextResponse.json(

--- a/src/app/api/calendar/events/route.ts
+++ b/src/app/api/calendar/events/route.ts
@@ -14,6 +14,8 @@ import {
   GoogleEventSchema,
   type GoogleEventsListResponse,
   GoogleEventsListResponseSchema,
+  VALIDATION_ISSUES_SUMMARY_COUNT,
+  parseGoogleErrorBody,
   parseGoogleResponse,
 } from "@/lib/google-calendar-schemas";
 import { fetchWithRetry } from "@/lib/http/retry";
@@ -107,7 +109,9 @@ async function fetchEventsFromCalendar(
   });
 
   if (!response.ok) {
-    const errorData = await response.json().catch(() => ({}));
+    const errorData = parseGoogleErrorBody(
+      await response.json().catch(() => ({}))
+    );
     return {
       events: [],
       error: {
@@ -131,7 +135,7 @@ async function fetchEventsFromCalendar(
         endpoint: error.endpoint,
         ...(error.calendarId ? { calendarId: error.calendarId } : {}),
         validationIssues: error.issues
-          .slice(0, 5)
+          .slice(0, VALIDATION_ISSUES_SUMMARY_COUNT)
           .map((i) => `${i.path.join(".") || "<root>"}: ${i.message}`)
           .join("; "),
       });
@@ -259,11 +263,21 @@ export async function GET(request: NextRequest) {
       }
     }
 
-    // If ALL calendars failed (and not auth errors), return error
-    if (errors.length === calendarIds.length && calendarIds.length === 1) {
+    // If every calendar in the request failed (and none were auth errors —
+    // those bail out earlier with a 401), surface an error status so a
+    // caller keying off the top-level status sees the failure. When the
+    // per-calendar statuses agree, use that shared status; mixed statuses
+    // collapse to 502 because we can't generally pick one as canonical.
+    //
+    // Single-calendar all-fail naturally falls through this branch with
+    // `statuses` of length 1, preserving the original 404/500/etc. wire
+    // behaviour. Issue #386 item 2.
+    if (errors.length === calendarIds.length && errors.length > 0) {
+      const statuses = errors.map((e) => e.status ?? 500);
+      const allSame = statuses.every((s) => s === statuses[0]);
       return NextResponse.json(
         { error: "Failed to fetch calendar events" },
-        { status: errors[0].status || 500 }
+        { status: allSame ? statuses[0] : 502 }
       );
     }
 
@@ -606,7 +620,7 @@ export async function POST(request: NextRequest) {
               : {}),
             userId: session.user.id,
             validationIssues: validationError.issues
-              .slice(0, 5)
+              .slice(0, VALIDATION_ISSUES_SUMMARY_COUNT)
               .map((i) => `${i.path.join(".") || "<root>"}: ${i.message}`)
               .join("; "),
           });
@@ -668,12 +682,14 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const errorBody = await response.json().catch(() => ({}));
+    const errorBody = parseGoogleErrorBody(
+      await response.json().catch(() => ({}))
+    );
     logger.error(new Error("Google Calendar create failed"), {
       userId: session.user.id,
       calendarId: event.calendarId,
       googleStatus: response.status,
-      googleError: errorBody?.error?.message ?? "unknown",
+      googleError: errorBody.error?.message ?? "unknown",
     });
 
     return NextResponse.json(

--- a/src/lib/__tests__/google-calendar-schemas.test.ts
+++ b/src/lib/__tests__/google-calendar-schemas.test.ts
@@ -13,6 +13,7 @@ import {
   GoogleCalendarListResponseSchema,
   GoogleEventSchema,
   GoogleEventsListResponseSchema,
+  parseGoogleErrorBody,
   parseGoogleResponse,
 } from "../google-calendar-schemas";
 
@@ -214,6 +215,59 @@ describe("GoogleApiErrorBodySchema", () => {
       error: { message: "Forbidden" },
     });
     expect(result.success).toBe(true);
+  });
+});
+
+describe("parseGoogleErrorBody", () => {
+  it("returns the parsed body on a canonical Google error envelope", () => {
+    const parsed = parseGoogleErrorBody({
+      error: {
+        code: 404,
+        message: "Calendar not found",
+        status: "NOT_FOUND",
+      },
+    });
+    expect(parsed.error?.message).toBe("Calendar not found");
+    expect(parsed.error?.code).toBe(404);
+    expect(parsed.error?.status).toBe("NOT_FOUND");
+  });
+
+  it("returns the body unchanged when error.message is the only field present", () => {
+    const parsed = parseGoogleErrorBody({ error: { message: "Forbidden" } });
+    expect(parsed.error?.message).toBe("Forbidden");
+  });
+
+  it("returns an empty object for an empty body (mirrors `.catch(() => ({}))` fallback)", () => {
+    const parsed = parseGoogleErrorBody({});
+    expect(parsed.error).toBeUndefined();
+  });
+
+  it("returns an empty object when the input is null", () => {
+    expect(parseGoogleErrorBody(null)).toEqual({});
+  });
+
+  it("returns an empty object when the input is a non-object primitive", () => {
+    expect(parseGoogleErrorBody("not a body")).toEqual({});
+    expect(parseGoogleErrorBody(42)).toEqual({});
+    expect(parseGoogleErrorBody(true)).toEqual({});
+  });
+
+  it("returns an empty object when the input is an array", () => {
+    expect(parseGoogleErrorBody([])).toEqual({});
+    expect(parseGoogleErrorBody([{ error: "wrong shape" }])).toEqual({});
+  });
+
+  it("returns an empty object when `error` is the wrong type", () => {
+    expect(parseGoogleErrorBody({ error: "string instead of object" })).toEqual(
+      {}
+    );
+  });
+
+  it("never throws — soft-fails to {} so route fallback chains stay intact", () => {
+    expect(() => parseGoogleErrorBody(undefined)).not.toThrow();
+    expect(() =>
+      parseGoogleErrorBody({ error: { code: "not a number" } })
+    ).not.toThrow();
   });
 });
 

--- a/src/lib/google-calendar-schemas.ts
+++ b/src/lib/google-calendar-schemas.ts
@@ -240,6 +240,14 @@ export const GoogleApiErrorBodySchema = z
 export type GoogleApiErrorBody = z.infer<typeof GoogleApiErrorBodySchema>;
 
 /**
+ * Maximum number of Zod issues to include when summarising a validation
+ * failure. Used both in the human-readable {@link GoogleApiValidationError}
+ * message and in the structured `validationIssues` log field every route
+ * emits, so the count stays consistent across the two surfaces.
+ */
+export const VALIDATION_ISSUES_SUMMARY_COUNT = 5;
+
+/**
  * Context for a {@link GoogleApiValidationError} so route logging has enough
  * information to triage which Google endpoint produced the malformed
  * payload.
@@ -263,7 +271,7 @@ export class GoogleApiValidationError extends Error {
 
   constructor(context: GoogleApiValidationContext, issues: z.core.$ZodIssue[]) {
     const summary = issues
-      .slice(0, 3)
+      .slice(0, VALIDATION_ISSUES_SUMMARY_COUNT)
       .map((i) => `${i.path.join(".") || "<root>"}: ${i.message}`)
       .join("; ");
     super(
@@ -274,6 +282,31 @@ export class GoogleApiValidationError extends Error {
     this.calendarId = context.calendarId;
     this.issues = issues;
   }
+}
+
+/**
+ * Soft-parse a Google API error response body. Used at the route-handler
+ * boundary on non-2xx responses, where the existing pattern is:
+ *
+ *     const errorData = await response.json().catch(() => ({}));
+ *     const msg = errorData.error?.message ?? "...";
+ *
+ * That access path is safe at runtime but bypasses
+ * {@link GoogleApiErrorBodySchema}. This helper restores type safety
+ * without changing observable behaviour: it returns the parsed body on a
+ * canonical Google error envelope and `{}` on anything else — `null`,
+ * primitives, arrays, wrong-typed `error` field, etc. It never throws, so
+ * existing fallbacks (`?? "unknown"`, `|| "Failed to fetch events"`)
+ * continue to do their job when Google sends a degenerate body.
+ *
+ * Why soft-fail and not throw? Routes already key off `response.status` to
+ * choose the wire response, and the body is only used for human-readable
+ * detail in the log line. A malformed body is a Google-side anomaly, not
+ * a route-handler failure mode worth a 502.
+ */
+export function parseGoogleErrorBody(data: unknown): GoogleApiErrorBody {
+  const result = GoogleApiErrorBodySchema.safeParse(data);
+  return result.success ? result.data : {};
 }
 
 /**


### PR DESCRIPTION
## Summary

Delivers items 1, 2, 4, 5 from #386. Item 3 (the `gapi.client.calendar.Event` cast at the Zod/mapper boundary) is deferred to a new tracking issue (#403) — it's a wider refactor than this follow-up slice can fit.

- **Item 1 — `parseGoogleErrorBody` helper wired in.** Adds a soft-failing `parseGoogleErrorBody(unknown): GoogleApiErrorBody` helper to `google-calendar-schemas.ts` and uses it at the three error-body access sites (`events/route.ts` fetcher + POST, `events/[id]/route.ts` DELETE). The helper returns the parsed envelope on a canonical Google error body and `{}` on anything else — never throws, so existing fallbacks (`?? "unknown"`, `|| "Failed to fetch events"`) keep the current UX intact when Google sends garbage.
- **Item 2 — multi-calendar all-fail returns an error status.** Drops the `calendarIds.length === 1` guard so a request that fails on every calendar surfaces a non-2xx status: the shared per-calendar status when they all agree, else 502. Single-calendar all-fail still returns its own status (1-element `statuses` array → `allSame === true` vacuously).
- **Item 4 — single const for validation-issues slice length.** Extracts `export const VALIDATION_ISSUES_SUMMARY_COUNT = 5` from `google-calendar-schemas.ts` and reuses it across the `GoogleApiValidationError` constructor and the four route logger callsites (`events/route.ts` x2, `calendars/route.ts`, `colors/route.ts`).
- **Item 5 — deletes the dead `interface CalendarInfo`** in the calendars route test — the file uses `CalendarsResponse` imported from `../route` for response parsing.

## Plan

Linked plan: [`.claude/plans/pr-325-followups-386.md`](https://github.com/BenSeymourODB/next-digital-wall-calendar/blob/claude/stoic-mayer-r9dqfi/.claude/plans/pr-325-followups-386.md)
Project: https://github.com/users/BenSeymourODB/projects/1

## Test plan

- [x] `pnpm lint:fix` — 0 errors (5 pre-existing warnings unrelated)
- [x] `pnpm format:fix` — clean
- [x] `pnpm check-types` — clean
- [x] `pnpm test` — 2533 / 2533 (was 2521 + 12 new)
- [x] 8 new unit tests for `parseGoogleErrorBody` (canonical body, empty body, `null` / primitive / array inputs, wrong-typed `error` field, never-throws contract)
- [x] 4 new route tests for multi-calendar all-fail (shared status, mixed → 502, all-validation-failure → 502, partial-failure regression guard)

## Deferred

- **Item 3** (drop `gapi.client.calendar.Event` cast at the Zod/mapper boundary) — tracked in #403. The cast lives in `events/route.ts:158` and `:622`; resolving it touches `lib/google-calendar.ts` and its callers, out of scope for a follow-up slice.

## First-pass review

First-pass review by Sonnet subagent found 3 findings (2 nits + 1 test-realism gap). All addressed in the second commit (`chore(calendar): apply first-pass review fixes (#386)`):

- Dropped the redundant `errors.length > 0` guard in the all-fail branch (`calendarIds` is non-empty by construction).
- Fixed the "shared status" test mock body to use the canonical Google error envelope (`{ error: { code, message, status } }`) so `parseGoogleErrorBody` exercises its happy path on the way through.
- Clarified the inline comment on the mixed-status test to spell out why `ok: true` on the second mock represents a 502 (Zod validation failure).

Closes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)