### PR TITLE
fix(calendar): unify bare-date parsing across overlap helpers (#375)

### DIFF
--- a/.claude/plans/bare-date-parsing-unification-375.md
+++ b/.claude/plans/bare-date-parsing-unification-375.md
@@ -41,13 +41,15 @@ targeted fix.
      `process.env.TZ` manipulation, matching the PR #251 test style).
 
 2. `src/lib/calendar-helpers.ts`:
-   - Export a `BARE_DATE_RE` and two helpers:
+   - Export two helpers:
      ```ts
      export function parseEventStart(event: IEvent): Date;
      export function parseEventEnd(event: IEvent): Date;
      ```
-   - Each tries `BARE_DATE_RE` first, falls back to `parseISO` on the
-     respective field.
+   - Each tries the module-private `BARE_DATE_RE` first, falls back to
+     `parseISO` on the respective field. The regex stays private — its
+     only callers are `parseEventStart` / `parseEventEnd`, so it doesn't
+     belong in the public surface.
 3. Swap `parseISO(event.startDate)` / `parseISO(event.endDate)` for the
    new helpers inside `getEventsForDay`, `getEventsForWeek`,
    `getEventsForMonth`, `getEventsForYear`. Other helpers stay on

--- a/.claude/plans/bare-date-parsing-unification-375.md
+++ b/.claude/plans/bare-date-parsing-unification-375.md
@@ -1,0 +1,95 @@
+# Issue #375 — Unify bare-date parsing across calendar-helpers + YearCalendar
+
+## Goal
+
+Eliminate the dot-vs-count asymmetry for bare-date all-day events. PR #251
+introduced `parseEventStartLocal` inside `YearCalendar.tsx`, but the
+sibling `getEventsForX` overlap helpers in `src/lib/calendar-helpers.ts`
+still use `parseISO`, which parses bare `YYYY-MM-DD` as UTC midnight.
+Promote the local helper to a shared `parseEventStart` (+ symmetric
+`parseEventEnd`) and use it everywhere the overlap math needs it.
+
+## Failure mode (from the issue)
+
+Bare-date all-day event `{ startDate: "2026-01-01", endDate: "2026-01-01",
+isAllDay: true }` in a negative-offset zone (UTC-8): the YearCalendar dot
+renders on Jan 1 but `getEventsForYear` returns `[]` because
+`parseISO("2026-01-01") → 2025-12-31T16:00 local`. Count and dot disagree.
+
+## Scope
+
+Touches the four overlap helpers only. Other `parseISO` callers
+(`groupEvents`, `getEventsCount`, `computeEventColumns`, `assignBarRows`,
+`calculateMonthEventPositions`, `getMonthCellEvents`, `getEventTimePosition`)
+are explicitly **out of scope** — the issue lists only the four overlap
+helpers in its table, and broadening would invite scope creep on a
+targeted fix.
+
+## Phases
+
+### Phase 1 — Shared parsers + overlap-helper rewire
+
+**TDD: write failing tests first.**
+
+1. `src/lib/__tests__/calendar-helpers.test.ts`:
+   - `parseEventStart` / `parseEventEnd`: bare `YYYY-MM-DD` parses to
+     local-midnight `Date`; full ISO timestamp falls through to `parseISO`.
+   - `getEventsForDay` / `getEventsForWeek` / `getEventsForMonth` /
+     `getEventsForYear`: a bare-date event at the year/month/week/day
+     boundary is included in the result. Tests construct expected dates
+     via `new Date(y, m, d)` to mirror the parser semantics (no
+     `process.env.TZ` manipulation, matching the PR #251 test style).
+
+2. `src/lib/calendar-helpers.ts`:
+   - Export a `BARE_DATE_RE` and two helpers:
+     ```ts
+     export function parseEventStart(event: IEvent): Date;
+     export function parseEventEnd(event: IEvent): Date;
+     ```
+   - Each tries `BARE_DATE_RE` first, falls back to `parseISO` on the
+     respective field.
+3. Swap `parseISO(event.startDate)` / `parseISO(event.endDate)` for the
+   new helpers inside `getEventsForDay`, `getEventsForWeek`,
+   `getEventsForMonth`, `getEventsForYear`. Other helpers stay on
+   `parseISO`.
+
+### Phase 2 — YearCalendar consumer + regression test
+
+1. `src/components/calendar/YearCalendar.tsx`:
+   - Import `parseEventStart` from `@/lib/calendar-helpers`.
+   - Replace the local `parseEventStartLocal` (and its `BARE_DATE_RE`)
+     with the shared helper.
+   - `bucketEventColorsByDayKey` keeps the same semantics — its existing
+     unit test still passes.
+2. `src/components/calendar/__tests__/YearCalendar.test.tsx`:
+   - Add a regression test asserting the year-count path matches the dot
+     path for a bare-date Jan-1 event in 2026 (the exact case from the
+     issue). Render with a single
+     `{ startDate: "2026-01-01", endDate: "2026-01-01", isAllDay: true }`
+     event and verify the `year-calendar-event-count` testid reads
+     `1 event` while the dot is visible on the Jan-1 cell.
+
+## Acceptance (mirrors issue)
+
+- [x] `parseEventStart` / `parseEventEnd` exported and used by the four
+      overlap helpers.
+- [x] `YearCalendar.tsx` imports the shared parsers instead of its local
+      copy.
+- [x] Unit tests cover bare-date events at Jan-1, Dec-31, first/last day
+      of month/week, and bare-date day queries.
+- [x] Regression test in `YearCalendar.test.tsx` proves count agrees with
+      dot for the issue's exact scenario.
+- [x] No behavior change for full-ISO-timestamp events — existing tests
+      stay green.
+- [x] `pnpm test && pnpm lint:fix && pnpm format:fix && pnpm check-types`
+      all green.
+
+## Out of scope
+
+- Multi-day bare-date event coverage in `assignBarRows` /
+  `calculateMonthEventPositions` — pre-existing limitation, not in #375.
+- The `getEventsCount` path (also uses `parseISO`) — it's the count used
+  by view headers, not the overlap helpers; the issue lists only the
+  four overlap helpers explicitly.
+- Retiring `parseISO` project-wide. The intent is to fix the bare-date
+  bug, not refactor all date parsing.

--- a/src/components/calendar/YearCalendar.tsx
+++ b/src/components/calendar/YearCalendar.tsx
@@ -3,7 +3,7 @@
 import { useCalendar } from "@/components/providers/CalendarProvider";
 import { Button } from "@/components/ui/button";
 import { useSlideDirection } from "@/hooks/use-slide-direction";
-import { getEventsForYear } from "@/lib/calendar-helpers";
+import { getEventsForYear, parseEventStart } from "@/lib/calendar-helpers";
 import { useDateNow } from "@/lib/hooks/use-date-now";
 import type { IEvent, TEventColor } from "@/types/calendar";
 import { useEffect, useRef } from "react";
@@ -52,32 +52,20 @@ function formatDayKey(date: Date): string {
   return `${y}-${m}-${d}`;
 }
 
-const BARE_DATE_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
-
-// All-day events from non-canonical sources can carry a bare YYYY-MM-DD
-// startDate. `new Date("YYYY-MM-DD")` parses it as UTC midnight, which slips
-// to the previous day in negative-offset zones — so the dot would render on
-// the wrong cell. Construct the date from local Y/M/D parts in that case.
-function parseEventStartLocal(event: IEvent): Date {
-  const match = BARE_DATE_RE.exec(event.startDate);
-  if (match) {
-    const [, y, m, d] = match;
-    return new Date(Number(y), Number(m) - 1, Number(d));
-  }
-  return new Date(event.startDate);
-}
-
 // Pre-bucket events into a Map<dayKey, Set<TEventColor>> so each day cell
 // reduces to an O(1) lookup instead of scanning the whole event array.
 // Drops the year-grid render from O(events × cells) to O(events + cells).
 // Exported for unit testing — the map shape is the contract that lets
 // MonthPanel render dots without ever touching the raw event list.
+//
+// Uses the shared `parseEventStart` so the dot path and the
+// `getEventsForX` count path agree on bare-date semantics (issue #375).
 export function bucketEventColorsByDayKey(
   events: IEvent[]
 ): Map<string, Set<TEventColor>> {
   const map = new Map<string, Set<TEventColor>>();
   for (const event of events) {
-    const key = formatDayKey(parseEventStartLocal(event));
+    const key = formatDayKey(parseEventStart(event));
     let colors = map.get(key);
     if (!colors) {
       colors = new Set<TEventColor>();

--- a/src/components/calendar/__tests__/YearCalendar.test.tsx
+++ b/src/components/calendar/__tests__/YearCalendar.test.tsx
@@ -536,6 +536,38 @@ describe("YearCalendar", () => {
     });
   });
 
+  describe("Bare-date count/dot parity (#375)", () => {
+    it("counts a bare-date Jan-1 event in the year header to match the dot", () => {
+      // Before #375 was fixed: the dot path used `parseEventStartLocal`
+      // (treats bare YYYY-MM-DD as the local calendar day) while the count
+      // path called `getEventsForYear`, which used `parseISO` (treats it as
+      // UTC midnight). In negative-offset zones, the count silently
+      // undercounted bare-date Jan-1 events while the dot still rendered.
+      // After the fix both paths share `parseEventStart`, so the count must
+      // equal the rendered-dot count for the exact scenario from #375.
+      const events = [
+        createMockEvent({
+          id: "bare-jan-1",
+          color: "blue",
+          startDate: "2026-01-01",
+          endDate: "2026-01-01",
+          isAllDay: true,
+        }),
+      ];
+
+      renderWithContext({ selectedDate: new Date(2026, 0, 1), events });
+
+      expect(screen.getByTestId("year-calendar-event-count")).toHaveTextContent(
+        "1 event"
+      );
+
+      const janCell = screen.getByTestId("year-calendar-day-2026-01-01");
+      expect(within(janCell).getAllByTestId("year-calendar-dot")).toHaveLength(
+        1
+      );
+    });
+  });
+
   describe("All-day timezone correctness (#203 bug 1)", () => {
     it("renders the dot on the calendar-local day for an all-day bare-date startDate", () => {
       // All-day events from non-canonical sources may carry a bare YYYY-MM-DD

--- a/src/components/calendar/__tests__/YearCalendar.test.tsx
+++ b/src/components/calendar/__tests__/YearCalendar.test.tsx
@@ -565,6 +565,12 @@ describe("YearCalendar", () => {
       expect(within(janCell).getAllByTestId("year-calendar-dot")).toHaveLength(
         1
       );
+
+      // Guard against the UTC-midnight slip reappearing across the whole
+      // year grid: if the parser ever regresses to `parseISO`, the dot
+      // would migrate off Jan-1 to a different cell in a negative-offset
+      // zone. The total dot count must stay at exactly 1.
+      expect(screen.getAllByTestId("year-calendar-dot")).toHaveLength(1);
     });
   });
 

--- a/src/lib/__tests__/calendar-helpers.test.ts
+++ b/src/lib/__tests__/calendar-helpers.test.ts
@@ -25,6 +25,8 @@ import {
   getWeekDates,
   groupEvents,
   navigateDate,
+  parseEventEnd,
+  parseEventStart,
   rangeText,
   toCapitalize,
 } from "../calendar-helpers";
@@ -625,6 +627,196 @@ describe("getEventsForYear", () => {
 
   it("handles invalid inputs gracefully", () => {
     expect(getEventsForYear([], new Date(2024, 0, 1))).toEqual([]);
+  });
+});
+
+describe("parseEventStart / parseEventEnd (#375)", () => {
+  // The bug surface: `parseISO("YYYY-MM-DD")` returns UTC midnight, so in a
+  // negative-offset zone the resulting Date displays as the previous day.
+  // `parseEventStart` / `parseEventEnd` must return a local-midnight Date
+  // for bare-date input — semantics identical to the `parseEventStartLocal`
+  // helper PR #251 introduced inside YearCalendar.tsx. Full ISO timestamps
+  // must keep parsing through `parseISO` so existing callers don't shift.
+
+  it("parseEventStart returns local-midnight Date for bare YYYY-MM-DD startDate", () => {
+    const event = createMockEvent({
+      startDate: "2026-01-01",
+      endDate: "2026-01-01",
+      isAllDay: true,
+    });
+
+    const result = parseEventStart(event);
+
+    expect(result.getFullYear()).toBe(2026);
+    expect(result.getMonth()).toBe(0);
+    expect(result.getDate()).toBe(1);
+    expect(result.getHours()).toBe(0);
+    expect(result.getMinutes()).toBe(0);
+    expect(result.getSeconds()).toBe(0);
+    expect(result.getTime()).toBe(new Date(2026, 0, 1).getTime());
+  });
+
+  it("parseEventEnd returns local-midnight Date for bare YYYY-MM-DD endDate", () => {
+    const event = createMockEvent({
+      startDate: "2026-12-31",
+      endDate: "2026-12-31",
+      isAllDay: true,
+    });
+
+    const result = parseEventEnd(event);
+
+    expect(result.getTime()).toBe(new Date(2026, 11, 31).getTime());
+  });
+
+  it("parseEventStart falls through to parseISO for full ISO timestamps", () => {
+    const event = createMockEvent({
+      startDate: "2026-03-15T10:30:00",
+      endDate: "2026-03-15T11:30:00",
+    });
+
+    // Equivalent to date-fns `parseISO` — both produce the same instant.
+    expect(parseEventStart(event).getTime()).toBe(
+      parseISO(event.startDate).getTime()
+    );
+  });
+
+  it("parseEventEnd falls through to parseISO for full ISO timestamps", () => {
+    const event = createMockEvent({
+      startDate: "2026-03-15T10:30:00",
+      endDate: "2026-03-15T11:30:00",
+    });
+
+    expect(parseEventEnd(event).getTime()).toBe(
+      parseISO(event.endDate).getTime()
+    );
+  });
+
+  it("parseEventStart treats a Z-suffixed timestamp as UTC (not bare-date)", () => {
+    // Sanity: only the bare `YYYY-MM-DD` regex shape opts into local parsing.
+    // A Z-suffixed timestamp must still parse as UTC via parseISO.
+    const event = createMockEvent({
+      startDate: "2026-01-01T00:00:00Z",
+      endDate: "2026-01-01T00:00:00Z",
+    });
+
+    expect(parseEventStart(event).getTime()).toBe(
+      parseISO(event.startDate).getTime()
+    );
+  });
+});
+
+describe("getEventsForX bare-date inclusion (#375)", () => {
+  // Bare-date all-day events from non-canonical sources (MockCalendarProvider,
+  // /test/calendar fixtures, non-Google integrations) must be included in the
+  // overlap result for the day/week/month/year they fall on. The buggy
+  // `parseISO` path returns UTC midnight, which slips them to the previous
+  // local day in negative-offset zones — the bug from issue #375.
+
+  it("includes a bare-date Jan-1 event in getEventsForYear for that year", () => {
+    const events: IEvent[] = [
+      createMockEvent({
+        id: "bare-jan-1",
+        startDate: "2026-01-01",
+        endDate: "2026-01-01",
+        isAllDay: true,
+      }),
+    ];
+
+    const result = getEventsForYear(events, new Date(2026, 0, 1));
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("bare-jan-1");
+  });
+
+  it("includes a bare-date Dec-31 event in getEventsForYear for that year", () => {
+    const events: IEvent[] = [
+      createMockEvent({
+        id: "bare-dec-31",
+        startDate: "2026-12-31",
+        endDate: "2026-12-31",
+        isAllDay: true,
+      }),
+    ];
+
+    const result = getEventsForYear(events, new Date(2026, 5, 15));
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("bare-dec-31");
+  });
+
+  it("includes a bare-date first-of-month event in getEventsForMonth", () => {
+    const events: IEvent[] = [
+      createMockEvent({
+        id: "bare-mar-1",
+        startDate: "2026-03-01",
+        endDate: "2026-03-01",
+        isAllDay: true,
+      }),
+    ];
+
+    const result = getEventsForMonth(events, new Date(2026, 2, 15));
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("bare-mar-1");
+  });
+
+  it("includes a bare-date last-of-month event in getEventsForMonth", () => {
+    const events: IEvent[] = [
+      createMockEvent({
+        id: "bare-mar-31",
+        startDate: "2026-03-31",
+        endDate: "2026-03-31",
+        isAllDay: true,
+      }),
+    ];
+
+    const result = getEventsForMonth(events, new Date(2026, 2, 1));
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("bare-mar-31");
+  });
+
+  it("includes a bare-date first-of-week event in getEventsForWeek", () => {
+    // Mar 8 2026 is a Sunday — start of a Sunday-first week (WEEK_STARTS_ON=0).
+    const events: IEvent[] = [
+      createMockEvent({
+        id: "bare-week-start",
+        startDate: "2026-03-08",
+        endDate: "2026-03-08",
+        isAllDay: true,
+      }),
+    ];
+
+    const result = getEventsForWeek(events, new Date(2026, 2, 10));
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("bare-week-start");
+  });
+
+  it("includes a bare-date last-of-week event in getEventsForWeek", () => {
+    // Mar 14 2026 is a Saturday — end of a Sunday-first week.
+    const events: IEvent[] = [
+      createMockEvent({
+        id: "bare-week-end",
+        startDate: "2026-03-14",
+        endDate: "2026-03-14",
+        isAllDay: true,
+      }),
+    ];
+
+    const result = getEventsForWeek(events, new Date(2026, 2, 10));
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("bare-week-end");
+  });
+
+  it("includes a bare-date event in getEventsForDay for that day", () => {
+    const events: IEvent[] = [
+      createMockEvent({
+        id: "bare-mar-15",
+        startDate: "2026-03-15",
+        endDate: "2026-03-15",
+        isAllDay: true,
+      }),
+    ];
+
+    const result = getEventsForDay(events, new Date(2026, 2, 15));
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("bare-mar-15");
   });
 });
 

--- a/src/lib/calendar-helpers.ts
+++ b/src/lib/calendar-helpers.ts
@@ -381,8 +381,11 @@ export const getEventsForDay = (
   const targetDate = startOfDay(date);
   return events
     .filter((event) => {
-      const startOfDayForEventStart = startOfDay(parseEventStart(event));
-      const startOfDayForEventEnd = startOfDay(parseEventEnd(event));
+      const eventStart = parseEventStart(event);
+      const eventEnd = parseEventEnd(event);
+      if (!isValid(eventStart) || !isValid(eventEnd)) return false;
+      const startOfDayForEventStart = startOfDay(eventStart);
+      const startOfDayForEventEnd = startOfDay(eventEnd);
       if (isWeek) {
         return (
           event.startDate !== event.endDate &&

--- a/src/lib/calendar-helpers.ts
+++ b/src/lib/calendar-helpers.ts
@@ -35,6 +35,36 @@ import {
 
 const FORMAT_STRING = "MMM d, yyyy";
 
+const BARE_DATE_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+function parseEventDateField(value: string): Date {
+  const m = BARE_DATE_RE.exec(value);
+  if (m) return new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]));
+  return parseISO(value);
+}
+
+/**
+ * Parse `event.startDate` into a `Date`. Bare `YYYY-MM-DD` values — which
+ * arrive from non-canonical sources like the `MockCalendarProvider`,
+ * `/test/calendar` fixtures, and non-Google integrations — are treated as
+ * the local calendar day. `parseISO` would parse them as UTC midnight,
+ * which slips them to the previous local day in negative-offset zones
+ * and silently undercounts bare-date events in the `getEventsForX`
+ * overlap helpers (issue #375). Full ISO timestamps fall through to
+ * `parseISO` unchanged.
+ */
+export function parseEventStart(event: IEvent): Date {
+  return parseEventDateField(event.startDate);
+}
+
+/**
+ * Parse `event.endDate`. Same bare-date local-parsing semantics as
+ * `parseEventStart` — see its docblock.
+ */
+export function parseEventEnd(event: IEvent): Date {
+  return parseEventDateField(event.endDate);
+}
+
 /**
  * Project-wide default for which day a calendar week begins on.
  *
@@ -351,8 +381,8 @@ export const getEventsForDay = (
   const targetDate = startOfDay(date);
   return events
     .filter((event) => {
-      const startOfDayForEventStart = startOfDay(parseISO(event.startDate));
-      const startOfDayForEventEnd = startOfDay(parseISO(event.endDate));
+      const startOfDayForEventStart = startOfDay(parseEventStart(event));
+      const startOfDayForEventEnd = startOfDay(parseEventEnd(event));
       if (isWeek) {
         return (
           event.startDate !== event.endDate &&
@@ -366,8 +396,8 @@ export const getEventsForDay = (
       );
     })
     .map((event) => {
-      const eventStart = startOfDay(parseISO(event.startDate));
-      const eventEnd = startOfDay(parseISO(event.endDate));
+      const eventStart = startOfDay(parseEventStart(event));
+      const eventEnd = startOfDay(parseEventEnd(event));
       let point: "start" | "end" | "none" | undefined;
 
       if (isSameDay(eventStart, eventEnd)) {
@@ -402,8 +432,8 @@ export const getEventsForWeek = (
   const endOfWeekDate = endOfWeek(date, { weekStartsOn });
 
   return events.filter((event) => {
-    const eventStart = parseISO(event.startDate);
-    const eventEnd = parseISO(event.endDate);
+    const eventStart = parseEventStart(event);
+    const eventEnd = parseEventEnd(event);
     return (
       isValid(eventStart) &&
       isValid(eventEnd) &&
@@ -418,8 +448,8 @@ export const getEventsForMonth = (events: IEvent[], date: Date): IEvent[] => {
   const endOfMonthDate = endOfMonth(date);
 
   return events.filter((event) => {
-    const eventStart = parseISO(event.startDate);
-    const eventEnd = parseISO(event.endDate);
+    const eventStart = parseEventStart(event);
+    const eventEnd = parseEventEnd(event);
     return (
       isValid(eventStart) &&
       isValid(eventEnd) &&
@@ -436,8 +466,8 @@ export const getEventsForYear = (events: IEvent[], date: Date): IEvent[] => {
   const endOfYearDate = endOfYear(date);
 
   return events.filter((event) => {
-    const eventStart = parseISO(event.startDate);
-    const eventEnd = parseISO(event.endDate);
+    const eventStart = parseEventStart(event);
+    const eventEnd = parseEventEnd(event);
     return (
       isValid(eventStart) &&
       isValid(eventEnd) &&


### PR DESCRIPTION
## Summary

- Promote `parseEventStartLocal` from `YearCalendar.tsx` into shared `parseEventStart` / `parseEventEnd` in `src/lib/calendar-helpers.ts`.
- Wire the four `getEventsForX` overlap helpers (day/week/month/year) onto the shared parser so bare `YYYY-MM-DD` events are bucketed on the local calendar day, not UTC midnight.
- Eliminates the dot-vs-count asymmetry where the YearCalendar dot rendered on the correct day but the count silently undercounted bare-date events in negative-offset timezones.

## Bug surface

For a bare-date all-day event `{ startDate: "2026-01-01", endDate: "2026-01-01", isAllDay: true }` in `America/Los_Angeles` (UTC-8):

- **Before:** dot renders on Jan 1 (uses local `parseEventStartLocal`) but `getEventsForYear` returns `[]` because `parseISO("2026-01-01") → 2025-12-31T16:00 local`. Count and dot disagree.
- **After:** both paths share `parseEventStart`, dot and count agree.

The bug fired for the `MockCalendarProvider`, `/test/calendar` fixtures, and any non-Google event source. Google-sourced events were unaffected because `transformGoogleEvent` already appends `T00:00:00` to bare dates.

## Plan

Linked plan: `.claude/plans/bare-date-parsing-unification-375.md`.
Project: https://github.com/users/BenSeymourODB/projects/1

## Test plan

- [x] Unit tests for `parseEventStart` / `parseEventEnd` covering bare-date and full-ISO inputs (incl. `Z`-suffixed UTC).
- [x] `getEventsForX` inclusion tests for bare-date events at Jan-1, Dec-31, first/last day of month, first/last day of week, and `getEventsForDay`.
- [x] `YearCalendar.test.tsx` regression: count and dot agree for `{ startDate: "2026-01-01", endDate: "2026-01-01" }`.
- [x] `pnpm test` — 2534/2534 passing.
- [x] `pnpm lint:fix && pnpm format:fix && pnpm check-types` — clean.

## Out of scope

Per the issue, only the four overlap helpers were rewired. Other `parseISO` callers (`groupEvents`, `getEventsCount`, `computeEventColumns`, `assignBarRows`, `calculateMonthEventPositions`, `getMonthCellEvents`, `getEventTimePosition`) remain on `parseISO` — they don't drive the bare-date count/dot mismatch this issue targets, and broadening would invite scope creep.

Closes #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AfFYsuzVBE5GG2N1nyVjUd)_