### PR TITLE
fix(settings): emit user-settings-bus rollback on PUT failure (#414)

### DIFF
--- a/src/components/settings/__tests__/settings-form.test.tsx
+++ b/src/components/settings/__tests__/settings-form.test.tsx
@@ -526,12 +526,21 @@ describe("SettingsForm — updateSettings rollback", () => {
  * next refresh.
  */
 describe("SettingsForm — bus rollback on PUT failure (#414)", () => {
+  // Hold the per-test bus unsubscribe so afterEach can run it unconditionally
+  // even if a test throws before reaching its own teardown line. Without this,
+  // an aborted test's subscriber would leak into the next case and start
+  // receiving its emits.
+  let unsubscribeBus: (() => void) | undefined;
+
   beforeEach(() => {
     vi.clearAllMocks();
     mockActiveProfile(ACTIVE_PROFILE_ID);
+    unsubscribeBus = undefined;
   });
 
   afterEach(() => {
+    unsubscribeBus?.();
+    unsubscribeBus = undefined;
     vi.unstubAllGlobals();
   });
 
@@ -554,7 +563,7 @@ describe("SettingsForm — bus rollback on PUT failure (#414)", () => {
     );
 
     const busHandler = vi.fn();
-    const unsubscribe = subscribeUserSettings(busHandler);
+    unsubscribeBus = subscribeUserSettings(busHandler);
 
     renderSettings();
 
@@ -570,10 +579,12 @@ describe("SettingsForm — bus rollback on PUT failure (#414)", () => {
     });
 
     // The bus subscriber must observe the rollback: the pre-call
-    // theme ("light"), not the optimistic value ("dark").
+    // theme ("light"), not the optimistic value ("dark"). Asserting on the
+    // exact call count guards against a future refactor that emits
+    // optimistically before the PUT — that would still satisfy a bare
+    // `toHaveBeenCalledWith(...)` matcher.
+    expect(busHandler).toHaveBeenCalledTimes(1);
     expect(busHandler).toHaveBeenCalledWith({ theme: "light" });
-
-    unsubscribe();
   });
 
   it("emits exactly once (the optimistic partial) when the PUT succeeds", async () => {
@@ -595,7 +606,7 @@ describe("SettingsForm — bus rollback on PUT failure (#414)", () => {
     );
 
     const busHandler = vi.fn();
-    const unsubscribe = subscribeUserSettings(busHandler);
+    unsubscribeBus = subscribeUserSettings(busHandler);
 
     renderSettings();
 
@@ -608,15 +619,16 @@ describe("SettingsForm — bus rollback on PUT failure (#414)", () => {
       expect(busHandler).toHaveBeenCalledWith({ theme: "dark" });
     });
 
-    // Give a microtask flush so any stray catch-path emit would have fired.
+    // A single microtask flush is sufficient here because the failure path
+    // throws synchronously off the `response.ok` check and the catch fires
+    // in the same microtask chain — no awaited steps between throw and
+    // `emitUserSettingsChange`. If a future refactor inserts an `await`
+    // between them, this flush would need to grow.
     await act(async () => {
       await Promise.resolve();
     });
 
-    // Exactly one emit — the success path — and never the rollback value.
     expect(busHandler).toHaveBeenCalledTimes(1);
     expect(busHandler).not.toHaveBeenCalledWith({ theme: "light" });
-
-    unsubscribe();
   });
 });

--- a/src/components/settings/__tests__/settings-form.test.tsx
+++ b/src/components/settings/__tests__/settings-form.test.tsx
@@ -5,6 +5,7 @@
  * for the active profile.
  */
 import { useProfile } from "@/components/profiles/profile-context";
+import { subscribeUserSettings } from "@/lib/user-settings-bus";
 import { makeProfile } from "@/test/fixtures/profile";
 import { makeUserSettings } from "@/test/fixtures/user-settings";
 import { act, render, screen, waitFor } from "@testing-library/react";
@@ -510,5 +511,112 @@ describe("SettingsForm — updateSettings rollback", () => {
 
     expect(darkRadio).toBeChecked();
     expect(toast.error).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Tests for SettingsForm — bus-rollback semantics (#414).
+ *
+ * `emitUserSettingsChange` fires on PUT success so in-tab subscribers (e.g.
+ * `CalendarProvider` via `useUserSettings`) stay in sync. The catch path
+ * must mirror that emit with the *reverted* partial — without it, any
+ * subscriber that consumed an earlier optimistic emit (e.g. via a
+ * preceding successful PUT to the same key, or a future move of the emit
+ * to the optimistic path) would be left holding a stale value until the
+ * next refresh.
+ */
+describe("SettingsForm — bus rollback on PUT failure (#414)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockActiveProfile(ACTIVE_PROFILE_ID);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("emits the reverted partial on the user-settings bus when a PUT fails", async () => {
+    const user = userEvent.setup();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url: string) => {
+        if (typeof url === "string" && url.startsWith("/api/profiles/")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              taskSortOrder: "dueDate",
+              showCompletedTasks: false,
+            }),
+          } as unknown as Response);
+        }
+        return Promise.resolve({ ok: false } as Response);
+      })
+    );
+
+    const busHandler = vi.fn();
+    const unsubscribe = subscribeUserSettings(busHandler);
+
+    renderSettings();
+
+    // Wait for the profile-settings GET to settle so the form is fully
+    // wired before driving the theme change.
+    await screen.findByRole("switch", { name: /show completed tasks/i });
+
+    const darkRadio = screen.getByLabelText(/^dark$/i);
+    await user.click(darkRadio);
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Failed to save settings");
+    });
+
+    // The bus subscriber must observe the rollback: the pre-call
+    // theme ("light"), not the optimistic value ("dark").
+    expect(busHandler).toHaveBeenCalledWith({ theme: "light" });
+
+    unsubscribe();
+  });
+
+  it("emits exactly once (the optimistic partial) when the PUT succeeds", async () => {
+    const user = userEvent.setup();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url: string) => {
+        if (typeof url === "string" && url.startsWith("/api/profiles/")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              taskSortOrder: "dueDate",
+              showCompletedTasks: false,
+            }),
+          } as unknown as Response);
+        }
+        return Promise.resolve({ ok: true } as Response);
+      })
+    );
+
+    const busHandler = vi.fn();
+    const unsubscribe = subscribeUserSettings(busHandler);
+
+    renderSettings();
+
+    await screen.findByRole("switch", { name: /show completed tasks/i });
+
+    const darkRadio = screen.getByLabelText(/^dark$/i);
+    await user.click(darkRadio);
+
+    await waitFor(() => {
+      expect(busHandler).toHaveBeenCalledWith({ theme: "dark" });
+    });
+
+    // Give a microtask flush so any stray catch-path emit would have fired.
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Exactly one emit — the success path — and never the rollback value.
+    expect(busHandler).toHaveBeenCalledTimes(1);
+    expect(busHandler).not.toHaveBeenCalledWith({ theme: "light" });
+
+    unsubscribe();
   });
 });

--- a/src/components/settings/settings-form.tsx
+++ b/src/components/settings/settings-form.tsx
@@ -155,6 +155,11 @@ export function SettingsForm({
       const revert = previousPartial;
       if (revert) {
         setSettings((curr) => ({ ...curr, ...revert }));
+        // #414 — pair the local rollback with a bus emit so in-tab
+        // subscribers (e.g. `CalendarProvider` via `useUserSettings`)
+        // converge on the rolled-back value rather than holding any
+        // earlier optimistic value they may have consumed.
+        emitUserSettingsChange(revert);
       }
     }
   };


### PR DESCRIPTION
## Summary

- `SettingsForm.updateSettings` already reverts local state on PUT failure (via the `#363` rollback) but never broadcast that revert on the user-settings bus, leaving in-tab subscribers (e.g. `CalendarProvider` via `useUserSettings`) holding any earlier optimistic value until the next change or refresh.
- Pair the local rollback with `emitUserSettingsChange(revert)` so every same-tab subscriber converges on the rolled-back partial.
- New tests cover both the failure path (subscriber receives the reverted value, not the optimistic one) and the success path (no rollback emit, no double-fire).

## Plan

No `.claude/plans/` file existed for this small follow-up — the issue body itself is the spec. Approach matches the proposed fix in [#414](https://github.com/BenSeymourODB/next-digital-wall-calendar/issues/414):

```ts
} catch {
  toast.error("Failed to save settings");
  if (previousPartial) {
    setSettings((curr) => ({ ...curr, ...previousPartial }));
    emitUserSettingsChange(previousPartial);
  }
}
```

Scope note: the issue body mentions `updateTaskSettings` as a future companion fix. That path operates on `ProfileSettings`, not `UserSettings`, and the user-settings bus payload doesn't model task-sort/show-completed — so it's intentionally out of scope here. PR [#416](https://github.com/BenSeymourODB/next-digital-wall-calendar/pull/416) (issue #413) already addresses the `updateTaskSettings` rollback semantics on a separate path.

## Deferred follow-ups (filed as tracking issues)

Surfaced during review of this PR; both pre-existing concerns, not introduced here, but the new emit site is a good moment to capture them.

- **#419 — refactor(settings): tighten `UserSettingsBusPayload` to a closed subset of `UserSettings` keys.** `Partial<UserSettingsData>` is silently widened to `UserSettingsBusPayload` at both emit sites; keys outside the bus payload (`weekStartDay`, `calendarWorkingHoursStart`, `calendarTransitionSpeed`) are carried through at runtime and silently discarded by `pickCalendarFields`. The bus-file comment already flags this as deferred work.
- **#420 — fix(settings): guard user-settings-bus subscribers against same-key PUT-race rollback.** Two rapid same-key PUTs where the later one succeeds and the earlier one fails will see the rollback emit overwrite the subscriber with a now-stale value. The local-state side is already race-safe via #363's functional-setter snapshot; the bus side is not.

## Test plan

- [x] New test: `emits the reverted partial on the user-settings bus when a PUT fails` — subscribes to the bus, drives a `theme: "dark"` change with a 4xx PUT, asserts the handler receives `{ theme: "light" }` exactly once.
- [x] New test: `emits exactly once (the optimistic partial) when the PUT succeeds` — guards against double-fire on the success path.
- [x] Bus subscription cleanup moved to `afterEach` so a thrown assertion can't leak a subscriber into the next test.
- [x] Existing `#363` rollback tests still pass.
- [x] `pnpm test:run` — 2543/2543 passing
- [x] `pnpm lint:fix && pnpm format:fix && pnpm check-types` — clean (no new warnings)

Closes #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)