### PR TITLE
fix(auth): validate Google token-refresh response shape at runtime (#405)

### DIFF
--- a/src/lib/auth/__tests__/refresh-google-token.test.ts
+++ b/src/lib/auth/__tests__/refresh-google-token.test.ts
@@ -10,6 +10,7 @@
  */
 import { jsonResponse } from "@/lib/test-utils/api-test-helpers";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { classifyTokenRefreshError } from "../refresh-error-classifier";
 import {
   GoogleTokenRefreshError,
   refreshGoogleAccessToken,
@@ -117,6 +118,95 @@ describe("refreshGoogleAccessToken", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  // Issue #405: Google can return a 200 with a non-token body (proxy error,
+  // partial payload, edge-case rate-limit JSON). Without runtime validation
+  // `expires_in` is undefined → `Math.floor(now/1000 + undefined)` is NaN and
+  // Prisma writes corrupt the account row's refresh window. These tests pin
+  // the shape-check at the wire boundary so the malformed payload surfaces as
+  // a transient `GoogleTokenRefreshError` instead of silent NaN downstream.
+  describe("runtime payload validation (issue #405)", () => {
+    it("throws GoogleTokenRefreshError when a 200 response is missing expires_in", async () => {
+      mockFetch.mockResolvedValue(
+        jsonResponse({ access_token: "valid-but-incomplete" })
+      );
+
+      await expect(
+        refreshGoogleAccessToken("rt", "cid", "sec")
+      ).rejects.toBeInstanceOf(GoogleTokenRefreshError);
+    });
+
+    it("throws GoogleTokenRefreshError when expires_in is the wrong type (string)", async () => {
+      mockFetch.mockResolvedValue(
+        jsonResponse({ access_token: "valid", expires_in: "3600" })
+      );
+
+      await expect(
+        refreshGoogleAccessToken("rt", "cid", "sec")
+      ).rejects.toBeInstanceOf(GoogleTokenRefreshError);
+    });
+
+    it("throws GoogleTokenRefreshError when the 200 body is null", async () => {
+      mockFetch.mockResolvedValue(jsonResponse(null));
+
+      await expect(
+        refreshGoogleAccessToken("rt", "cid", "sec")
+      ).rejects.toBeInstanceOf(GoogleTokenRefreshError);
+    });
+
+    it("throws GoogleTokenRefreshError when the 200 body is an unrelated JSON value", async () => {
+      // A proxy rewriting the response to a string or array still parses as
+      // JSON but doesn't satisfy the token shape.
+      mockFetch.mockResolvedValue(jsonResponse([]));
+
+      await expect(
+        refreshGoogleAccessToken("rt", "cid", "sec")
+      ).rejects.toBeInstanceOf(GoogleTokenRefreshError);
+    });
+
+    it("throws GoogleTokenRefreshError when expires_in is non-positive", async () => {
+      // `Math.floor(now/1000 + 0)` would still update the row to an already-
+      // expired window — caller would re-enter the refresh path on every
+      // session callback. Treat zero / negative as malformed.
+      mockFetch.mockResolvedValue(
+        jsonResponse({ access_token: "valid", expires_in: 0 })
+      );
+
+      await expect(
+        refreshGoogleAccessToken("rt", "cid", "sec")
+      ).rejects.toBeInstanceOf(GoogleTokenRefreshError);
+    });
+
+    it("tags the malformed-payload error so classifyTokenRefreshError returns transient", async () => {
+      // The orchestrator's `.finally()` purges the singleflight slot on either
+      // classification, but a terminal classification would dump the user back
+      // to a sign-in screen for a Google-side anomaly. Pin it to transient.
+      mockFetch.mockResolvedValue(jsonResponse({}));
+
+      const caught = await refreshGoogleAccessToken("rt", "cid", "sec").catch(
+        (e: unknown) => e
+      );
+
+      expect(caught).toBeInstanceOf(GoogleTokenRefreshError);
+      const err = caught as GoogleTokenRefreshError;
+      expect(err.body).toMatchObject({ error: "malformed_token_response" });
+      expect(classifyTokenRefreshError(err)).toBe("transient");
+    });
+
+    it("accepts a canonical response (access_token + positive int expires_in) without throwing", async () => {
+      // Locks in that the validator doesn't reject the happy path, including
+      // when the optional refresh_token / scope / token_type fields are absent
+      // (Google omits refresh_token on routine refreshes).
+      mockFetch.mockResolvedValue(
+        jsonResponse({ access_token: "new-access", expires_in: 3599 })
+      );
+
+      const tokens = await refreshGoogleAccessToken("rt", "cid", "sec");
+
+      expect(tokens.access_token).toBe("new-access");
+      expect(tokens.expires_in).toBe(3599);
+    });
   });
 
   it("propagates the underlying TypeError when transient network errors exhaust the retry budget", async () => {

--- a/src/lib/auth/__tests__/refresh-google-token.test.ts
+++ b/src/lib/auth/__tests__/refresh-google-token.test.ts
@@ -165,12 +165,24 @@ describe("refreshGoogleAccessToken", () => {
       ).rejects.toBeInstanceOf(GoogleTokenRefreshError);
     });
 
-    it("throws GoogleTokenRefreshError when expires_in is non-positive", async () => {
+    it("throws GoogleTokenRefreshError when expires_in is zero", async () => {
       // `Math.floor(now/1000 + 0)` would still update the row to an already-
       // expired window — caller would re-enter the refresh path on every
-      // session callback. Treat zero / negative as malformed.
+      // session callback. Treat zero as malformed.
       mockFetch.mockResolvedValue(
         jsonResponse({ access_token: "valid", expires_in: 0 })
+      );
+
+      await expect(
+        refreshGoogleAccessToken("rt", "cid", "sec")
+      ).rejects.toBeInstanceOf(GoogleTokenRefreshError);
+    });
+
+    it("throws GoogleTokenRefreshError when expires_in is negative", async () => {
+      // Sibling to the zero case — pins that the schema's `positive()`
+      // constraint actually means `> 0`, not just non-NaN.
+      mockFetch.mockResolvedValue(
+        jsonResponse({ access_token: "valid", expires_in: -1 })
       );
 
       await expect(

--- a/src/lib/auth/refresh-google-token.ts
+++ b/src/lib/auth/refresh-google-token.ts
@@ -94,9 +94,17 @@ export async function refreshGoogleAccessToken(
 
   const parsed = GoogleRefreshedTokensSchema.safeParse(rawBody);
   if (!parsed.success) {
+    // Scrub Zod's raw issues to a fixed shape — `received` / `input` fields on
+    // some issue codes can echo the offending value verbatim, which would
+    // surface in the orchestrator's `logger.error(err, ...)` if a future
+    // schema tightening ever applies to a string-typed token field.
     throw new GoogleTokenRefreshError(response.status, {
       error: "malformed_token_response",
-      issues: parsed.error.issues,
+      issues: parsed.error.issues.map(({ code, path, message }) => ({
+        code,
+        path,
+        message,
+      })),
     });
   }
   return parsed.data;

--- a/src/lib/auth/refresh-google-token.ts
+++ b/src/lib/auth/refresh-google-token.ts
@@ -9,26 +9,44 @@
  * {@link GoogleTokenRefreshError} so the upstream HTTP status survives),
  * and Google's "no new refresh token" rotation policy is left untouched
  * (callers fall back to the existing plaintext refresh token).
+ *
+ * On a 200 response the JSON body is validated against
+ * {@link GoogleRefreshedTokensSchema} before returning. A malformed payload
+ * (proxy rewrite, partial body, edge-case rate-limit JSON) is converted into
+ * a `GoogleTokenRefreshError` with `body.error === "malformed_token_response"`
+ * so the orchestrator's classifier treats it as transient — the alternative
+ * is `expires_in` being `undefined`, `Math.floor(NaN)`, and a corrupted
+ * `expires_at` column. See issue #405.
  */
 import { fetchWithRetry } from "@/lib/http/retry";
+import { z } from "zod";
 
 export const GOOGLE_OAUTH_TOKEN_ENDPOINT =
   "https://oauth2.googleapis.com/token";
 
-export interface GoogleRefreshedTokens {
-  access_token: string;
-  expires_in: number;
-  /** Google only returns a new refresh_token on first consent or revocation. */
-  refresh_token?: string;
-  scope?: string;
-  token_type?: string;
-}
+/**
+ * Schema for the JSON body of a successful Google OAuth refresh-token grant
+ * response. Only `access_token` and `expires_in` are strictly required for
+ * the orchestrator to write a usable account row; `refresh_token` is omitted
+ * on routine refreshes and the remaining fields are advisory metadata.
+ */
+export const GoogleRefreshedTokensSchema = z.object({
+  access_token: z.string().min(1),
+  expires_in: z.number().int().positive(),
+  refresh_token: z.string().min(1).optional(),
+  scope: z.string().optional(),
+  token_type: z.string().optional(),
+});
+
+export type GoogleRefreshedTokens = z.infer<typeof GoogleRefreshedTokensSchema>;
 
 /**
  * Thrown by {@link refreshGoogleAccessToken} on a non-OK response from
- * Google's token endpoint. Carries both the upstream status (so server-side
- * routes can forward it to clients) and the parsed JSON body (so callers
- * can branch on `error: "invalid_grant"` etc. without re-reading the body).
+ * Google's token endpoint, or on a 200 whose body fails
+ * {@link GoogleRefreshedTokensSchema}. Carries both the upstream status (so
+ * server-side routes can forward it to clients) and the parsed JSON body /
+ * synthetic envelope (so callers can branch on `error: "invalid_grant"` or
+ * `"malformed_token_response"` without re-reading the body).
  */
 export class GoogleTokenRefreshError extends Error {
   readonly status: number;
@@ -45,7 +63,8 @@ export class GoogleTokenRefreshError extends Error {
 /**
  * Exchange a long-lived refresh token for a fresh access token.
  *
- * Throws {@link GoogleTokenRefreshError} on non-OK responses; transient
+ * Throws {@link GoogleTokenRefreshError} on non-OK responses or on a 200
+ * whose body doesn't match {@link GoogleRefreshedTokensSchema}; transient
  * 5xx / 429 / network failures are retried by {@link fetchWithRetry} before
  * reaching the throw.
  */
@@ -67,11 +86,18 @@ export async function refreshGoogleAccessToken(
     }),
   });
 
-  const tokensOrError = await response.json();
+  const rawBody: unknown = await response.json();
 
   if (!response.ok) {
-    throw new GoogleTokenRefreshError(response.status, tokensOrError);
+    throw new GoogleTokenRefreshError(response.status, rawBody);
   }
 
-  return tokensOrError as GoogleRefreshedTokens;
+  const parsed = GoogleRefreshedTokensSchema.safeParse(rawBody);
+  if (!parsed.success) {
+    throw new GoogleTokenRefreshError(response.status, {
+      error: "malformed_token_response",
+      issues: parsed.error.issues,
+    });
+  }
+  return parsed.data;
 }


### PR DESCRIPTION
## Summary

- Define `GoogleRefreshedTokensSchema` (Zod v4) and validate the 200 body via `safeParse` before returning; the existing cast was silently letting malformed payloads through.
- On parse failure, throw `GoogleTokenRefreshError(status, { error: "malformed_token_response", issues })` — `classifyTokenRefreshError` treats the unknown error code as transient, so the singleflight slot purges and the next callback retries instead of forcing re-auth.
- Re-export `GoogleRefreshedTokens` as `z.infer<typeof GoogleRefreshedTokensSchema>` so the in-tree callers (`refresh-session-tokens.ts`, `session-callback.test.ts`) keep the same type without a duplicate declaration.

## Why

Without a runtime shape check, a Google 200 with a partial / proxy-rewritten body left `expires_in` as `undefined`. The orchestrator then computed `Math.floor(now/1000 + undefined) → NaN` and Prisma either wrote `NaN` (rejected) or silently coerced to `NULL` on the optional column, corrupting the refresh window. Either path is hard to diagnose. PR #401's singleflight raises the impact: every concurrent session callback for that account collapses onto the same broken refresh.

## Plan

No plan file existed under `.claude/plans/`; the issue body is the spec (5 acceptance criteria, all covered).
Project: https://github.com/users/BenSeymourODB/projects/1

## Test plan

- [x] `pnpm test:run src/lib/auth/__tests__/refresh-google-token.test.ts` — 13 passed (6 new + 7 existing)
- [x] `pnpm test:run` — full suite, 2531 passed across 153 files
- [x] `pnpm lint:fix` — 0 errors (6 pre-existing warnings unrelated to this diff)
- [x] `pnpm format:fix` — clean
- [x] `pnpm check-types` — clean

New test cases (issue #405 acceptance criteria):

- [x] Throws on 200 missing `expires_in`
- [x] Throws on 200 with `expires_in` as a string
- [x] Throws on 200 with `null` body
- [x] Throws on 200 with unrelated JSON value (array)
- [x] Throws on 200 with non-positive `expires_in` (defensive — zero would write an already-expired window)
- [x] Synthetic envelope tags `body.error === "malformed_token_response"` so `classifyTokenRefreshError` returns `"transient"`
- [x] Canonical 200 (only the required pair, no optional fields) still passes through

Closes #405

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RuS2DGGXmyvKK63KFtc17D)_