### PR TITLE
fix(e2e): repair Playwright suite surfaced by the new E2E CI workflow (#369)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,15 +1,22 @@
 name: E2E
 
+# E2E runs on merges to main only (plus manual dispatch) — not on PRs. The
+# suite drives a production build under workers:1 and takes several minutes;
+# running it post-merge keeps the PR feedback loop short. Failures are surfaced
+# as GitHub issues (see the "Open an issue on failure" step) so regressions get
+# triaged in the normal dev cycle instead of silently going red.
 on:
   push:
-    branches: [main]
-  pull_request:
     branches: [main]
   workflow_dispatch:
 
 concurrency:
   group: e2e-${{ github.ref }}
   cancel-in-progress: true
+
+permissions:
+  contents: read
+  issues: write
 
 jobs:
   e2e:
@@ -44,10 +51,11 @@ jobs:
       AUTH_SECRET: e2e-test-secret-not-used-in-production
       GOOGLE_CLIENT_ID: e2e-dummy-client-id
       GOOGLE_CLIENT_SECRET: e2e-dummy-client-secret
-      # TOKEN_ENCRYPTION_KEY intentionally omitted: src/lib/crypto/token-cipher.ts
-      # falls back to an HKDF-derived key from NEXTAUTH_SECRET in non-production
-      # builds, which is sufficient for E2E. If a future workflow runs the app
-      # with NODE_ENV=production, this var must be set explicitly.
+      # The E2E suite runs a production build (`next start`, NODE_ENV=production),
+      # so token-cipher's dev-only HKDF fallback is disabled and an explicit
+      # 32-byte key is required. This is a throwaway key for CI only — it never
+      # decrypts real tokens (no real Google session exists in E2E).
+      TOKEN_ENCRYPTION_KEY: 9uYnwF24I0vZllDPVV6Da+KAcbtQxnDex/3zZhFrSnQ=
 
     steps:
       - uses: actions/checkout@v6
@@ -87,12 +95,18 @@ jobs:
       - name: Apply Prisma migrations
         run: pnpm db:migrate:deploy
 
+      # Build once here so Playwright's webServer (`pnpm start`) serves a
+      # prebuilt production app. Running against `next start` instead of the
+      # Turbopack dev server avoids on-demand route compilation and the memory
+      # growth that starved late-running specs under workers:1.
+      - name: Build production app
+        run: pnpm build
+
       - name: Run Playwright tests (chromium)
-        # Playwright treats `--` as a positional test-filter (no Unix-style
-        # end-of-options convention), so `pnpm test:e2e -- --project=chromium`
-        # expands to `playwright test -- --project=chromium` and matches zero
-        # tests ("No tests found."). pnpm 10 forwards trailing args to script
-        # commands without an explicit separator — just append the flag.
+        # CI=true makes playwright.config start `pnpm start` (the build above)
+        # rather than `pnpm dev`. Playwright treats `--` as a positional test
+        # filter, so the flag is appended directly (pnpm 10 forwards trailing
+        # args without an explicit separator).
         run: pnpm test:e2e --project=chromium
 
       - name: Upload Playwright report
@@ -112,3 +126,66 @@ jobs:
           path: test-results/
           retention-days: 14
           if-no-files-found: ignore
+
+      # Surface post-merge E2E regressions as a tracked issue. Since this runs
+      # on main only, a failure means main is red — file (or update) an issue so
+      # it lands in the normal triage flow instead of going unnoticed.
+      - name: Open an issue on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const sha = context.sha.slice(0, 7);
+            const label = "e2e-failure";
+
+            // Ensure the label exists (ignore "already exists").
+            try {
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: label,
+                color: "b60205",
+                description: "Automated: E2E suite failed on main",
+              });
+            } catch (e) {
+              if (e.status !== 422) throw e;
+            }
+
+            // Reuse a single open rolling issue if one exists, so a string of
+            // red runs comments on one thread instead of spamming new issues.
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              labels: label,
+              per_page: 1,
+            });
+
+            const body = [
+              `E2E suite failed on \`main\`.`,
+              ``,
+              `- Commit: ${context.sha}`,
+              `- Run: ${runUrl}`,
+              `- Triggered by: @${context.actor}`,
+              ``,
+              `Download the \`playwright-report\` / \`playwright-test-results\` artifacts from the run for traces, screenshots, and the HTML report.`,
+            ].join("\n");
+
+            if (existing.data.length > 0) {
+              const number = existing.data[0].number;
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: number,
+                body: `Another failed run (\`${sha}\`).\n\n${body}`,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: `E2E failing on main (${sha})`,
+                labels: [label],
+                body,
+              });
+            }

--- a/e2e/agenda-search-screenshots.spec.ts
+++ b/e2e/agenda-search-screenshots.spec.ts
@@ -6,7 +6,10 @@ import { expect, test } from "@playwright/test";
 
 test.use({ video: "retain-on-failure" });
 
-test.describe("QA Screenshots — Agenda Search (#144)", () => {
+// SKIPPED (whole file): QA screenshots of the legacy on-page agenda search UI
+// (removed from /test/calendar by #287 — see agenda-search.spec.ts for the full
+// rationale). Parked pending the agenda-search-access product decision.
+test.describe.skip("QA Screenshots — Agenda Search (#144)", () => {
   test("01-default-agenda — search input visible, events listed", async ({
     page,
   }) => {

--- a/e2e/agenda-search.spec.ts
+++ b/e2e/agenda-search.spec.ts
@@ -1,10 +1,20 @@
 import { expect, test } from "@playwright/test";
 
+// SKIPPED (whole file): these specs drive the legacy on-page agenda *search*
+// surface — the "Upcoming Events" header, `agenda-search-input`,
+// `agenda-search-clear`, and the Group-by-date/color buttons rendered by the
+// old AgendaCalendar component. Issue #287 replaced the /test/calendar agenda
+// surface with DayCalendar + AgendaList, which has no on-page search, so this
+// coverage no longer maps to anything reachable in the app. The search logic
+// itself is still unit-tested in AgendaCalendar.test.tsx. These are parked
+// (not deleted) pending a product decision on whether/where agenda search is
+// surfaced — tracked in the "agenda search access" issue.
+
 // Retain video only when a test fails so the interaction flow can be replayed
 // without accumulating artifacts on every passing run.
 test.use({ video: "retain-on-failure" });
 
-test.describe("Agenda Calendar — Search", () => {
+test.describe.skip("Agenda Calendar — Search", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/test/calendar?events=default&view=agenda");
     await expect(page.getByText("Upcoming Events")).toBeVisible();
@@ -60,7 +70,7 @@ test.describe("Agenda Calendar — Search", () => {
   });
 });
 
-test.describe("Agenda Calendar — Search (family scenario)", () => {
+test.describe.skip("Agenda Calendar — Search (family scenario)", () => {
   test("filters multi-user events by attendee name", async ({ page }) => {
     await page.goto("/test/calendar?events=family&view=agenda");
     await expect(page.getByText("Upcoming Events")).toBeVisible();
@@ -80,7 +90,7 @@ test.describe("Agenda Calendar — Search (family scenario)", () => {
   });
 });
 
-test.describe("Agenda Calendar — Group By", () => {
+test.describe.skip("Agenda Calendar — Group By", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/test/calendar?events=default&view=agenda");
     await expect(page.getByText("Upcoming Events")).toBeVisible();

--- a/e2e/agenda-toggle.spec.ts
+++ b/e2e/agenda-toggle.spec.ts
@@ -12,22 +12,41 @@
  * Month round-trip so the grid ↔ agenda fade and the new split-button UX
  * can be reviewed as part of the PR.
  */
-import { expect, test } from "@playwright/test";
+import { type Page, expect, test } from "@playwright/test";
 
 test.use({ video: "on", viewport: { width: 1280, height: 720 } });
+
+/** Open a split-view caret menu and pick a sub-mode, waiting for the menu to
+ *  fully open before selecting and fully close afterwards. The close wait keeps
+ *  the next caret interaction from overlapping a still-exit-animating menu (two
+ *  matching menuitemradios → strict-mode violation) or being swallowed by
+ *  Radix's post-close guard. */
+async function pickSubMode(
+  page: Page,
+  view: "day" | "week",
+  mode: "grid" | "agenda"
+) {
+  await expect(page.getByRole("menu")).toHaveCount(0);
+  await page.getByTestId(`view-switcher-${view}-mode`).click();
+  const item = page.getByRole("menuitemradio", {
+    name: new RegExp(mode, "i"),
+  });
+  await expect(item).toBeVisible();
+  await item.click();
+  await expect(page.getByRole("menu")).toHaveCount(0);
+}
 
 test.describe("Agenda toggle inside Day and Week views (#150 + #235)", () => {
   test("Day → Day+Agenda → Week+Agenda → Week → Month round-trip", async ({
     page,
   }) => {
     // Start in Day view (grid).
-    await page.goto("/test/calendar?events=default&view=day");
+    await page.goto("/test/calendar?events=default&view=day&transitionMs=0");
     await expect(page.getByTestId("day-calendar-grid")).toBeVisible();
     await expect(page.getByTestId("agenda-list")).toHaveCount(0);
 
     // Day → Day+Agenda via the Day caret.
-    await page.getByTestId("view-switcher-day-mode").click();
-    await page.getByRole("menuitemradio", { name: /agenda/i }).click();
+    await pickSubMode(page, "day", "agenda");
 
     // The grid is gone, AgendaList is in. Day header is still visible.
     await expect(page.getByTestId("day-calendar-grid")).toHaveCount(0);
@@ -36,16 +55,14 @@ test.describe("Agenda toggle inside Day and Week views (#150 + #235)", () => {
 
     // Switching to Week + Agenda from Day+Agenda commits both a view change
     // and keeps agenda mode on via the Week caret's Agenda sub-option.
-    await page.getByTestId("view-switcher-week-mode").click();
-    await page.getByRole("menuitemradio", { name: /agenda/i }).click();
+    await pickSubMode(page, "week", "agenda");
 
     // Week range header replaces Day header; AgendaList stays.
     await expect(page.getByTestId("agenda-list")).toBeVisible();
     await expect(page.getByTestId("week-calendar-range")).toBeVisible();
 
     // Week+Agenda → Week (grid) via the Grid sub-option.
-    await page.getByTestId("view-switcher-week-mode").click();
-    await page.getByRole("menuitemradio", { name: /grid/i }).click();
+    await pickSubMode(page, "week", "grid");
 
     // Week time-grid is back, AgendaList is gone.
     await expect(page.getByTestId("agenda-list")).toHaveCount(0);
@@ -62,7 +79,7 @@ test.describe("Agenda toggle inside Day and Week views (#150 + #235)", () => {
     page,
   }) => {
     // Start in Month so the primary Day click is a real view change.
-    await page.goto("/test/calendar?events=default&view=month");
+    await page.goto("/test/calendar?events=default&view=month&transitionMs=0");
 
     // Click the primary Day button — should land in Day grid view, no menu.
     await page.getByTestId("view-switcher-day").click();
@@ -73,7 +90,7 @@ test.describe("Agenda toggle inside Day and Week views (#150 + #235)", () => {
 
   test("primary Week button preserves agenda mode — #235", async ({ page }) => {
     // Pre-toggle Day+Agenda via the Day caret.
-    await page.goto("/test/calendar?events=default&view=day");
+    await page.goto("/test/calendar?events=default&view=day&transitionMs=0");
     await page.getByTestId("view-switcher-day-mode").click();
     await page.getByRole("menuitemradio", { name: /agenda/i }).click();
     await expect(page.getByTestId("agenda-list")).toBeVisible();
@@ -88,7 +105,7 @@ test.describe("Agenda toggle inside Day and Week views (#150 + #235)", () => {
   test("agenda mode preserves the selected date when toggled", async ({
     page,
   }) => {
-    await page.goto("/test/calendar?events=default&view=day");
+    await page.goto("/test/calendar?events=default&view=day&transitionMs=0");
     const heading = page.getByTestId("day-calendar-heading");
     const startingHeading = await heading.textContent();
 
@@ -107,7 +124,7 @@ test.describe("Agenda toggle inside Day and Week views (#150 + #235)", () => {
   });
 
   test("primary Day label reflects the current sub-mode", async ({ page }) => {
-    await page.goto("/test/calendar?events=default&view=day");
+    await page.goto("/test/calendar?events=default&view=day&transitionMs=0");
     const dayBtn = page.getByTestId("view-switcher-day");
 
     // Initially in grid mode — the primary reads just "Day".
@@ -126,7 +143,7 @@ test.describe("Agenda toggle inside Day and Week views (#150 + #235)", () => {
     // clicks on sibling buttons after the dropdown closed. With
     // `modal={false}` the overlay is gone and Year click should land
     // immediately.
-    await page.goto("/test/calendar?events=default&view=month");
+    await page.goto("/test/calendar?events=default&view=month&transitionMs=0");
 
     // Open the Week caret menu, then dismiss without picking anything.
     await page.getByTestId("view-switcher-week-mode").click();
@@ -145,7 +162,7 @@ test.describe("Agenda toggle inside Day and Week views (#150 + #235)", () => {
 
   test("Month is unaffected by the agenda mode setting", async ({ page }) => {
     // Pre-toggle agenda mode via the Day caret.
-    await page.goto("/test/calendar?events=default&view=day");
+    await page.goto("/test/calendar?events=default&view=day&transitionMs=0");
     await page.getByTestId("view-switcher-day-mode").click();
     await page.getByRole("menuitemradio", { name: /agenda/i }).click();
     await expect(page.getByTestId("agenda-list")).toBeVisible();

--- a/e2e/analog-clock-floating-labels.spec.ts
+++ b/e2e/analog-clock-floating-labels.spec.ts
@@ -49,8 +49,10 @@ test.describe("Analog Clock — floating off-arc labels (#311)", () => {
     await page.goto("/test/analog-clock?scenario=default&hour=10&min=10");
     const connector = page.getByTestId("floating-label-connector-d3");
     await expect(connector).toBeAttached();
-    // d3 is the blue Team Standup event.
-    await expect(connector).toHaveAttribute("stroke", "#3B82F6");
+    // d3 is the blue Team Standup event. The DOM serializes the stroke in
+    // lower-case (#3b82f6); match case-insensitively so the assertion doesn't
+    // depend on hex casing.
+    await expect(connector).toHaveAttribute("stroke", /^#3b82f6$/i);
   });
 
   test("the analog clock SVG carries overflow='visible' so labels can paint outside the viewBox", async ({

--- a/e2e/auth/auth-setup.ts
+++ b/e2e/auth/auth-setup.ts
@@ -257,9 +257,18 @@ export async function withAuthenticatedPage<T>(
 }
 
 /**
- * Disconnect database pool (call in afterAll)
+ * Disconnect database pool (call in afterAll).
+ *
+ * Idempotent: the pool is a module-level singleton shared by every spec in a
+ * worker, so with Playwright's `workers: 1` (CI) more than one spec file's
+ * `afterAll` ends up calling this against the same pool. `pg`'s `pool.end()`
+ * throws "Called end on pool more than once" on the second call, so we guard
+ * with a flag and only end the pool the first time.
  */
+let poolEnded = false;
 export async function disconnectDatabase(): Promise<void> {
+  if (poolEnded) return;
+  poolEnded = true;
   await pool.end();
 }
 

--- a/e2e/calendar-filter-panel.spec.ts
+++ b/e2e/calendar-filter-panel.spec.ts
@@ -12,8 +12,13 @@ test.use({ video: "on" });
 
 test.describe("CalendarFilterPanel", () => {
   test.beforeEach(async ({ page }) => {
+    // Week-agenda (not day-agenda) so the whole family event set — which spans
+    // today..+3 days — falls inside the visible window. `anchor` pins "today"
+    // to a Monday so every relative event lands in the same Sun–Sat week
+    // regardless of the day the suite runs. transitionMs=0 avoids transient
+    // AnimatedSwap duplicates when the filtered list re-renders.
     await page.goto(
-      "/test/calendar?events=family&filters=true&view=agenda&controls=false"
+      "/test/calendar?events=family&filters=true&view=week&agendaMode=true&controls=false&anchor=2026-06-15&transitionMs=0"
     );
   });
 

--- a/e2e/calendar-settings-panel.spec.ts
+++ b/e2e/calendar-settings-panel.spec.ts
@@ -13,7 +13,9 @@ import { expect, test } from "@playwright/test";
 
 test.describe("CalendarSettingsPanel", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto("/test/calendar?events=default&view=month&sidebar=true");
+    await page.goto(
+      "/test/calendar?events=default&view=month&sidebar=true&transitionMs=0"
+    );
   });
 
   test("opens the settings panel from the gear trigger and exposes all four controls", async ({
@@ -33,11 +35,14 @@ test.describe("CalendarSettingsPanel", () => {
   test("switching week start to Monday reorders both calendar grids", async ({
     page,
   }) => {
-    const miniDow = page.getByTestId("mini-calendar-dow");
+    // The main month grid and the mini-calendar sidebar are never visible at
+    // the same time (the sidebar is hidden in month view — #146/#214), so we
+    // verify the main grid in month view, then switch to day view — which
+    // preserves the week-start setting in provider state — to verify the
+    // mini-calendar reorders too.
     const mainDow = page.getByTestId("calendar-dow");
 
-    // Default Sunday-first ordering in both grids
-    await expect(miniDow.first()).toHaveText("S");
+    // Default Sunday-first ordering in the main month grid.
     await expect(mainDow.first()).toHaveText("Sun");
 
     await page.getByTestId("calendar-settings-trigger").click();
@@ -46,13 +51,19 @@ test.describe("CalendarSettingsPanel", () => {
       .getByTestId("setting-week-start-day-monday")
       .click();
 
-    // Close the popover so the assertion targets the underlying grids.
+    // Close the popover so the assertion targets the underlying grid.
     await page.keyboard.press("Escape");
 
-    await expect(miniDow.first()).toHaveText("M");
-    await expect(miniDow.nth(6)).toHaveText("S");
     await expect(mainDow.first()).toHaveText("Mon");
     await expect(mainDow.nth(6)).toHaveText("Sun");
+
+    // Switch to day view (primary button preserves the setting) — the
+    // mini-calendar sidebar is now visible and must honour Monday-first too.
+    await page.getByTestId("view-switcher-day").click();
+
+    const miniDow = page.getByTestId("mini-calendar-dow");
+    await expect(miniDow.first()).toHaveText("M");
+    await expect(miniDow.nth(6)).toHaveText("S");
   });
 
   test("week view also honours the Monday-first setting (#205)", async ({

--- a/e2e/calendar-transition-speed.spec.ts
+++ b/e2e/calendar-transition-speed.spec.ts
@@ -72,7 +72,9 @@ test.describe("Calendar transition speed (#283)", () => {
   }) => {
     await page.goto("/test/calendar?events=default&view=month&transitionMs=0");
 
-    await page.getByTestId("view-switcher-day").click();
+    // After #235 the primary Day button switches view directly; the Grid/Agenda
+    // menu lives behind the `-mode` caret. Open the caret to pick Agenda.
+    await page.getByTestId("view-switcher-day-mode").click();
     await page.getByRole("menuitemradio", { name: /agenda/i }).click();
 
     // No outgoing snapshot for the cross-view fade either.

--- a/e2e/calendar.spec.ts
+++ b/e2e/calendar.spec.ts
@@ -117,7 +117,12 @@ test.describe("Agenda Calendar", () => {
     await page.goto("/test/calendar?events=default&view=agenda");
   });
 
-  test("displays 'Upcoming Events' header", async ({ page }) => {
+  // SKIPPED: the on-page agenda search surface (legacy AgendaCalendar, with the
+  // "Upcoming Events" header) was removed from /test/calendar by #287 — agenda
+  // now renders via DayCalendar + AgendaList, which has no such header. Pending a
+  // product decision on whether/where agenda search is reachable (tracked in the
+  // agenda-search-access issue), this assertion is parked rather than rewritten.
+  test.skip("displays 'Upcoming Events' header", async ({ page }) => {
     await expect(page.getByText("Upcoming Events")).toBeVisible();
   });
 
@@ -154,7 +159,11 @@ test.describe("Agenda Calendar", () => {
 });
 
 test.describe("Agenda Calendar - Empty State", () => {
-  test("shows empty message when no upcoming events", async ({ page }) => {
+  // SKIPPED: "No upcoming events in the next 7 days" is the legacy AgendaCalendar
+  // empty copy. The current day-agenda surface (AgendaList) renders a
+  // per-range empty label instead. Parked pending the agenda-search-access
+  // product decision rather than rewritten to the new copy.
+  test.skip("shows empty message when no upcoming events", async ({ page }) => {
     await page.goto("/test/calendar?events=empty&view=agenda");
 
     await expect(
@@ -212,7 +221,9 @@ test.describe("View Switcher", () => {
   });
 
   test("maintains events when switching views", async ({ page }) => {
-    await page.goto("/test/calendar?events=default&view=month");
+    // transitionMs=0 → instant swap, so "Morning Standup" can't resolve to
+    // both the outgoing month grid and the incoming agenda layer mid-fade.
+    await page.goto("/test/calendar?events=default&view=month&transitionMs=0");
 
     // Verify event in month view
     await expect(page.getByText("Morning Standup")).toBeVisible();
@@ -304,7 +315,10 @@ test.describe("Responsive Design", () => {
     await page.setViewportSize({ width: 375, height: 667 });
     await page.goto("/test/calendar?events=default&view=agenda");
 
-    await expect(page.getByText("Upcoming Events")).toBeVisible();
+    // Agenda now renders via DayCalendar + AgendaList (#287); assert the
+    // agenda surface itself plus a today event rather than the removed
+    // legacy "Upcoming Events" header.
+    await expect(page.getByTestId("agenda-list")).toBeVisible();
     await expect(page.getByText("Morning Standup")).toBeVisible();
   });
 

--- a/e2e/event-detail-modal.spec.ts
+++ b/e2e/event-detail-modal.spec.ts
@@ -89,7 +89,13 @@ test.describe("Event detail modal — month view", () => {
 
 test.describe("Event detail modal — agenda view", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto("/test/calendar?events=default&view=agenda");
+    // "Client Call" is a +1-day event, so a single-day day-agenda would window
+    // it out. Use week-agenda with a Monday anchor so tomorrow's event is in
+    // range deterministically. transitionMs=0 keeps the swap from briefly
+    // duplicating the event card.
+    await page.goto(
+      "/test/calendar?events=default&view=week&agendaMode=true&anchor=2026-06-15&transitionMs=0"
+    );
     await expect(
       page.getByRole("button", { name: /Client Call/ })
     ).toBeVisible();

--- a/e2e/mini-calendar-sidebar.spec.ts
+++ b/e2e/mini-calendar-sidebar.spec.ts
@@ -112,7 +112,9 @@ test.describe("MiniCalendarSidebar", () => {
   }) => {
     // The `overflow` mock set puts 10 events on today, cycling through
     // blue/green/red/yellow/purple/orange — at least 6 distinct colors.
-    await page.goto("/test/calendar?events=overflow&view=month&sidebar=true");
+    // Use an agenda view: the mini-calendar sidebar is intentionally hidden in
+    // month view (it would duplicate the main grid — #146/#214).
+    await page.goto("/test/calendar?events=overflow&view=agenda&sidebar=true");
 
     const todayCell = page
       .getByTestId("mini-calendar-sidebar")

--- a/e2e/month-calendar-overflow-popover.spec.ts
+++ b/e2e/month-calendar-overflow-popover.spec.ts
@@ -7,7 +7,11 @@ import { expect, test } from "@playwright/test";
 // not legal mid-describe). Splitting these specs into their own file
 // preserves the per-describe scoping intent without affecting the rest of
 // `calendar.spec.ts`.
-test.use({ video: "on" });
+// A tall viewport keeps the 10-event popover opening downward and fully on
+// screen. At the default 720px height Radix flips it upward (not enough room
+// below the mid-grid trigger), which pushes the header close button above the
+// viewport top so Playwright can't click it.
+test.use({ video: "on", viewport: { width: 1280, height: 1400 } });
 
 test.describe("Month Calendar - Day Overflow Popover", () => {
   // Read today's key inside the browser after navigation so the test and the

--- a/e2e/new-task-modal.spec.ts
+++ b/e2e/new-task-modal.spec.ts
@@ -117,7 +117,11 @@ test.describe("NewTaskModal launched from TaskList", () => {
     await page.getByRole("button", { name: /add task/i }).click();
     const dialog = page.getByRole("dialog");
 
+    // The List select is labelled only once the task lists have loaded; wait
+    // for it to be present before asserting the smart-default value so the
+    // check doesn't race the async lists fetch.
     const listSelect = dialog.getByLabel(/^list/i);
+    await expect(listSelect).toBeVisible();
     await expect(listSelect).toHaveValue("list-groceries");
   });
 
@@ -130,7 +134,10 @@ test.describe("NewTaskModal launched from TaskList", () => {
     await page.getByRole("button", { name: /add task/i }).click();
     const dialog = page.getByRole("dialog");
 
+    // Wait for the dialog's List select to mount before asserting its value so
+    // the check doesn't race the modal's open transition.
     const listSelect = dialog.getByLabel(/^list/i);
+    await expect(listSelect).toBeVisible();
     await expect(listSelect).toHaveValue("");
   });
 

--- a/e2e/reward-points.spec.ts
+++ b/e2e/reward-points.spec.ts
@@ -135,7 +135,15 @@ async function mockTasksApi(page: Page, initial: MockTask[]) {
 }
 
 test.describe("Reward points happy path (#173)", () => {
-  test("badge starts at 50 → completing a task POSTs award → animation appears + badge updates to 60", async ({
+  // SKIPPED: this asserts the transient "+N points!" banner that the TaskItem
+  // renders on the incomplete→complete transition. The banner is hosted by the
+  // same TaskItem row that is being completed, and the award POST + task refetch
+  // + animation mount race non-deterministically (the award sometimes posts 0
+  // points, sometimes the row unmounts before the banner paints). This is a real
+  // rewards-feature lifecycle issue rather than e2e-workflow test drift, so it's
+  // parked here and tracked in its own issue rather than masked with waits. The
+  // sibling already-awarded / disabled cases below still run.
+  test.skip("badge starts at 50 → completing a task POSTs award → animation appears + badge updates to 60", async ({
     page,
   }) => {
     const points = await mockPointsApi(page, {

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -1,4 +1,57 @@
-import { expect, test } from "@playwright/test";
+import { type Page, expect, test } from "@playwright/test";
+
+/**
+ * Task settings ("Show completed tasks", "Default sort order") persist per
+ * profile via `/api/profiles/:id/settings`, and the form silently no-ops them
+ * when there is no active profile. The /test/settings harness has no real
+ * session, so without these mocks the root-layout ProfileProvider fetches an
+ * empty profile list and those controls never apply. Seed one profile and a
+ * stateful settings endpoint so the task controls behave like a signed-in user.
+ */
+async function mockActiveProfile(page: Page): Promise<void> {
+  const profile = {
+    id: "test-profile-1",
+    userId: "test-user-1",
+    name: "Admin",
+    type: "admin",
+    ageGroup: "adult",
+    color: "#3b82f6",
+    avatar: { type: "initials", value: "A" },
+    pinEnabled: false,
+    isActive: true,
+  };
+  await page.route("**/api/profiles", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([profile]),
+    })
+  );
+  const taskSettings: Record<string, unknown> = {
+    taskSortOrder: "dueDate",
+    showCompletedTasks: false,
+  };
+  await page.route("**/api/profiles/*/settings", async (route) => {
+    if (route.request().method() === "PUT") {
+      Object.assign(taskSettings, route.request().postDataJSON() ?? {});
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(taskSettings),
+    });
+  });
+}
+
+/** Re-load /test/settings with profile mocks active and wait for the profile's
+ *  task settings to load, so the task controls are interactive. */
+async function gotoSettingsWithProfile(page: Page): Promise<void> {
+  await mockActiveProfile(page);
+  await page.goto("/test/settings");
+  await page.waitForResponse((r) =>
+    /\/api\/profiles\/[^/]+\/settings/.test(r.url())
+  );
+}
 
 test.describe("Settings Page (/test/settings)", () => {
   test.beforeEach(async ({ page }) => {
@@ -225,6 +278,12 @@ test.describe("Settings Page (/test/settings)", () => {
   });
 
   test.describe("Tasks Section", () => {
+    // Task settings persist per profile; re-load with an active profile so the
+    // sort-order select and show-completed toggle actually apply.
+    test.beforeEach(async ({ page }) => {
+      await gotoSettingsWithProfile(page);
+    });
+
     test("shows section description", async ({ page }) => {
       await expect(
         page.getByText("Configure task list defaults")
@@ -258,8 +317,9 @@ test.describe("Settings Page (/test/settings)", () => {
     });
 
     test("can open sort order dropdown and see options", async ({ page }) => {
-      // Click the select trigger to open dropdown
-      await page.getByRole("combobox").click();
+      // Scope to the sort-order select by its label — the calendar transition
+      // speed setting (#283) adds a second combobox to this page.
+      await page.getByRole("combobox", { name: /default sort order/i }).click();
 
       await expect(
         page.getByRole("option", { name: "Due Date" })
@@ -274,11 +334,14 @@ test.describe("Settings Page (/test/settings)", () => {
     });
 
     test("can change sort order", async ({ page }) => {
-      await page.getByRole("combobox").click();
+      const sortSelect = page.getByRole("combobox", {
+        name: /default sort order/i,
+      });
+      await sortSelect.click();
       await page.getByRole("option", { name: "Title" }).click();
 
       // The trigger should now show "Title"
-      await expect(page.getByRole("combobox")).toHaveText("Title");
+      await expect(sortSelect).toHaveText("Title");
     });
   });
 
@@ -338,6 +401,9 @@ test.describe("Settings Page (/test/settings)", () => {
       await page.route("**/api/settings", (route) =>
         route.fulfill({ status: 200, body: "{}" })
       );
+      // Show-completed-tasks is a per-profile task setting, so load with an
+      // active profile (and its mocked settings endpoint) too.
+      await gotoSettingsWithProfile(page);
 
       const radio24h = page.locator('input[name="timeFormat"][value="24h"]');
 

--- a/e2e/side-navigation.spec.ts
+++ b/e2e/side-navigation.spec.ts
@@ -1,4 +1,11 @@
 import { type Page, expect, test } from "@playwright/test";
+import {
+  type AuthenticatedUser,
+  cleanupTestUser,
+  createTestUser,
+  disconnectDatabase,
+  setAuthCookies,
+} from "./auth/auth-setup";
 
 /**
  * E2E tests for the left-side navigation bar (PR #132).
@@ -37,6 +44,28 @@ async function expectActiveNavLink(page: Page, label: string) {
 }
 
 test.describe("Side navigation bar transitions", () => {
+  // /calendar is auth-gated (unauthenticated requests 307 → /auth/signin), and
+  // the AppShell nav + ScreenTransition only mount on the real app routes. Seed
+  // a DB-backed session so the nav-driven routes render the shell instead of
+  // redirecting to sign-in.
+  let authUser: AuthenticatedUser | null = null;
+
+  test.beforeEach(async ({ context }) => {
+    authUser = await createTestUser();
+    await setAuthCookies(context, authUser.sessionToken);
+  });
+
+  test.afterEach(async () => {
+    if (authUser) {
+      await cleanupTestUser(authUser.userId);
+      authUser = null;
+    }
+  });
+
+  test.afterAll(async () => {
+    await disconnectDatabase();
+  });
+
   test("clicking nav icons slides between screens and highlights active icon", async ({
     page,
   }) => {

--- a/e2e/week-day-views.spec.ts
+++ b/e2e/week-day-views.spec.ts
@@ -149,7 +149,11 @@ test.describe("View switcher navigation", () => {
   test("cycles Month → Week → Day → Day+Agenda and back to Month", async ({
     page,
   }) => {
-    await page.goto("/test/calendar?events=default&view=month");
+    // transitionMs=0 makes view swaps instant so a testid like `agenda-list`
+    // never resolves to both the incoming and outgoing AnimatedSwap layers
+    // mid-fade (strict-mode violation). View-switch animation itself is
+    // covered by calendar-transition-speed.spec.ts.
+    await page.goto("/test/calendar?events=default&view=month&transitionMs=0");
     await expect(page.getByText("Sun", { exact: true }).first()).toBeVisible();
 
     // After #235, Day and Week are split buttons — primary click switches

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -48,9 +48,13 @@ export default defineConfig({
     },
   ],
 
-  // Run local dev server before starting tests
+  // Local dev uses the Turbopack dev server for fast iteration. CI runs against
+  // a production build (`next start`, built in a prior workflow step): the dev
+  // server's on-demand compilation and memory growth starved late-running specs
+  // under `workers: 1`, causing flaky 30s timeouts. A prebuilt server serves
+  // every route instantly and stays stable for the whole run.
   webServer: {
-    command: "pnpm dev",
+    command: process.env.CI ? "pnpm start" : "pnpm dev",
     url: "http://localhost:3000",
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000,

--- a/src/components/calendar/ViewSwitcher.tsx
+++ b/src/components/calendar/ViewSwitcher.tsx
@@ -10,6 +10,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import type { TCalendarView } from "@/types/calendar";
+import { useState } from "react";
 import {
   Calendar,
   CalendarDays,
@@ -155,6 +156,12 @@ function SplitViewControl({
   const currentValue = active && agendaMode ? "agenda" : "grid";
   const variant = active ? "default" : "ghost";
 
+  // Control the menu's open state so it closes after a sub-mode is picked.
+  // With the uncontrolled default + `modal={false}`, the menu lingered open
+  // after a selection, so reopening the same caret toggled it shut instead of
+  // re-opening it.
+  const [menuOpen, setMenuOpen] = useState(false);
+
   return (
     <div
       role="group"
@@ -176,7 +183,7 @@ function SplitViewControl({
       {/* `modal={false}` prevents Radix from installing the body-level
           overlay that previously left sibling buttons unclickable after
           dismissal (issue #235). */}
-      <DropdownMenu modal={false}>
+      <DropdownMenu modal={false} open={menuOpen} onOpenChange={setMenuOpen}>
         <DropdownMenuTrigger asChild>
           <Button
             type="button"
@@ -192,7 +199,10 @@ function SplitViewControl({
         <DropdownMenuContent align="start">
           <DropdownMenuRadioGroup
             value={currentValue}
-            onValueChange={(value) => onSelectMode(value as "grid" | "agenda")}
+            onValueChange={(value) => {
+              onSelectMode(value as "grid" | "agenda");
+              setMenuOpen(false);
+            }}
           >
             <DropdownMenuRadioItem value="grid">Grid</DropdownMenuRadioItem>
             <DropdownMenuRadioItem value="agenda">Agenda</DropdownMenuRadioItem>

--- a/src/components/settings/task-section.tsx
+++ b/src/components/settings/task-section.tsx
@@ -26,12 +26,12 @@ export function TaskSection({ values, onChange }: TaskSectionProps) {
     <SettingsSection title="Tasks" description="Configure task list defaults">
       <div className="space-y-6">
         <div className="space-y-2">
-          <Label>Default sort order</Label>
+          <Label id="task-sort-order-label">Default sort order</Label>
           <Select
             value={values.taskSortOrder}
             onValueChange={(value) => onChange({ taskSortOrder: value })}
           >
-            <SelectTrigger>
+            <SelectTrigger aria-labelledby="task-sort-order-label">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>


### PR DESCRIPTION
## Summary

The E2E workflow added in #369 failed on its first run with **41 failing Playwright tests** — the first time the full suite had ever run in CI. The failures were pre-existing drift (specs lagging behind #150 agenda-in-day/week, #235 split view buttons, #283 transition speed, #287 removal of the legacy on-page agenda surface) plus a couple of small real bugs the tests surfaced.

Every failure was reproduced locally (Postgres + Playwright Chromium) and fixed by root cause.

This PR has **two parts**:
1. **Repair the failing specs** (commit 1) — realign tests with current behavior; fix two small app bugs.
2. **Stabilize the E2E workflow** (commit 2) — run against a production build, on merge to `main` only, with auto-filed issues on failure.

## Part 1 — App fixes (2 real bugs the tests surfaced)

| File | Change | Why |
|---|---|---|
| `ViewSwitcher.tsx` | Control the Day/Week display-mode caret menu and close it after a sub-mode is selected | Uncontrolled + `modal={false}` left it open, so reopening the same caret toggled it shut — broke the round-trip and was poor UX |
| `task-section.tsx` | Give the "Default sort order" Select an accessible name via `aria-labelledby` | No accessible name; #283 added a second combobox so `getByRole('combobox')` was ambiguous |

### Test fixes by root cause
- **AnimatedSwap duplicate layers** — `transitionMs=0` so a testid can't match both fade layers (agenda-toggle, week-day-views, calendar).
- **Day-agenda windows to one day (#150)** — week-agenda + fixed Monday `anchor` for multi-day events (calendar-filter-panel, event-detail-modal).
- **Sidebar hidden in month view (#146/#214)** — use views where the mini-calendar renders; verify both grids via an in-page view switch (mini-calendar-sidebar, calendar-settings-panel).
- **Split buttons (#235) / removed header (#287)** — open the caret + assert the `AgendaList` surface (calendar-transition-speed, mobile agenda).
- **Per-profile task settings** — mock an active profile so the show-completed toggle / sort order apply on `/test/settings`.
- **`/calendar` auth-gated** — seed a DB session for side-navigation.
- **Shared pg pool** — idempotent `disconnectDatabase` (shared across specs under `workers:1`).
- **Misc** — case-insensitive hex match; taller viewport for the overflow popover; wait for the new-task modal's List select.

### Parked (skipped, not deleted) — per maintainer decision
- **Legacy agenda search specs** → skipped, pointing to design issue **#421** (drop / add to AgendaList / global search).
- **Reward-points happy path** → skipped; the "+N points!" banner races the task refetch/unmount on completion (a real rewards lifecycle issue, not drift).

## Part 2 — Workflow stabilization (`.github/workflows/e2e.yml`, `playwright.config.ts`)

The first CI run also revealed the suite was **flaky against the Turbopack dev server**: under `workers:1`, on-demand route compilation + dev-server memory growth starved late-running specs, causing stochastic 30s timeouts (a different ~3 specs failed each run). Per maintainer direction:

- **Production build** — `next build` once, then Playwright's `webServer` runs `pnpm start` in CI (local dev still uses `pnpm dev`). Stable, prebuilt, fast.
- **On merge to `main` only** — dropped the `pull_request` trigger (kept `workflow_dispatch`). Trades PR-time visibility for a short PR loop. *(That's why this PR no longer shows an `e2e` check — only `ci` runs on PRs now.)*
- **Auto-file issues on failure** — a `failure()` step opens/updates a rolling `e2e-failure` issue so a red `main` enters normal triage.
- `TOKEN_ENCRYPTION_KEY` set (throwaway CI key) since the prod build runs `NODE_ENV=production`.

## Test plan

- [x] `pnpm test:run` → 2533 unit tests passing
- [x] `pnpm check-types` → clean · `pnpm lint` → 0 errors
- [x] Full Playwright suite vs **dev** server → all targeted fixes green
- [x] Full Playwright suite vs **production build** (`next build` + `next start`, mirroring the new workflow) → **290 passed / 26 skipped / 0 failed in ~3.5m**

Relates to #369, #281. Agenda-search direction tracked in #421.

🤖 Generated with [Claude Code](https://claude.com/claude-code)