### PR TITLE
chore(calendar): PR #325 review follow-ups — items 1, 2, 4, 5 (#386)

### DIFF
--- a/.claude/plans/pr-325-followups-386.md
+++ b/.claude/plans/pr-325-followups-386.md
@@ -62,7 +62,9 @@ helper falls back to `{}` so callers keep their `?.error?.message ?? "..."`
 ladder; the only behaviour change is that the read goes through a parsed,
 typed envelope instead of a raw cast.
 
-Replace the four sites:
+Replace the three error-body access sites in the events routes (the
+`calendars` and `colors` routes log the raw `errorData` as a structured
+blob rather than reading `.error.message`, so they're not in scope):
 
 | File                                        | Line    | Pattern today                                                 |
 | ------------------------------------------- | ------- | ------------------------------------------------------------- |

--- a/.claude/plans/pr-325-followups-386.md
+++ b/.claude/plans/pr-325-followups-386.md
@@ -1,0 +1,127 @@
+# Plan: PR #325 follow-ups (#386)
+
+Issue: https://github.com/BenSeymourODB/next-digital-wall-calendar/issues/386
+
+Five observation-only findings surfaced during the in-depth review of PR #325.
+This slice picks up items **1, 2, 4, 5**. Item 3 is deferred (out of scope —
+bundled with the `gapi.client.calendar.*` retirement under #117 / #196).
+
+## Phases
+
+### Phase 1 — cleanup (item 5 + item 4)
+
+Two small, mechanical changes; no behaviour change. Land them first so the
+later phases ship against the cleaner baseline.
+
+- **Item 5**: delete `interface CalendarInfo` at
+  `src/app/api/calendar/calendars/__tests__/route.test.ts:45-56`. The file
+  already imports `CalendarsResponse` from the route module and uses it for
+  response parsing (lines 131, 179, 210, 228). The local copy is dead and
+  surfaces as the only unused-vars lint warning on a file PR #325 touched.
+
+- **Item 4**: define a single `VALIDATION_ISSUES_SUMMARY_COUNT` const in
+  `src/lib/google-calendar-schemas.ts`. The constructor uses `.slice(0, 3)`;
+  the four route loggers use `.slice(0, 5)`. The divergence has no rationale.
+  Standardise on **5** — it matches 4 callsites vs 1, and 5 issues still fits
+  the Error-message summary at the schema constructor. Export the const so
+  routes share the same source of truth.
+
+  Files to update:
+  - `src/lib/google-calendar-schemas.ts` (constructor — replace `3` with the const)
+  - `src/app/api/calendar/events/route.ts` (two sites: GET `:134`, POST `:609`)
+  - `src/app/api/calendar/calendars/route.ts` (`:137`)
+  - `src/app/api/calendar/colors/route.ts` (`:107`)
+
+  No new tests needed — existing tests already cover the validation-failure
+  log shape, and the const change preserves the behaviour they assert.
+
+### Phase 2 — wire Zod error-body parsing (item 1)
+
+`GoogleApiErrorBodySchema` is exported and unit-tested (`google-calendar-schemas.test.ts:192-218`)
+but no route uses it. Every error-body access today is the raw
+`errorData.error?.message || ...` pattern.
+
+Approach: option **(a)** from the issue — wire it in via a typed helper so
+the success/error-body validation asymmetry closes. The schema already
+accepts empty `{}` so existing `.catch(() => ({}))` fallback shapes remain
+valid input.
+
+Add to `src/lib/google-calendar-schemas.ts`:
+
+```ts
+export function parseGoogleErrorBody(data: unknown): GoogleApiErrorBody {
+  const result = GoogleApiErrorBodySchema.safeParse(data);
+  return result.success ? result.data : {};
+}
+```
+
+Failure mode is deliberately quiet: a malformed Google error body is not a
+loggable Google-API contract break (the canonical error envelope is
+documented but the route handlers already tolerate missing fields). The
+helper falls back to `{}` so callers keep their `?.error?.message ?? "..."`
+ladder; the only behaviour change is that the read goes through a parsed,
+typed envelope instead of a raw cast.
+
+Replace the four sites:
+
+| File                                        | Line    | Pattern today                                                 |
+| ------------------------------------------- | ------- | ------------------------------------------------------------- |
+| `src/app/api/calendar/events/route.ts`      | 110-118 | `await response.json().catch(() => ({}))` → `.error?.message` |
+| `src/app/api/calendar/events/route.ts`      | 671-677 | same shape, POST path                                         |
+| `src/app/api/calendar/events/[id]/route.ts` | 130-137 | same shape, DELETE path                                       |
+
+Tests:
+
+- New unit tests on `parseGoogleErrorBody` in `google-calendar-schemas.test.ts`:
+  - returns `{}` on `null`, `undefined`, primitive, array
+  - returns the parsed body when it matches the schema
+  - returns `{}` when the body has the wrong shape (so callers fall through to their string fallback)
+- Existing route tests pass unchanged — the user-visible `errorData.error?.message`
+  fallback behaviour is preserved.
+
+### Phase 3 — multi-calendar all-fail returns error status (item 2)
+
+Today at `src/app/api/calendar/events/route.ts:262-268`:
+
+```ts
+if (errors.length === calendarIds.length && calendarIds.length === 1) {
+  return NextResponse.json(
+    { error: "Failed to fetch calendar events" },
+    { status: errors[0].status || 500 }
+  );
+}
+```
+
+The `calendarIds.length === 1` guard means a 2-calendar request where both
+fail returns 200 with `events: []` and a populated `errors[]`. Drop the
+guard. Pick the response status as:
+
+- All failures share the same status → return that status.
+- Mixed statuses → return **502** (proxy-style "upstream failures").
+
+Auth errors (401) already trigger an early return at line 227-238, so the
+all-fail path will never see a 401.
+
+Test cases to add to `events/__tests__/route.test.ts`:
+
+1. Two-calendar request, both fail with 404 → response status **404**,
+   `errors[]` lists both, `events[]` is empty.
+2. Two-calendar request, mixed 404 + 502 → response status **502**.
+3. Two-calendar request, one fails / one succeeds → still 200 (unchanged
+   partial-failure semantics).
+4. Single-calendar request, fails → still bubbles the per-calendar status
+   (unchanged path).
+
+## Commits / push cadence
+
+Each phase commits and pushes separately. First push opens the draft PR;
+subsequent pushes update it.
+
+## Out of scope (this slice)
+
+- **Item 3** (`event as gapi.client.calendar.Event` cast at the mapper
+  boundary) — needs `normalizeFetchedEvent` and `GoogleCalendarEvent` to be
+  retyped onto `GoogleEventPayload` rather than the `gapi.client.calendar.*`
+  ambient types. That ripples into the legacy `lib/google-calendar.ts`
+  client-side callers (also typed against gapi) and belongs with the wider
+  gapi retirement under #117 / #196.

--- a/src/app/api/calendar/calendars/__tests__/route.test.ts
+++ b/src/app/api/calendar/calendars/__tests__/route.test.ts
@@ -42,19 +42,6 @@ vi.mock("@/lib/logger", () => ({
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
 
-// Type definitions for calendar list response
-interface CalendarInfo {
-  id: string;
-  summary: string;
-  summaryOverride?: string;
-  description?: string;
-  backgroundColor: string;
-  foregroundColor: string;
-  primary: boolean;
-  selected: boolean;
-  accessRole?: "freeBusyReader" | "reader" | "writer" | "owner";
-}
-
 describe("/api/calendar/calendars", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/app/api/calendar/calendars/route.ts
+++ b/src/app/api/calendar/calendars/route.ts
@@ -8,6 +8,7 @@ import {
   type GoogleCalendarListEntry,
   type GoogleCalendarListResponse,
   GoogleCalendarListResponseSchema,
+  VALIDATION_ISSUES_SUMMARY_COUNT,
   parseGoogleResponse,
 } from "@/lib/google-calendar-schemas";
 import { fetchWithRetry } from "@/lib/http/retry";
@@ -134,7 +135,7 @@ export async function GET() {
           endpoint: validationError.endpoint,
           userId: session.user.id,
           validationIssues: validationError.issues
-            .slice(0, 5)
+            .slice(0, VALIDATION_ISSUES_SUMMARY_COUNT)
             .map((i) => `${i.path.join(".") || "<root>"}: ${i.message}`)
             .join("; "),
         });

--- a/src/app/api/calendar/colors/route.ts
+++ b/src/app/api/calendar/colors/route.ts
@@ -9,6 +9,7 @@ import {
   type GoogleCalendarListEntry,
   type GoogleCalendarListResponse,
   GoogleCalendarListResponseSchema,
+  VALIDATION_ISSUES_SUMMARY_COUNT,
   parseGoogleResponse,
 } from "@/lib/google-calendar-schemas";
 import { fetchWithRetry } from "@/lib/http/retry";
@@ -104,7 +105,7 @@ export async function GET() {
           endpoint: validationError.endpoint,
           userId: session.user.id,
           validationIssues: validationError.issues
-            .slice(0, 5)
+            .slice(0, VALIDATION_ISSUES_SUMMARY_COUNT)
             .map((i) => `${i.path.join(".") || "<root>"}: ${i.message}`)
             .join("; "),
         });

--- a/src/app/api/calendar/events/[id]/route.ts
+++ b/src/app/api/calendar/events/[id]/route.ts
@@ -13,6 +13,7 @@
  * - `[id]`: the Google Calendar event id.
  */
 import { AuthError, getAccessToken, getSession } from "@/lib/auth";
+import { parseGoogleErrorBody } from "@/lib/google-calendar-schemas";
 import { fetchWithRetry } from "@/lib/http/retry";
 import { logger } from "@/lib/logger";
 import { NextRequest, NextResponse } from "next/server";
@@ -127,13 +128,15 @@ export async function DELETE(request: NextRequest, { params }: RouteContext) {
       return NextResponse.json({ error: "Event not found" }, { status: 404 });
     }
 
-    const errorBody = await response.json().catch(() => ({}));
+    const errorBody = parseGoogleErrorBody(
+      await response.json().catch(() => ({}))
+    );
     logger.error(new Error("Google Calendar delete failed"), {
       userId: session.user.id,
       calendarId,
       eventId,
       googleStatus: response.status,
-      googleError: errorBody?.error?.message ?? "unknown",
+      googleError: errorBody.error?.message ?? "unknown",
     });
 
     return NextResponse.json(

--- a/src/app/api/calendar/events/__tests__/route.test.ts
+++ b/src/app/api/calendar/events/__tests__/route.test.ts
@@ -541,6 +541,135 @@ describe("/api/calendar/events", () => {
         );
       });
 
+      // #386 item 2 — when every calendar in a multi-calendar request fails
+      // (non-auth), the route used to return 200 with `events: []` and a
+      // populated `errors[]` because the all-fail short-circuit was gated on
+      // `calendarIds.length === 1`. Dropping that guard means a UI consumer
+      // can key off the top-level status without inspecting `errors[]`.
+      it("returns the shared per-calendar status when every calendar fails with the same status", async () => {
+        vi.mocked(getSession).mockResolvedValue(mockSession);
+        vi.mocked(getAccessToken).mockResolvedValue(
+          mockGoogleAccount.access_token!
+        );
+
+        // Both calendars 404 — the wire response should be 404, not 200.
+        mockFetch
+          .mockResolvedValueOnce({
+            ok: false,
+            status: 404,
+            json: () =>
+              Promise.resolve({ error: { message: "Calendar not found" } }),
+          })
+          .mockResolvedValueOnce({
+            ok: false,
+            status: 404,
+            json: () =>
+              Promise.resolve({ error: { message: "Calendar not found" } }),
+          });
+
+        const request = createMockRequest(
+          "/api/calendar/events?calendarIds=missing-1%40group.calendar.google.com,missing-2%40group.calendar.google.com"
+        );
+        const response = await GET(request);
+        const { status, data } = await parseResponse<{
+          events: unknown[];
+          errors?: Array<{ calendarId: string; status?: number }>;
+          error?: string;
+        }>(response);
+
+        expect(status).toBe(404);
+        expect(data.error).toMatch(/calendar/i);
+        expect(data.events).toEqual([]);
+        // The all-fail body still lists per-calendar context so the UI can
+        // show which calendars failed and why.
+        expect(data.errors).toHaveLength(2);
+        expect(data.errors![0].calendarId).toBe(
+          "missing-1@group.calendar.google.com"
+        );
+        expect(data.errors![1].calendarId).toBe(
+          "missing-2@group.calendar.google.com"
+        );
+      });
+
+      it("returns 502 when multi-calendar failures have mixed statuses", async () => {
+        vi.mocked(getSession).mockResolvedValue(mockSession);
+        vi.mocked(getAccessToken).mockResolvedValue(
+          mockGoogleAccount.access_token!
+        );
+
+        // One 404, one 403 — both non-transient (so `fetchWithRetry` won't
+        // consume extra mocks). Mixed statuses collapse to a 502 "upstream
+        // failures" status (proxy-style) rather than picking one arbitrarily.
+        mockFetch
+          .mockResolvedValueOnce({
+            ok: false,
+            status: 404,
+            json: () =>
+              Promise.resolve({ error: { message: "Calendar not found" } }),
+          })
+          .mockResolvedValueOnce({
+            ok: false,
+            status: 403,
+            json: () => Promise.resolve({ error: { message: "Forbidden" } }),
+          });
+
+        const request = createMockRequest(
+          "/api/calendar/events?calendarIds=cal-a%40group.calendar.google.com,cal-b%40group.calendar.google.com"
+        );
+        const response = await GET(request);
+        const { status, data } = await parseResponse<{
+          events: unknown[];
+          errors?: Array<{ calendarId: string; status?: number }>;
+          error?: string;
+        }>(response);
+
+        expect(status).toBe(502);
+        expect(data.events).toEqual([]);
+        expect(data.errors).toHaveLength(2);
+      });
+
+      it("keeps 200 partial-failure semantics when one calendar succeeds and another fails", async () => {
+        vi.mocked(getSession).mockResolvedValue(mockSession);
+        vi.mocked(getAccessToken).mockResolvedValue(
+          mockGoogleAccount.access_token!
+        );
+
+        mockFetch
+          .mockResolvedValueOnce({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                items: [
+                  {
+                    id: "evt-1",
+                    summary: "Good event",
+                    start: { dateTime: "2026-05-01T14:00:00Z" },
+                    end: { dateTime: "2026-05-01T15:00:00Z" },
+                  },
+                ],
+              }),
+          })
+          .mockResolvedValueOnce({
+            ok: false,
+            status: 404,
+            json: () =>
+              Promise.resolve({ error: { message: "Calendar not found" } }),
+          });
+
+        const request = createMockRequest(
+          "/api/calendar/events?calendarIds=primary,missing%40group.calendar.google.com"
+        );
+        const response = await GET(request);
+        const { status, data } = await parseResponse<{
+          events: Array<{ id: string }>;
+          errors?: Array<{ calendarId: string }>;
+        }>(response);
+
+        expect(status).toBe(200);
+        expect(data.events).toHaveLength(1);
+        expect(data.errors).toHaveLength(1);
+      });
+
       it("falls back to single calendarId when calendarIds not provided", async () => {
         vi.mocked(getSession).mockResolvedValue(mockSession);
         vi.mocked(getAccessToken).mockResolvedValue(

--- a/src/app/api/calendar/events/route.ts
+++ b/src/app/api/calendar/events/route.ts
@@ -77,6 +77,20 @@ function toWireFetchError(e: InternalCalendarFetchError): CalendarFetchError {
 }
 
 /**
+ * Pick the HTTP status to return when every calendar in a multi-calendar
+ * GET failed. If all per-calendar statuses agree, bubble that status. On
+ * mixed statuses, collapse to a 502 — proxy-style "upstream failures" that
+ * signals the overall request couldn't be served without claiming any
+ * single upstream status as canonical. Auth (401) errors short-circuit the
+ * outer handler so they never reach this function.
+ */
+function resolveAllFailStatus(errors: InternalCalendarFetchError[]): number {
+  if (errors.length === 0) return 500;
+  const first = errors[0].status ?? 500;
+  return errors.every((e) => (e.status ?? 500) === first) ? first : 502;
+}
+
+/**
  * Fetch events from a single calendar
  */
 async function fetchEventsFromCalendar(
@@ -263,11 +277,19 @@ export async function GET(request: NextRequest) {
       }
     }
 
-    // If ALL calendars failed (and not auth errors), return error
-    if (errors.length === calendarIds.length && calendarIds.length === 1) {
+    // If ALL calendars failed (and not auth errors — those early-returned
+    // above), surface an error status so the UI can react to the top-level
+    // status without inspecting `errors[]`. Pre-#386 this was gated on
+    // `calendarIds.length === 1` and multi-calendar all-fail leaked a 200
+    // with an empty events array.
+    if (errors.length === calendarIds.length) {
       return NextResponse.json(
-        { error: "Failed to fetch calendar events" },
-        { status: errors[0].status || 500 }
+        {
+          error: "Failed to fetch calendar events",
+          events: [],
+          errors: errors.map(toWireFetchError),
+        },
+        { status: resolveAllFailStatus(errors) }
       );
     }
 

--- a/src/app/api/calendar/events/route.ts
+++ b/src/app/api/calendar/events/route.ts
@@ -15,6 +15,7 @@ import {
   type GoogleEventsListResponse,
   GoogleEventsListResponseSchema,
   VALIDATION_ISSUES_SUMMARY_COUNT,
+  parseGoogleErrorBody,
   parseGoogleResponse,
 } from "@/lib/google-calendar-schemas";
 import { fetchWithRetry } from "@/lib/http/retry";
@@ -108,12 +109,14 @@ async function fetchEventsFromCalendar(
   });
 
   if (!response.ok) {
-    const errorData = await response.json().catch(() => ({}));
+    const errorBody = parseGoogleErrorBody(
+      await response.json().catch(() => ({}))
+    );
     return {
       events: [],
       error: {
         calendarId,
-        error: errorData.error?.message || "Failed to fetch events",
+        error: errorBody.error?.message || "Failed to fetch events",
         status: response.status,
       },
     };
@@ -669,12 +672,14 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const errorBody = await response.json().catch(() => ({}));
+    const errorBody = parseGoogleErrorBody(
+      await response.json().catch(() => ({}))
+    );
     logger.error(new Error("Google Calendar create failed"), {
       userId: session.user.id,
       calendarId: event.calendarId,
       googleStatus: response.status,
-      googleError: errorBody?.error?.message ?? "unknown",
+      googleError: errorBody.error?.message ?? "unknown",
     });
 
     return NextResponse.json(

--- a/src/app/api/calendar/events/route.ts
+++ b/src/app/api/calendar/events/route.ts
@@ -14,6 +14,7 @@ import {
   GoogleEventSchema,
   type GoogleEventsListResponse,
   GoogleEventsListResponseSchema,
+  VALIDATION_ISSUES_SUMMARY_COUNT,
   parseGoogleResponse,
 } from "@/lib/google-calendar-schemas";
 import { fetchWithRetry } from "@/lib/http/retry";
@@ -131,7 +132,7 @@ async function fetchEventsFromCalendar(
         endpoint: error.endpoint,
         ...(error.calendarId ? { calendarId: error.calendarId } : {}),
         validationIssues: error.issues
-          .slice(0, 5)
+          .slice(0, VALIDATION_ISSUES_SUMMARY_COUNT)
           .map((i) => `${i.path.join(".") || "<root>"}: ${i.message}`)
           .join("; "),
       });
@@ -606,7 +607,7 @@ export async function POST(request: NextRequest) {
               : {}),
             userId: session.user.id,
             validationIssues: validationError.issues
-              .slice(0, 5)
+              .slice(0, VALIDATION_ISSUES_SUMMARY_COUNT)
               .map((i) => `${i.path.join(".") || "<root>"}: ${i.message}`)
               .join("; "),
           });

--- a/src/app/api/calendar/events/route.ts
+++ b/src/app/api/calendar/events/route.ts
@@ -82,10 +82,10 @@ function toWireFetchError(e: InternalCalendarFetchError): CalendarFetchError {
  * mixed statuses, collapse to a 502 — proxy-style "upstream failures" that
  * signals the overall request couldn't be served without claiming any
  * single upstream status as canonical. Auth (401) errors short-circuit the
- * outer handler so they never reach this function.
+ * outer handler so they never reach this function. The caller's guard
+ * (`errors.length === calendarIds.length`) ensures `errors` is non-empty.
  */
 function resolveAllFailStatus(errors: InternalCalendarFetchError[]): number {
-  if (errors.length === 0) return 500;
   const first = errors[0].status ?? 500;
   return errors.every((e) => (e.status ?? 500) === first) ? first : 502;
 }

--- a/src/lib/__tests__/google-calendar-schemas.test.ts
+++ b/src/lib/__tests__/google-calendar-schemas.test.ts
@@ -13,6 +13,7 @@ import {
   GoogleCalendarListResponseSchema,
   GoogleEventSchema,
   GoogleEventsListResponseSchema,
+  parseGoogleErrorBody,
   parseGoogleResponse,
 } from "../google-calendar-schemas";
 
@@ -214,6 +215,60 @@ describe("GoogleApiErrorBodySchema", () => {
       error: { message: "Forbidden" },
     });
     expect(result.success).toBe(true);
+  });
+});
+
+describe("parseGoogleErrorBody", () => {
+  // #386 item 1 — `GoogleApiErrorBodySchema` was added in PR #233 but no route
+  // wired it in. `parseGoogleErrorBody` closes the success/error validation
+  // asymmetry: it always returns a typed `GoogleApiErrorBody`, falling back to
+  // `{}` so existing `?.error?.message ?? "..."` ladders keep working.
+
+  it("returns the parsed body when it matches the canonical Google envelope", () => {
+    const body = parseGoogleErrorBody({
+      error: {
+        code: 404,
+        message: "Calendar not found",
+        status: "NOT_FOUND",
+      },
+    });
+    expect(body.error?.message).toBe("Calendar not found");
+    expect(body.error?.code).toBe(404);
+  });
+
+  it("returns an empty body when input is null", () => {
+    expect(parseGoogleErrorBody(null)).toEqual({});
+  });
+
+  it("returns an empty body when input is undefined", () => {
+    expect(parseGoogleErrorBody(undefined)).toEqual({});
+  });
+
+  it("returns an empty body when input is a primitive", () => {
+    expect(parseGoogleErrorBody("not an object")).toEqual({});
+    expect(parseGoogleErrorBody(42)).toEqual({});
+    expect(parseGoogleErrorBody(true)).toEqual({});
+  });
+
+  it("returns an empty body when input is an array", () => {
+    expect(parseGoogleErrorBody(["a", "b"])).toEqual({});
+  });
+
+  it("returns an empty body when error is a string (wrong shape)", () => {
+    // Some malformed proxies return `{ error: "not an object" }`. The schema
+    // expects `error` to be an object envelope; on mismatch we want
+    // `parseGoogleErrorBody` to fall back to `{}` rather than surface a typed
+    // `error` field that doesn't match the documented shape.
+    expect(parseGoogleErrorBody({ error: "not an object" })).toEqual({});
+  });
+
+  it("accepts the documented empty fallback shape", () => {
+    expect(parseGoogleErrorBody({})).toEqual({});
+  });
+
+  it("returns the parsed body when only error.message is set", () => {
+    const body = parseGoogleErrorBody({ error: { message: "Forbidden" } });
+    expect(body.error?.message).toBe("Forbidden");
   });
 });
 

--- a/src/lib/google-calendar-schemas.ts
+++ b/src/lib/google-calendar-schemas.ts
@@ -248,6 +248,24 @@ export const GoogleApiErrorBodySchema = z
 export type GoogleApiErrorBody = z.infer<typeof GoogleApiErrorBodySchema>;
 
 /**
+ * Safely parse a non-2xx Google API response body into a typed envelope.
+ *
+ * Closes the success/error validation asymmetry surfaced by #386: the success
+ * paths go through {@link parseGoogleResponse} but every error path used to
+ * read `errorData.error?.message` against a raw `unknown` JSON body. This
+ * helper lets all four sites read the same field through a parsed envelope.
+ *
+ * Failure mode is deliberately quiet — a malformed Google error body is not a
+ * loggable contract break (the canonical envelope is documented but the route
+ * handlers already tolerate missing fields). On parse failure we fall back to
+ * `{}` so callers keep their `?.error?.message ?? "..."` ladder.
+ */
+export function parseGoogleErrorBody(data: unknown): GoogleApiErrorBody {
+  const result = GoogleApiErrorBodySchema.safeParse(data);
+  return result.success ? result.data : {};
+}
+
+/**
  * Context for a {@link GoogleApiValidationError} so route logging has enough
  * information to triage which Google endpoint produced the malformed
  * payload.

--- a/src/lib/google-calendar-schemas.ts
+++ b/src/lib/google-calendar-schemas.ts
@@ -208,6 +208,14 @@ export type GoogleCalendarListResponse = z.infer<
 >;
 
 /**
+ * Maximum number of Zod issues summarised when reporting validation
+ * failures — used both inside `GoogleApiValidationError`'s human-readable
+ * message and by route-level `logger.error` `validationIssues` payloads.
+ * Single source of truth so the two stay aligned (#386 item 4).
+ */
+export const VALIDATION_ISSUES_SUMMARY_COUNT = 5;
+
+/**
  * Schema for the canonical Google API error envelope. Used to safely pluck
  * `error.message` from a non-2xx response body without trusting an
  * arbitrary cast. The schema accepts an empty `{}` body so existing
@@ -263,7 +271,7 @@ export class GoogleApiValidationError extends Error {
 
   constructor(context: GoogleApiValidationContext, issues: z.core.$ZodIssue[]) {
     const summary = issues
-      .slice(0, 3)
+      .slice(0, VALIDATION_ISSUES_SUMMARY_COUNT)
       .map((i) => `${i.path.join(".") || "<root>"}: ${i.message}`)
       .join("; ");
     super(


### PR DESCRIPTION
## Summary

PR #325 review surfaced 5 follow-ups (#386). This PR picks up **items 1, 2, 4, 5**; item 3 is deferred (bundled with the `gapi.client.calendar.*` retirement under #117 / #196).

- **Item 4** ✅ — single `VALIDATION_ISSUES_SUMMARY_COUNT = 5` const, used by both the `GoogleApiValidationError` constructor summary and the four route-level `logger.error` `validationIssues` payloads. Eliminates the rationale-free divergence between `slice(0, 3)` (schema) and `slice(0, 5)` (routes).
- **Item 5** ✅ — drop the dead `interface CalendarInfo` from the calendars route test file. The file already imports `CalendarsResponse` from the route for actual parsing; the local copy had no consumers.
- **Item 1** ✅ — wire `GoogleApiErrorBodySchema` in via `parseGoogleErrorBody(unknown)` at the four `errorData.error?.message` sites in `events/route.ts` (GET / POST) and `events/[id]/route.ts` (DELETE). Failure mode is deliberately quiet (falls back to `{}` so existing `?.error?.message ?? "..."` ladders keep working) — the schema is the trust boundary, not a logging surface.
- **Item 2** ✅ — drop the `calendarIds.length === 1` guard at `events/route.ts`. Multi-calendar all-fail now returns the consensus per-calendar status (or 502 on mixed statuses) rather than leaking a 200 with empty events.

## Plan

Linked plan: `.claude/plans/pr-325-followups-386.md`
Project: https://github.com/users/BenSeymourODB/projects/1

## Test plan

- [x] Phase 1 (items 4, 5): existing test suite still green
- [x] Phase 2 (item 1): 8 new unit tests on `parseGoogleErrorBody` cover null / undefined / primitive / array / wrong-shape / canonical envelope / empty-fallback / only-message inputs
- [x] Phase 3 (item 2): 3 new route tests cover same-status (404+404 → 404), mixed-status (404+403 → 502), partial-failure preservation (success + 404 → 200). Single-calendar all-fail unchanged.
- [x] `pnpm lint:fix && pnpm format:fix && pnpm check-types && pnpm test` green — 2485 tests pass.

## Out of scope

- **Item 3** (`event as gapi.client.calendar.Event` cast at the mapper boundary) — needs `normalizeFetchedEvent` and `GoogleCalendarEvent` retyped onto `GoogleEventPayload` rather than the `gapi.client.calendar.*` ambient types. That ripples into the legacy `lib/google-calendar.ts` client-side callers and belongs with the wider gapi retirement under #117 / #196.

Closes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)