### PR TITLE
refactor(settings): narrow timeFormat to TTimeFormat (#423)

### DIFF
--- a/.claude/plans/timeformat-narrow-423.md
+++ b/.claude/plans/timeformat-narrow-423.md
@@ -1,0 +1,84 @@
+# Narrow `UserSettingsData.timeFormat` to `TTimeFormat` — #423
+
+Pure refactor. No runtime behaviour change. Mirrors the (in-flight in #390)
+`dateFormat: TDateFormat` narrowing for the sibling `timeFormat` field, and
+matches the existing pattern already in place for `weekStartDay` /
+`calendarTransitionSpeed`.
+
+## Goal
+
+`UserSettingsData.timeFormat` and `DisplayValues.timeFormat` carry the narrow
+`TTimeFormat = "12h" | "24h"` union from `src/hooks/useUserSettings.ts`,
+matching how `useUserSettings.UserCalendarSettings.timeFormat` already types
+the field. The server-side `/api/settings/route.ts` validator already enforces
+the allow-list on PUT, so this is type-safety only.
+
+## Acceptance criteria (from issue body)
+
+- [x] `UserSettingsData.timeFormat: TTimeFormat`
+- [x] `DisplayValues.timeFormat: TTimeFormat`
+- [x] No `as TTimeFormat` casts introduced (and remove the existing one at
+      `useUserSettings.ts:249` since the new typeguard makes it unnecessary)
+- [x] Full test suite passes
+- [x] `pnpm lint:fix && pnpm format:fix && pnpm check-types` clean
+
+## File-level changes
+
+1. **`src/hooks/useUserSettings.ts`**
+   - Export a typeguard `isTimeFormat(value: unknown): value is TTimeFormat`
+     that wraps the existing `VALID_TIME_FORMATS` array. No duplicated
+     allow-list.
+   - Replace `picked.timeFormat = data.timeFormat as TTimeFormat` (line 249)
+     with the typeguarded form (no cast).
+
+2. **`src/components/settings/settings-form.tsx`**
+   - `interface UserSettingsData.timeFormat: string` → `TTimeFormat`.
+   - Import `TTimeFormat` from `@/hooks/useUserSettings`.
+
+3. **`src/components/settings/display-section.tsx`**
+   - `interface DisplayValues.timeFormat: string` → `TTimeFormat`.
+   - Update the time-format `RadioGroup`'s `onValueChange` to narrow the raw
+     string via `isTimeFormat` (the Radix callback signature is
+     `(value: string) => void`, so we must validate before forwarding). A
+     non-allow-listed value is silently ignored — the only producers are the
+     `"12h"`/`"24h"` radio items so this branch is unreachable in practice
+     but type-safe.
+
+4. **`src/app/settings/page.tsx`**
+   - Coerce `settings.timeFormat` (Prisma's `string`) at the server-rendered
+     boundary using the typeguard, with a `"12h"` fallback that mirrors the
+     Prisma `@default` and the `DEFAULT_USER_CALENDAR_SETTINGS` default.
+     Parallel to the existing `calendarTransitionSpeed` shape on this page.
+
+5. **`src/test/fixtures/user-settings.ts`**
+   - Add `timeFormat` to the `Omit<UserSettings, …>` list and add
+     `timeFormat: TTimeFormat` to the override block — same pattern as
+     `weekStartDay` and `calendarTransitionSpeed` already in the fixture.
+     The fixture's `timeFormat: "12h"` literal default stays.
+
+6. **`src/app/test/time-format-sync/page.tsx` & `src/app/test/settings/page.tsx`**
+   - Both pass `timeFormat: "12h"` as a literal — TS narrows literals to
+     their union member automatically. No code change required, but they're
+     covered by `check-types` so any regression will surface.
+
+## Tests
+
+- New unit test `src/hooks/__tests__/useUserSettings.test.tsx`:
+  - `isTimeFormat` returns `true` for `"12h"` / `"24h"`, `false` for
+    `"13h"`, `""`, `null`, `undefined`, `0`.
+- Existing `display-section.test.tsx`, `settings-form.test.tsx`, and
+  `useUserSettings.test.tsx` must pass unchanged — pure refactor.
+
+## Independence
+
+PR #390 narrows the sibling `dateFormat` field. The only files both PRs
+touch are `interface UserSettingsData` (one-line edit) and the
+`MockUserSettings` fixture (one-line edit). Whichever lands second has a
+trivial conflict resolution.
+
+## Out of scope
+
+- The `/api/settings` server validator already enforces the allow-list;
+  hardening that further is unrelated.
+- `useUserSettings.UserCalendarSettings.timeFormat` is already `TTimeFormat`
+  — no change there.

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,4 +1,5 @@
 import { SettingsForm } from "@/components/settings/settings-form";
+import { isTimeFormat } from "@/hooks/useUserSettings";
 import { getSession } from "@/lib/auth";
 import {
   DEFAULT_CALENDAR_TRANSITION_SPEED,
@@ -48,7 +49,13 @@ export default async function SettingsPage() {
         providers={providers}
         initialSettings={{
           theme: settings.theme,
-          timeFormat: settings.timeFormat,
+          // Coerce the Prisma `string` to the application-level `TTimeFormat`
+          // union; fall back to the schema default if a manually-edited row
+          // ever contains a non-allow-listed value. Parallel to the
+          // `calendarTransitionSpeed` shape below.
+          timeFormat: isTimeFormat(settings.timeFormat)
+            ? settings.timeFormat
+            : "12h",
           // Narrow at the boundary so the form's `UserSettingsData` can
           // carry the strong `TDateFormat` type — a stale DB row with an
           // unknown value falls back to the schema default.

--- a/src/components/settings/display-section.tsx
+++ b/src/components/settings/display-section.tsx
@@ -3,6 +3,7 @@
 import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Slider } from "@/components/ui/slider";
+import { type TTimeFormat, isTimeFormat } from "@/hooks/useUserSettings";
 import type { TDateFormat } from "@/lib/format-date";
 import type { TWeekStartDay } from "@/types/calendar";
 import { useTheme } from "next-themes";
@@ -10,7 +11,7 @@ import { SettingsSection } from "./settings-section";
 
 interface DisplayValues {
   theme: string;
-  timeFormat: string;
+  timeFormat: TTimeFormat;
   dateFormat: TDateFormat;
   defaultZoomLevel: number;
   weekStartDay: TWeekStartDay;
@@ -77,7 +78,16 @@ export function DisplaySection({ values, onChange }: DisplaySectionProps) {
           </legend>
           <RadioGroup
             value={values.timeFormat}
-            onValueChange={(timeFormat) => onChange({ timeFormat })}
+            onValueChange={(timeFormat) => {
+              // Radix forwards the raw string of the selected radio item.
+              // Both items below render values in the TTimeFormat union, so
+              // this branch only filters out theoretical garbage from
+              // future DOM tampering — TypeScript no longer accepts a
+              // widened string at the callsite.
+              if (isTimeFormat(timeFormat)) {
+                onChange({ timeFormat });
+              }
+            }}
             className="mt-2 flex gap-4"
           >
             <Label className="flex items-center gap-2">

--- a/src/hooks/__tests__/useUserSettings.test.tsx
+++ b/src/hooks/__tests__/useUserSettings.test.tsx
@@ -7,6 +7,7 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   DEFAULT_USER_CALENDAR_SETTINGS,
+  isTimeFormat,
   useUserSettings,
 } from "../useUserSettings";
 
@@ -734,5 +735,26 @@ describe("useUserSettings", () => {
       ).not.toThrow();
       expect(result.current.settings.timeFormat).toBe("12h");
     });
+  });
+});
+
+describe("isTimeFormat", () => {
+  it("accepts the two valid literal values", () => {
+    expect(isTimeFormat("12h")).toBe(true);
+    expect(isTimeFormat("24h")).toBe(true);
+  });
+
+  it("rejects similar-looking strings outside the allow-list", () => {
+    expect(isTimeFormat("13h")).toBe(false);
+    expect(isTimeFormat("12H")).toBe(false);
+    expect(isTimeFormat("12")).toBe(false);
+    expect(isTimeFormat("")).toBe(false);
+  });
+
+  it("rejects non-string inputs", () => {
+    expect(isTimeFormat(null)).toBe(false);
+    expect(isTimeFormat(undefined)).toBe(false);
+    expect(isTimeFormat(12)).toBe(false);
+    expect(isTimeFormat({})).toBe(false);
   });
 });

--- a/src/hooks/useUserSettings.ts
+++ b/src/hooks/useUserSettings.ts
@@ -28,6 +28,13 @@ export type TTimeFormat = "12h" | "24h";
 
 const VALID_TIME_FORMATS: readonly TTimeFormat[] = ["12h", "24h"] as const;
 
+export function isTimeFormat(value: unknown): value is TTimeFormat {
+  return (
+    typeof value === "string" &&
+    (VALID_TIME_FORMATS as readonly string[]).includes(value)
+  );
+}
+
 export interface UserCalendarSettings {
   calendarRefreshIntervalMinutes: number;
   calendarFetchMonthsAhead: number;
@@ -255,11 +262,8 @@ function pickCalendarFields(
   ) {
     picked.defaultZoomLevel = data.defaultZoomLevel;
   }
-  if (
-    typeof data.timeFormat === "string" &&
-    (VALID_TIME_FORMATS as readonly string[]).includes(data.timeFormat)
-  ) {
-    picked.timeFormat = data.timeFormat as TTimeFormat;
+  if (isTimeFormat(data.timeFormat)) {
+    picked.timeFormat = data.timeFormat;
   }
   // Same defensive contract as `timeFormat`: unknown values are dropped so a
   // stale DB row or a typo'd bus emit doesn't poison `formatUserDate` with a

--- a/src/test/fixtures/user-settings.ts
+++ b/src/test/fixtures/user-settings.ts
@@ -16,6 +16,7 @@
  * supplied, and every consuming test inherits it for free.
  */
 import type { UserSettings } from "@/generated/prisma/client";
+import type { TTimeFormat } from "@/hooks/useUserSettings";
 import type { CalendarTransitionSpeed } from "@/lib/calendar/transition-speed";
 import type { TDateFormat } from "@/lib/format-date";
 import type { TWeekStartDay } from "@/types/calendar";
@@ -29,11 +30,12 @@ import type { TWeekStartDay } from "@/types/calendar";
  */
 export type MockUserSettings = Omit<
   UserSettings,
-  "weekStartDay" | "calendarTransitionSpeed" | "dateFormat"
+  "weekStartDay" | "calendarTransitionSpeed" | "dateFormat" | "timeFormat"
 > & {
   weekStartDay: TWeekStartDay;
   calendarTransitionSpeed: CalendarTransitionSpeed;
   dateFormat: TDateFormat;
+  timeFormat: TTimeFormat;
 };
 
 /**

--- a/src/types/user-settings.ts
+++ b/src/types/user-settings.ts
@@ -1,3 +1,4 @@
+import type { TTimeFormat } from "@/hooks/useUserSettings";
 import type { CalendarTransitionSpeed } from "@/lib/calendar/transition-speed";
 import type { TDateFormat } from "@/lib/format-date";
 import type { TWeekStartDay } from "@/types/calendar";
@@ -7,7 +8,7 @@ import type { TWeekStartDay } from "@/types/calendar";
  *
  * Mirrors the columns on the Prisma `UserSettings` model that the settings
  * UI can mutate, with the narrow-union columns retyped to their
- * application-level unions (`dateFormat`, `weekStartDay`, and
+ * application-level unions (`timeFormat`, `dateFormat`, `weekStartDay`, and
  * `calendarTransitionSpeed`).
  *
  * Lives in `src/types/` because more than one module needs the shape:
@@ -18,7 +19,7 @@ import type { TWeekStartDay } from "@/types/calendar";
  */
 export interface UserSettingsData {
   theme: string;
-  timeFormat: string;
+  timeFormat: TTimeFormat;
   dateFormat: TDateFormat;
   defaultZoomLevel: number;
   weekStartDay: TWeekStartDay;


### PR DESCRIPTION
## Summary

Pure refactor — no runtime behaviour change. Narrows `UserSettingsData.timeFormat` and `DisplayValues.timeFormat` to the existing `TTimeFormat = "12h" | "24h"` union, mirroring the in-flight `dateFormat: TDateFormat` narrowing in #390 and the long-standing pattern for `weekStartDay` / `calendarTransitionSpeed`.

- Exports a new `isTimeFormat` typeguard from `src/hooks/useUserSettings.ts` that reuses the existing `VALID_TIME_FORMATS` allow-list (no duplication).
- Drops the `as TTimeFormat` cast in `pickCalendarFields` — the typeguard flows the narrowed type through automatically (acceptance criterion).
- Coerces the Prisma `string` at the server-rendered `/settings` boundary via the typeguard, falling back to the schema-default `"12h"` — parallel to the `calendarTransitionSpeed` shape already on the page.
- Retypes `MockUserSettings.timeFormat` so the test fixture stays assignable to the narrower component prop shape without an `as` cast, same as the existing `weekStartDay` / `calendarTransitionSpeed` overrides documented in the fixture.

## Plan

Linked plan: [`.claude/plans/timeformat-narrow-423.md`](https://github.com/BenSeymourODB/next-digital-wall-calendar/blob/claude/elegant-newton-ud2bbf/.claude/plans/timeformat-narrow-423.md)
Project: https://github.com/users/BenSeymourODB/projects/1

## Independence from PR #390

#390 narrows the sibling `dateFormat` field. The only files both PRs touch are `interface UserSettingsData` (one-line edit) and the `MockUserSettings` fixture (one-line edit). Whichever lands second has a trivial conflict.

## Deferred follow-ups

Both surfaced in the first-pass review; both intentionally left out of this PR to keep the slice clean.

- `UserSettingsBusPayload.timeFormat` in `src/lib/user-settings-bus.ts:37` is still `string` — tracked by #419 (which covers tightening the whole bus payload to a closed subset of `UserSettings` keys).
- `src/app/api/settings/route.ts:15` duplicates `VALID_TIME_FORMATS` instead of importing from `useUserSettings.ts` — filed as #427.

## Test plan

- [x] `pnpm test` — all 2546 tests pass (155 files).
- [x] `pnpm lint:fix && pnpm format:fix && pnpm check-types` — clean.
- [x] New `isTimeFormat` typeguard unit tests cover valid (`"12h"` / `"24h"`), invalid-string (`"13h"`, `""`, `"12H"`, `"12"`), and non-string (`null`, `undefined`, `12`, `{}`) inputs.
- [x] `grep -rn "as TTimeFormat" src/` returns no results (acceptance criterion satisfied).
- [x] Existing display-section, settings-form, and useUserSettings test suites pass unchanged (pure refactor).

## Notes

No UI surface changed — Playwright run not warranted for this slice. The narrowing only tightens compile-time types; the radio items in `DisplaySection` already only render `"12h"` / `"24h"`, and the server validator at `/api/settings` is the authoritative enforcer at runtime.

Closes #423

🤖 Generated with [Claude Code](https://claude.com/claude-code)