### PR TITLE
fix(settings): rollback only touched keys in updateTaskSettings (#413)

### DIFF
--- a/src/components/settings/__tests__/settings-form.test.tsx
+++ b/src/components/settings/__tests__/settings-form.test.tsx
@@ -754,3 +754,98 @@ describe("SettingsForm — same-key rollback race (#420)", () => {
     expect(busHandler).toHaveBeenCalledWith({ theme: "light" });
   });
 });
+
+/**
+ * Tests for SettingsForm.updateTaskSettings optimistic-update rollback
+ * semantics (#413).
+ *
+ * Mirrors the #363/#366 rollback contract for the profile-scoped task
+ * settings: the failure path must restore the pre-call value of *only*
+ * the keys being updated, read from the truly-current state via the
+ * functional setter — not a stale closure of the entire
+ * `taskSettings` object. Without this, an overlapping successful PUT to
+ * a different task-settings key loses its optimistic value when an
+ * earlier PUT fails.
+ */
+describe("SettingsForm — updateTaskSettings rollback (#413)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockActiveProfile(ACTIVE_PROFILE_ID);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("preserves a concurrent successful task-settings PUT when an earlier PUT fails", async () => {
+    const user = userEvent.setup();
+    const firstPut = deferred<Response>();
+    const secondPut = deferred<Response>();
+    let putIndex = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url: string, init?: RequestInit) => {
+        if (
+          typeof url === "string" &&
+          url === `/api/profiles/${ACTIVE_PROFILE_ID}/settings`
+        ) {
+          if (init?.method === "PUT") {
+            putIndex += 1;
+            return putIndex === 1 ? firstPut.promise : secondPut.promise;
+          }
+          // GET on mount
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              taskSortOrder: "dueDate",
+              showCompletedTasks: false,
+            }),
+          } as unknown as Response);
+        }
+        return Promise.resolve({ ok: true } as Response);
+      })
+    );
+
+    renderSettings();
+
+    const switchEl = await screen.findByRole("switch", {
+      name: /show completed tasks/i,
+    });
+    await waitFor(() =>
+      expect(switchEl).toHaveAttribute("data-state", "unchecked")
+    );
+
+    // PUT #1 — toggle showCompletedTasks on.
+    await user.click(switchEl);
+    expect(switchEl).toHaveAttribute("data-state", "checked");
+
+    // PUT #2 — change sort order to Priority. The task-sort-order
+    // combobox is the only one initialised to "Due Date".
+    const combobox = screen
+      .getAllByRole("combobox")
+      .find((el) => /due date/i.test(el.textContent ?? ""));
+    expect(combobox).toBeDefined();
+    await user.click(combobox!);
+    const option = await screen.findByRole("option", { name: /priority/i });
+    await user.click(option);
+
+    // Second resolves OK, first rejects — a whole-object rollback
+    // would wipe the successful sort-order change when the toggle
+    // reverts.
+    secondPut.resolve({ ok: true } as Response);
+    firstPut.reject(new Error("network failure"));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Failed to save task settings");
+    });
+
+    // showCompletedTasks reverts (its PUT failed)…
+    expect(switchEl).toHaveAttribute("data-state", "unchecked");
+    // …but the sort-order change must NOT be wiped by the failed
+    // toggle's rollback — its own PUT succeeded.
+    const updatedCombobox = screen
+      .getAllByRole("combobox")
+      .find((el) => /priority/i.test(el.textContent ?? ""));
+    expect(updatedCombobox).toBeDefined();
+  });
+});

--- a/src/components/settings/__tests__/settings-form.test.tsx
+++ b/src/components/settings/__tests__/settings-form.test.tsx
@@ -842,10 +842,10 @@ describe("SettingsForm — updateTaskSettings rollback (#413)", () => {
     // showCompletedTasks reverts (its PUT failed)…
     expect(switchEl).toHaveAttribute("data-state", "unchecked");
     // …but the sort-order change must NOT be wiped by the failed
-    // toggle's rollback — its own PUT succeeded.
-    const updatedCombobox = screen
-      .getAllByRole("combobox")
-      .find((el) => /priority/i.test(el.textContent ?? ""));
-    expect(updatedCombobox).toBeDefined();
+    // toggle's rollback — its own PUT succeeded. Assert against the
+    // original combobox node identity so a different "priority"-bearing
+    // element elsewhere on the page cannot satisfy this check.
+    expect(combobox).toHaveTextContent(/priority/i);
+    expect(combobox).not.toHaveTextContent(/due date/i);
   });
 });

--- a/src/components/settings/settings-form.tsx
+++ b/src/components/settings/settings-form.tsx
@@ -215,9 +215,19 @@ export function SettingsForm({
       return;
     }
 
-    const previous = taskSettings;
-    const next = { ...previous, ...partial };
-    setTaskSettings(next);
+    // Capture the pre-call value of *only* the keys we're about to overwrite,
+    // read from the functional setter's current state (not a stale closure).
+    // On rollback, merge those keys back so any concurrent successful PUT
+    // to other task-settings keys is preserved (#413, mirrors #363/#366).
+    let previousPartial: Partial<ProfileTaskSettings> | undefined;
+    setTaskSettings((curr) => {
+      previousPartial = Object.fromEntries(
+        (Object.keys(partial) as Array<keyof ProfileTaskSettings>).map(
+          (key) => [key, curr[key]]
+        )
+      ) as Partial<ProfileTaskSettings>;
+      return { ...curr, ...partial };
+    });
 
     try {
       const response = await fetch(
@@ -234,7 +244,10 @@ export function SettingsForm({
       }
     } catch {
       toast.error("Failed to save task settings");
-      setTaskSettings(previous);
+      const revert = previousPartial;
+      if (revert) {
+        setTaskSettings((curr) => ({ ...curr, ...revert }));
+      }
     }
   };
 


### PR DESCRIPTION
## Summary

- `SettingsForm.updateTaskSettings` snapshotted `previous = taskSettings` from the render closure and restored the whole object on PUT failure. With two overlapping PUTs to different task-settings keys, the failed one's rollback wiped the concurrent successful change.
- Apply PR #366's `updateSettings` pattern: snapshot only the keys being updated via the functional setter's current state, then rollback by merging that partial snapshot back into the truly-current state.
- Add a component regression test that fires two overlapping task-settings PUTs (toggle `showCompletedTasks` + change `taskSortOrder`), resolves the sort-order PUT first then rejects the toggle PUT, and asserts only the toggle reverts while the sort-order change is preserved.

## Plan

No `.claude/plans/` entry — the fix is a direct port of the #363/#366 pattern to the sibling `updateTaskSettings` function. Acceptance criteria from the issue body:

- [x] `updateTaskSettings` rolls back only the keys it attempted, sourced from the functional-setter current state (not a closure snapshot)
- [x] Component test mirroring the `"preserves a concurrent successful PUT"` spec — two overlapping task-settings PUTs (one fails, one succeeds), asserting the successful field's value is preserved
- [x] `pnpm test:run src/components/settings/__tests__/settings-form.test.tsx` passes
- [x] `pnpm lint:fix && pnpm format:fix && pnpm check-types` clean

Project: https://github.com/users/BenSeymourODB/projects/1

## Test plan

- [x] `pnpm test` — full suite (2,525 tests) passes
- [x] `pnpm lint:fix && pnpm format:fix && pnpm check-types` clean
- [x] New test fails against the pre-fix code (whole-object rollback wipes the sort-order change) and passes against the partial-keys rollback

Closes #413

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015LHPSX6SQLGGNpXaYSsziH)_