### PR TITLE
fix(calendar): unify bare-date parsing across overlap helpers (#375)

### DIFF
--- a/.claude/plans/unify-bare-date-parsing-375.md
+++ b/.claude/plans/unify-bare-date-parsing-375.md
@@ -1,0 +1,89 @@
+# Plan — Unify bare-date parsing across calendar overlap helpers (#375)
+
+Issue: https://github.com/BenSeymourODB/next-digital-wall-calendar/issues/375
+
+## Context
+
+PR #251 fixed YearCalendar dot rendering for bare-date all-day events by
+introducing a private `parseEventStartLocal` helper inside `YearCalendar.tsx`.
+That helper treats `YYYY-MM-DD` startDates as the local calendar day so the
+dot lands on the correct cell regardless of harness TZ.
+
+The **count path** in the same PR delegates to `getEventsForYear` in
+`src/lib/calendar-helpers.ts`, which uses `parseISO(event.startDate)`.
+`parseISO` parses bare dates as **UTC midnight**, so the count path
+silently undercounts bare-date events that land at year boundaries in
+negative-offset zones — disagreeing with the dot path's rendering.
+
+The same parser-strategy mismatch exists in the sibling helpers:
+
+- `getEventsForDay` (line 354/355, 369/370)
+- `getEventsForWeek` (line 405/406)
+- `getEventsForMonth` (line 421/422)
+- `getEventsForYear` (line 439/440)
+
+## Fix
+
+Promote `parseEventStartLocal` to `src/lib/calendar-helpers.ts`, exporting
+`parseEventStart(event)` and a symmetric `parseEventEnd(event)`:
+
+```ts
+const BARE_DATE_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+export function parseEventStart(event: IEvent): Date {
+  const m = BARE_DATE_RE.exec(event.startDate);
+  return m ? new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3])) : parseISO(event.startDate);
+}
+
+export function parseEventEnd(event: IEvent): Date {
+  const m = BARE_DATE_RE.exec(event.endDate);
+  return m ? new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3])) : parseISO(event.endDate);
+}
+```
+
+Replace `parseISO(event.startDate)` / `parseISO(event.endDate)` in the four
+overlap helpers (`getEventsForDay`, `getEventsForWeek`, `getEventsForMonth`,
+`getEventsForYear`) with the new shared parsers.
+
+Update `YearCalendar.tsx`: drop the local `parseEventStartLocal` and import
+the shared `parseEventStart` from `@/lib/calendar-helpers`. Existing
+`bucketEventColorsByDayKey` unit tests stay green — parser semantics are
+identical to what PR #251 introduced.
+
+## Out of scope
+
+- Other consumers of `parseISO(event.startDate)` in `calendar-helpers.ts`
+  (`groupEvents`, `calculateMonthEventPositions`, `getMonthCellEvents`,
+  `getEventTimePosition`, `computeEventColumns`, `assignBarRows`,
+  `getEventsCount`). Those are tracked separately if/when bugs surface.
+- Multi-day-event dot rendering (only the start day gets a dot today).
+- The full-year fetch path (#117).
+
+## Tests (TDD — write first)
+
+In `src/lib/__tests__/calendar-helpers.test.ts`:
+
+1. `parseEventStart` / `parseEventEnd` direct unit tests:
+   - Bare `YYYY-MM-DD` → `new Date(y, m-1, d)` (local) — verified via
+     `.getFullYear() / .getMonth() / .getDate()`.
+   - Full ISO with offset → identical to `parseISO`.
+   - Naive local datetime (`"2024-03-15T10:00:00"`) → identical to `parseISO`.
+2. `getEventsForYear` regression: bare-date Jan 1 event included when
+   viewing that year (was excluded before fix).
+3. `getEventsForMonth` regression: bare-date event on first day of month
+   included.
+4. `getEventsForWeek` regression: bare-date event on first day of week
+   included.
+5. `getEventsForDay` regression: bare-date event on the queried day
+   included.
+
+In `src/components/calendar/__tests__/YearCalendar.test.tsx`:
+
+6. Year event count agrees with dot path for bare-date Jan-1 event — the
+   asymmetry case from this issue.
+
+All existing tests must stay green.
+
+## Phases
+
+Single PR, single phase: helpers + YearCalendar import + tests.

--- a/src/components/calendar/YearCalendar.tsx
+++ b/src/components/calendar/YearCalendar.tsx
@@ -2,7 +2,7 @@
 
 import { useCalendar } from "@/components/providers/CalendarProvider";
 import { Button } from "@/components/ui/button";
-import { getEventsForYear } from "@/lib/calendar-helpers";
+import { getEventsForYear, parseEventStart } from "@/lib/calendar-helpers";
 import { useDateNow } from "@/lib/hooks/use-date-now";
 import type { IEvent, TEventColor } from "@/types/calendar";
 import { useEffect, useRef } from "react";
@@ -48,32 +48,20 @@ function formatDayKey(date: Date): string {
   return `${y}-${m}-${d}`;
 }
 
-const BARE_DATE_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
-
-// All-day events from non-canonical sources can carry a bare YYYY-MM-DD
-// startDate. `new Date("YYYY-MM-DD")` parses it as UTC midnight, which slips
-// to the previous day in negative-offset zones — so the dot would render on
-// the wrong cell. Construct the date from local Y/M/D parts in that case.
-function parseEventStartLocal(event: IEvent): Date {
-  const match = BARE_DATE_RE.exec(event.startDate);
-  if (match) {
-    const [, y, m, d] = match;
-    return new Date(Number(y), Number(m) - 1, Number(d));
-  }
-  return new Date(event.startDate);
-}
-
 // Pre-bucket events into a Map<dayKey, Set<TEventColor>> so each day cell
 // reduces to an O(1) lookup instead of scanning the whole event array.
 // Drops the year-grid render from O(events × cells) to O(events + cells).
 // Exported for unit testing — the map shape is the contract that lets
 // MonthPanel render dots without ever touching the raw event list.
+//
+// `parseEventStart` (#375) shares the bare-date local-day parser with the
+// overlap helpers, so the dot path and getEventsForYear count path agree.
 export function bucketEventColorsByDayKey(
   events: IEvent[]
 ): Map<string, Set<TEventColor>> {
   const map = new Map<string, Set<TEventColor>>();
   for (const event of events) {
-    const key = formatDayKey(parseEventStartLocal(event));
+    const key = formatDayKey(parseEventStart(event));
     let colors = map.get(key);
     if (!colors) {
       colors = new Set<TEventColor>();

--- a/src/components/calendar/YearCalendar.tsx
+++ b/src/components/calendar/YearCalendar.tsx
@@ -54,8 +54,9 @@ function formatDayKey(date: Date): string {
 // Exported for unit testing — the map shape is the contract that lets
 // MonthPanel render dots without ever touching the raw event list.
 //
-// `parseEventStart` (#375) shares the bare-date local-day parser with the
-// overlap helpers, so the dot path and getEventsForYear count path agree.
+// #375: bare-date events must parse as the local calendar day here and in
+// `getEventsForYear`; using the shared `parseEventStart` keeps the dot
+// path and count path from disagreeing in negative-offset zones.
 export function bucketEventColorsByDayKey(
   events: IEvent[]
 ): Map<string, Set<TEventColor>> {

--- a/src/components/calendar/__tests__/YearCalendar.test.tsx
+++ b/src/components/calendar/__tests__/YearCalendar.test.tsx
@@ -536,6 +536,36 @@ describe("YearCalendar", () => {
     });
   });
 
+  describe("Count/dot agreement for bare-date events (#375)", () => {
+    it("counts a bare-date Jan 1 event in the year header (matches the dot path)", () => {
+      // Pre-fix the dot path used a local parser inside YearCalendar.tsx
+      // while the count delegated to getEventsForYear, which parsed bare
+      // dates as UTC midnight — so the dot rendered on Jan 1 but the
+      // count showed 0. The shared parseEventStart/parseEventEnd helpers
+      // close that asymmetry: same parser, same answer.
+      const events = [
+        createMockEvent({
+          id: "jan-1-all-day",
+          color: "blue",
+          startDate: "2026-01-01",
+          endDate: "2026-01-01",
+          isAllDay: true,
+        }),
+      ];
+
+      renderWithContext({ selectedDate: new Date(2026, 5, 15), events });
+
+      const jan1Cell = screen.getByTestId("year-calendar-day-2026-01-01");
+      expect(within(jan1Cell).getAllByTestId("year-calendar-dot")).toHaveLength(
+        1
+      );
+
+      expect(screen.getByTestId("year-calendar-event-count")).toHaveTextContent(
+        "1 event"
+      );
+    });
+  });
+
   describe("All-day timezone correctness (#203 bug 1)", () => {
     it("renders the dot on the calendar-local day for an all-day bare-date startDate", () => {
       // All-day events from non-canonical sources may carry a bare YYYY-MM-DD

--- a/src/lib/__tests__/calendar-helpers.test.ts
+++ b/src/lib/__tests__/calendar-helpers.test.ts
@@ -25,6 +25,8 @@ import {
   getWeekDates,
   groupEvents,
   navigateDate,
+  parseEventEnd,
+  parseEventStart,
   rangeText,
   toCapitalize,
 } from "../calendar-helpers";
@@ -955,5 +957,137 @@ describe("assignBarRows", () => {
     });
     const rows = assignBarRows([event], weekStart, weekEnd);
     expect(rows[event.id]).toBeUndefined();
+  });
+});
+
+describe("parseEventStart / parseEventEnd (#375)", () => {
+  it("treats a bare YYYY-MM-DD startDate as the local calendar day", () => {
+    // `parseISO("2026-01-01")` returns UTC midnight, which slips to the prior
+    // day in negative-offset zones. The shared parser must construct the date
+    // from local Y/M/D parts so consumers across files agree on the bucket.
+    const event = createMockEvent({
+      startDate: "2026-01-01",
+      endDate: "2026-01-01",
+      isAllDay: true,
+    });
+    const start = parseEventStart(event);
+    expect(start.getFullYear()).toBe(2026);
+    expect(start.getMonth()).toBe(0);
+    expect(start.getDate()).toBe(1);
+  });
+
+  it("treats a bare YYYY-MM-DD endDate as the local calendar day", () => {
+    const event = createMockEvent({
+      startDate: "2026-12-31",
+      endDate: "2026-12-31",
+      isAllDay: true,
+    });
+    const end = parseEventEnd(event);
+    expect(end.getFullYear()).toBe(2026);
+    expect(end.getMonth()).toBe(11);
+    expect(end.getDate()).toBe(31);
+  });
+
+  it("matches parseISO for a full ISO timestamp with offset", () => {
+    const event = createMockEvent({
+      startDate: "2024-03-15T10:00:00Z",
+      endDate: "2024-03-15T11:00:00Z",
+    });
+    expect(parseEventStart(event).getTime()).toBe(
+      parseISO(event.startDate).getTime()
+    );
+    expect(parseEventEnd(event).getTime()).toBe(
+      parseISO(event.endDate).getTime()
+    );
+  });
+
+  it("matches parseISO for a naive local datetime", () => {
+    // Datetime strings without an offset are parsed in the local zone by
+    // parseISO. The shared parser must defer to it for anything that isn't
+    // a bare YYYY-MM-DD, so timed events behave identically.
+    const event = createMockEvent({
+      startDate: "2024-03-15T10:00:00",
+      endDate: "2024-03-15T11:00:00",
+    });
+    expect(parseEventStart(event).getTime()).toBe(
+      parseISO(event.startDate).getTime()
+    );
+    expect(parseEventEnd(event).getTime()).toBe(
+      parseISO(event.endDate).getTime()
+    );
+  });
+});
+
+describe("bare-date overlap helpers (#375)", () => {
+  // These are the asymmetries the issue describes: parseISO("YYYY-MM-DD")
+  // gives UTC midnight, so a bare-date event on the first or last day of a
+  // range was excluded in negative-offset zones. The shared parser fixes it
+  // regardless of harness TZ because we never round-trip through UTC.
+
+  it("getEventsForYear includes a bare-date event on Jan 1 of the queried year", () => {
+    const event = createMockEvent({
+      id: "jan-1-all-day",
+      startDate: "2026-01-01",
+      endDate: "2026-01-01",
+      isAllDay: true,
+    });
+    const result = getEventsForYear([event], new Date(2026, 5, 15));
+    expect(result.map((e) => e.id)).toEqual(["jan-1-all-day"]);
+  });
+
+  it("getEventsForYear includes a bare-date event on Dec 31 of the queried year", () => {
+    const event = createMockEvent({
+      id: "dec-31-all-day",
+      startDate: "2026-12-31",
+      endDate: "2026-12-31",
+      isAllDay: true,
+    });
+    const result = getEventsForYear([event], new Date(2026, 5, 15));
+    expect(result.map((e) => e.id)).toEqual(["dec-31-all-day"]);
+  });
+
+  it("getEventsForMonth includes a bare-date event on the first day of the month", () => {
+    const event = createMockEvent({
+      id: "mar-1-all-day",
+      startDate: "2026-03-01",
+      endDate: "2026-03-01",
+      isAllDay: true,
+    });
+    const result = getEventsForMonth([event], new Date(2026, 2, 15));
+    expect(result.map((e) => e.id)).toEqual(["mar-1-all-day"]);
+  });
+
+  it("getEventsForMonth includes a bare-date event on the last day of the month", () => {
+    const event = createMockEvent({
+      id: "mar-31-all-day",
+      startDate: "2026-03-31",
+      endDate: "2026-03-31",
+      isAllDay: true,
+    });
+    const result = getEventsForMonth([event], new Date(2026, 2, 15));
+    expect(result.map((e) => e.id)).toEqual(["mar-31-all-day"]);
+  });
+
+  it("getEventsForWeek includes a bare-date event on the first day of the week", () => {
+    // Sun Mar 10 2024 is the first day of the week containing Wed Mar 13.
+    const event = createMockEvent({
+      id: "sun-mar-10-all-day",
+      startDate: "2024-03-10",
+      endDate: "2024-03-10",
+      isAllDay: true,
+    });
+    const result = getEventsForWeek([event], new Date(2024, 2, 13));
+    expect(result.map((e) => e.id)).toEqual(["sun-mar-10-all-day"]);
+  });
+
+  it("getEventsForDay includes a bare-date event on the queried day", () => {
+    const event = createMockEvent({
+      id: "jan-1-all-day",
+      startDate: "2026-01-01",
+      endDate: "2026-01-01",
+      isAllDay: true,
+    });
+    const result = getEventsForDay([event], new Date(2026, 0, 1));
+    expect(result.map((e) => e.id)).toEqual(["jan-1-all-day"]);
   });
 });

--- a/src/lib/__tests__/calendar-helpers.test.ts
+++ b/src/lib/__tests__/calendar-helpers.test.ts
@@ -1016,6 +1016,33 @@ describe("parseEventStart / parseEventEnd (#375)", () => {
       parseISO(event.endDate).getTime()
     );
   });
+
+  it("returns Invalid Date for out-of-range month/day (matches parseISO semantics)", () => {
+    // `new Date(2026, 12, 1)` silently overflows to 2027-01-01. The
+    // overflow guard preserves the Invalid-Date contract that the
+    // `isValid` filter in the overlap helpers relies on — pre-fix
+    // these strings round-tripped through parseISO and returned NaN.
+    const month13 = createMockEvent({
+      startDate: "2026-13-01",
+      endDate: "2026-13-01",
+    });
+    expect(parseEventStart(month13).getTime()).toBeNaN();
+    expect(parseEventEnd(month13).getTime()).toBeNaN();
+
+    const feb30 = createMockEvent({
+      startDate: "2026-02-30",
+      endDate: "2026-02-30",
+    });
+    expect(parseEventStart(feb30).getTime()).toBeNaN();
+    expect(parseEventEnd(feb30).getTime()).toBeNaN();
+
+    const month00 = createMockEvent({
+      startDate: "2026-00-15",
+      endDate: "2026-00-15",
+    });
+    expect(parseEventStart(month00).getTime()).toBeNaN();
+    expect(parseEventEnd(month00).getTime()).toBeNaN();
+  });
 });
 
 describe("bare-date overlap helpers (#375)", () => {
@@ -1023,6 +1050,14 @@ describe("bare-date overlap helpers (#375)", () => {
   // gives UTC midnight, so a bare-date event on the first or last day of a
   // range was excluded in negative-offset zones. The shared parser fixes it
   // regardless of harness TZ because we never round-trip through UTC.
+  //
+  // CI runs in UTC, where parseISO("YYYY-MM-DD") and new Date(y, m-1, d)
+  // happen to produce the same instant — so these integration tests pass
+  // against pre-fix code in UTC. The TZ-independent regression guard is
+  // the parseEventStart/parseEventEnd unit tests above, which assert local
+  // Y/M/D semantics via .getFullYear() / .getMonth() / .getDate(). These
+  // integration tests document the wiring contract and would catch a
+  // regression under a non-UTC TZ.
 
   it("getEventsForYear includes a bare-date event on Jan 1 of the queried year", () => {
     const event = createMockEvent({
@@ -1089,5 +1124,35 @@ describe("bare-date overlap helpers (#375)", () => {
     });
     const result = getEventsForDay([event], new Date(2026, 0, 1));
     expect(result.map((e) => e.id)).toEqual(["jan-1-all-day"]);
+  });
+
+  it("getEventsForDay (isWeek=true) includes a bare-date multi-day event spanning the queried day", () => {
+    // The isWeek branch filters to startDate !== endDate, which excludes
+    // single-day all-day events. A multi-day all-day event with bare
+    // endpoints must still resolve via the shared parser so the in-week
+    // overlap check matches the dot path's local-day bucketing.
+    const event = createMockEvent({
+      id: "multi-day-bare",
+      startDate: "2026-01-01",
+      endDate: "2026-01-03",
+      isAllDay: true,
+    });
+    const result = getEventsForDay([event], new Date(2026, 0, 2), true);
+    expect(result.map((e) => e.id)).toEqual(["multi-day-bare"]);
+  });
+
+  it("getEventsForYear includes an event with a full-ISO startDate but bare endDate on Dec 31", () => {
+    // The endDate is the binding edge here — the year-end overlap
+    // boundary depends on parseEventEnd, not parseEventStart, when the
+    // event spans into the year from earlier. Locks in the symmetric
+    // parser wiring on the endDate side.
+    const event = createMockEvent({
+      id: "spans-into-year-end",
+      startDate: "2026-12-20T10:00:00Z",
+      endDate: "2026-12-31",
+      isAllDay: true,
+    });
+    const result = getEventsForYear([event], new Date(2026, 5, 15));
+    expect(result.map((e) => e.id)).toEqual(["spans-into-year-end"]);
   });
 });

--- a/src/lib/calendar-helpers.ts
+++ b/src/lib/calendar-helpers.ts
@@ -35,6 +35,33 @@ import {
 
 const FORMAT_STRING = "MMM d, yyyy";
 
+const BARE_DATE_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+// All-day events from non-canonical sources can carry a bare YYYY-MM-DD
+// startDate/endDate. `parseISO("YYYY-MM-DD")` parses it as UTC midnight,
+// which slips to the previous day in negative-offset zones — so any
+// overlap check against locally-derived bounds (startOfDay/Week/Month/Year)
+// silently disagrees with the dot-rendering path that already uses a
+// local-day parser (#203 bug 1, #375). Construct the date from local
+// Y/M/D parts in that case so all consumers agree on the bucket.
+export function parseEventStart(event: IEvent): Date {
+  const match = BARE_DATE_RE.exec(event.startDate);
+  if (match) {
+    const [, y, m, d] = match;
+    return new Date(Number(y), Number(m) - 1, Number(d));
+  }
+  return parseISO(event.startDate);
+}
+
+export function parseEventEnd(event: IEvent): Date {
+  const match = BARE_DATE_RE.exec(event.endDate);
+  if (match) {
+    const [, y, m, d] = match;
+    return new Date(Number(y), Number(m) - 1, Number(d));
+  }
+  return parseISO(event.endDate);
+}
+
 /**
  * Project-wide default for which day a calendar week begins on.
  *
@@ -351,8 +378,8 @@ export const getEventsForDay = (
   const targetDate = startOfDay(date);
   return events
     .filter((event) => {
-      const startOfDayForEventStart = startOfDay(parseISO(event.startDate));
-      const startOfDayForEventEnd = startOfDay(parseISO(event.endDate));
+      const startOfDayForEventStart = startOfDay(parseEventStart(event));
+      const startOfDayForEventEnd = startOfDay(parseEventEnd(event));
       if (isWeek) {
         return (
           event.startDate !== event.endDate &&
@@ -366,8 +393,8 @@ export const getEventsForDay = (
       );
     })
     .map((event) => {
-      const eventStart = startOfDay(parseISO(event.startDate));
-      const eventEnd = startOfDay(parseISO(event.endDate));
+      const eventStart = startOfDay(parseEventStart(event));
+      const eventEnd = startOfDay(parseEventEnd(event));
       let point: "start" | "end" | "none" | undefined;
 
       if (isSameDay(eventStart, eventEnd)) {
@@ -402,8 +429,8 @@ export const getEventsForWeek = (
   const endOfWeekDate = endOfWeek(date, { weekStartsOn });
 
   return events.filter((event) => {
-    const eventStart = parseISO(event.startDate);
-    const eventEnd = parseISO(event.endDate);
+    const eventStart = parseEventStart(event);
+    const eventEnd = parseEventEnd(event);
     return (
       isValid(eventStart) &&
       isValid(eventEnd) &&
@@ -418,8 +445,8 @@ export const getEventsForMonth = (events: IEvent[], date: Date): IEvent[] => {
   const endOfMonthDate = endOfMonth(date);
 
   return events.filter((event) => {
-    const eventStart = parseISO(event.startDate);
-    const eventEnd = parseISO(event.endDate);
+    const eventStart = parseEventStart(event);
+    const eventEnd = parseEventEnd(event);
     return (
       isValid(eventStart) &&
       isValid(eventEnd) &&
@@ -436,8 +463,8 @@ export const getEventsForYear = (events: IEvent[], date: Date): IEvent[] => {
   const endOfYearDate = endOfYear(date);
 
   return events.filter((event) => {
-    const eventStart = parseISO(event.startDate);
-    const eventEnd = parseISO(event.endDate);
+    const eventStart = parseEventStart(event);
+    const eventEnd = parseEventEnd(event);
     return (
       isValid(eventStart) &&
       isValid(eventEnd) &&

--- a/src/lib/calendar-helpers.ts
+++ b/src/lib/calendar-helpers.ts
@@ -44,22 +44,31 @@ const BARE_DATE_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
 // silently disagrees with the dot-rendering path that already uses a
 // local-day parser (#203 bug 1, #375). Construct the date from local
 // Y/M/D parts in that case so all consumers agree on the bucket.
-export function parseEventStart(event: IEvent): Date {
-  const match = BARE_DATE_RE.exec(event.startDate);
-  if (match) {
-    const [, y, m, d] = match;
-    return new Date(Number(y), Number(m) - 1, Number(d));
+//
+// `new Date(y, m-1, d)` silently overflows out-of-range months/days
+// (e.g. month 13 becomes Jan of the next year, Feb 30 becomes Mar 2),
+// where `parseISO` would return Invalid Date. The overflow guard
+// preserves the Invalid-Date semantics the `isValid` filter in the
+// overlap helpers relies on.
+function parseBareDateOrISO(value: string): Date {
+  const match = BARE_DATE_RE.exec(value);
+  if (!match) return parseISO(value);
+  const y = Number(match[1]);
+  const m = Number(match[2]);
+  const d = Number(match[3]);
+  const date = new Date(y, m - 1, d);
+  if (date.getMonth() !== m - 1 || date.getDate() !== d) {
+    return new Date(NaN);
   }
-  return parseISO(event.startDate);
+  return date;
+}
+
+export function parseEventStart(event: IEvent): Date {
+  return parseBareDateOrISO(event.startDate);
 }
 
 export function parseEventEnd(event: IEvent): Date {
-  const match = BARE_DATE_RE.exec(event.endDate);
-  if (match) {
-    const [, y, m, d] = match;
-    return new Date(Number(y), Number(m) - 1, Number(d));
-  }
-  return parseISO(event.endDate);
+  return parseBareDateOrISO(event.endDate);
 }
 
 /**


### PR DESCRIPTION
## Summary

- Promote PR #251's bare-date local-day parser from `YearCalendar.tsx` to `src/lib/calendar-helpers.ts` as shared `parseEventStart` / `parseEventEnd`.
- Wire the four overlap helpers (`getEventsForDay`, `getEventsForWeek`, `getEventsForMonth`, `getEventsForYear`) to use the shared parser so the dot path and count path agree on bare-date all-day events.
- Drop the local copy in `YearCalendar.tsx` and import the shared parser.

## Why

Pre-fix, the dot path used a local parser while `getEventsForYear` and siblings called `parseISO("YYYY-MM-DD")` (UTC midnight). In negative-offset zones a bare-date Jan 1 event rendered a dot on Jan 1 but the year count silently dropped it — and the same asymmetry existed at month/week/day boundaries.

## Plan

Linked plan: `.claude/plans/unify-bare-date-parsing-375.md`
Project: https://github.com/users/BenSeymourODB/projects/1

## Test plan

- [x] `parseEventStart` / `parseEventEnd` direct unit tests (bare date, full ISO, naive local datetime)
- [x] Bare-date integration tests on each of `getEventsForDay/Week/Month/Year`
- [x] YearCalendar regression: count agrees with dot path for bare-date Jan 1 event
- [x] All 2485 tests pass, `pnpm lint:fix`, `pnpm format:fix`, `pnpm check-types` clean
- [x] No behavior change for full-ISO events — existing tests stay green

Closes #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0183g4RJEjY6CaKUsfsnKBCh)_