### PR TITLE
refactor(settings): tighten UserSettingsBusPayload to Partial&lt;UserSettingsData&gt; (#419)

### DIFF
--- a/.claude/plans/user-settings-bus-payload-tightening-419.md
+++ b/.claude/plans/user-settings-bus-payload-tightening-419.md
@@ -1,0 +1,87 @@
+# Tighten `UserSettingsBusPayload` to mirror `UserSettingsData` (#419)
+
+## Problem
+
+`UserSettingsBusPayload` in `src/lib/user-settings-bus.ts` is a hand-maintained subset of
+`UserSettings`. It is missing three columns that the settings form can write:
+
+- `weekStartDay`
+- `calendarWorkingHoursStart`
+- `calendarTransitionSpeed`
+
+`SettingsForm.updateSettings` calls `emitUserSettingsChange(partial)` where
+`partial: Partial<UserSettingsData>`. TypeScript does not excess-check on
+non-literal arguments, so a `Partial<UserSettingsData>` is structurally
+compatible with the narrower `UserSettingsBusPayload` and the call compiles.
+The same hole exists at the two emit sites inside `useUserSettings.mutate`
+(`src/hooks/useUserSettings.ts:193,214`). Extra keys flow through `CustomEvent.detail`
+and are silently discarded by the consumer's `pickCalendarFields`.
+
+## Decision: Option 1 from the issue
+
+Tighten `UserSettingsBusPayload` so it models every settable column. Concretely,
+extract the `UserSettingsData` shape out of `settings-form.tsx` into a shared
+type module and redefine the bus payload as `Partial<UserSettingsData>`. This
+keeps the change minimal — no runtime filtering or per-emit-site whitelists.
+
+Subscribers (`useUserSettings` → `pickCalendarFields`) already validate every
+key they care about, so they continue to work without modification.
+
+Option 2 (runtime narrowing at every call site) was rejected as boilerplate.
+
+## Files touched
+
+1. **New: `src/types/user-settings.ts`** — exports the `UserSettingsData`
+   interface previously local to `settings-form.tsx`. This is the single
+   source of truth for the form's settings shape.
+2. **`src/components/settings/settings-form.tsx`** — drop the local
+   `UserSettingsData` declaration, import from the shared module. No
+   behavioural change.
+3. **`src/lib/user-settings-bus.ts`** — import `UserSettingsData` and
+   redefine `UserSettingsBusPayload = Partial<UserSettingsData>`. Update
+   the docstring to point at the shared type as the source of truth.
+4. **`src/lib/__tests__/user-settings-bus.test.ts`** — add a runtime test
+   verifying that emitting with the previously-missing keys
+   (`weekStartDay`, `calendarWorkingHoursStart`, `calendarTransitionSpeed`)
+   reaches subscribers intact. This catches a future regression where the
+   bus payload drifts back to a narrower subset.
+
+## Out of scope
+
+- `useUserSettings.UserCalendarSettings` is the consumer-side projection,
+  not the bus payload — it stays unchanged.
+- `pickCalendarFields` keeps its current set; the bus carries a strict
+  superset, the consumer picks what it cares about. Future widening of
+  the consumer happens in separate issues (e.g. wiring `weekStartDay` /
+  `calendarWorkingHoursStart` into `CalendarProvider` is already done
+  through the GET path).
+- `calendar-settings-panel.tsx` does **not** emit on the bus today, so it
+  is not touched. (The issue body listed it conditionally with "if it
+  also emits".)
+- #418 (in-flight) adds a second emit site in the catch block of
+  `updateSettings`. The current PR is independent of #418; if #418 lands
+  first the rebase is trivial (both new emit calls accept the wider
+  payload). If #419 lands first, #418's emit will pick up the wider
+  type automatically.
+
+## TDD steps
+
+1. Add the test exercising `weekStartDay` / `calendarWorkingHoursStart` /
+   `calendarTransitionSpeed` round-tripping through the bus — at this
+   point the test passes runtime-wise (CustomEvent carries any payload),
+   but the _type-level_ contract still claims those keys are not part of
+   `UserSettingsBusPayload`. The acceptance is that the test compiles
+   without `@ts-expect-error` once the type is widened.
+2. Create `src/types/user-settings.ts` with the extracted interface.
+3. Update `user-settings-bus.ts` to use `Partial<UserSettingsData>`.
+4. Update `settings-form.tsx` to import from the shared module.
+5. Run `pnpm lint:fix && pnpm format:fix && pnpm check-types && pnpm test`.
+
+## Verification
+
+- `pnpm check-types` clean — proves the type widening compiles end-to-end.
+- New bus test green — proves the wider keys round-trip.
+- Existing `user-settings-bus.test.ts` green — proves no regression of
+  current behaviour.
+- Existing `useUserSettings.test.tsx` and `settings-form.test.tsx`
+  green — proves no consumer/emit-site regression.

--- a/src/components/settings/settings-form.tsx
+++ b/src/components/settings/settings-form.tsx
@@ -2,15 +2,13 @@
 
 import { useProfile } from "@/components/profiles/profile-context";
 import type { TransitionConfig } from "@/components/scheduler/types";
-import type { CalendarTransitionSpeed } from "@/lib/calendar/transition-speed";
-import type { TDateFormat } from "@/lib/format-date";
 import { DEFAULT_TRANSITION_CONFIG } from "@/lib/scheduler/schedule-config";
 import {
   loadScheduleConfig,
   saveScheduleConfig,
 } from "@/lib/scheduler/schedule-storage";
 import { emitUserSettingsChange } from "@/lib/user-settings-bus";
-import type { TWeekStartDay } from "@/types/calendar";
+import type { UserSettingsData } from "@/types/user-settings";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { AccountSection } from "./account-section";
@@ -32,25 +30,6 @@ const DEFAULT_TASK_SETTINGS: ProfileTaskSettings = {
   taskSortOrder: "dueDate",
   showCompletedTasks: false,
 };
-
-interface UserSettingsData {
-  theme: string;
-  timeFormat: string;
-  dateFormat: TDateFormat;
-  defaultZoomLevel: number;
-  weekStartDay: TWeekStartDay;
-  rewardSystemEnabled: boolean;
-  defaultTaskPoints: number;
-  showPointsOnCompletion: boolean;
-  schedulerIntervalSeconds: number;
-  schedulerPauseOnInteractionSeconds: number;
-  calendarRefreshIntervalMinutes: number;
-  calendarFetchMonthsAhead: number;
-  calendarFetchMonthsBehind: number;
-  calendarMaxEventsPerDay: number;
-  calendarWorkingHoursStart: number;
-  calendarTransitionSpeed: CalendarTransitionSpeed;
-}
 
 interface SettingsFormProps {
   user: {

--- a/src/lib/__tests__/user-settings-bus.test.ts
+++ b/src/lib/__tests__/user-settings-bus.test.ts
@@ -76,4 +76,38 @@ describe("user-settings-bus", () => {
 
     globalThis.window = original;
   });
+
+  /**
+   * Regression coverage for #419. Before tightening, `UserSettingsBusPayload`
+   * was a hand-maintained subset that omitted `weekStartDay`,
+   * `calendarWorkingHoursStart`, and `calendarTransitionSpeed`. The values
+   * still flowed through `CustomEvent.detail` at runtime (and were silently
+   * discarded by `pickCalendarFields`), but the *type* claimed they were
+   * not part of the bus contract — leaving `Partial<UserSettingsData>`
+   * call sites to widen structurally.
+   *
+   * Compile-time assertion: this file would not type-check on `main` before
+   * the bus payload was widened. If the type drifts back to a narrower
+   * subset, `pnpm check-types` flags the literals below as excess
+   * properties.
+   */
+  it("round-trips weekStartDay / calendarWorkingHoursStart / calendarTransitionSpeed", () => {
+    const handler = vi.fn();
+    const unsubscribe = subscribeUserSettings(handler);
+
+    emitUserSettingsChange({
+      weekStartDay: 1,
+      calendarWorkingHoursStart: 8,
+      calendarTransitionSpeed: "slow",
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith({
+      weekStartDay: 1,
+      calendarWorkingHoursStart: 8,
+      calendarTransitionSpeed: "slow",
+    });
+
+    unsubscribe();
+  });
 });

--- a/src/lib/__tests__/user-settings-bus.test.ts
+++ b/src/lib/__tests__/user-settings-bus.test.ts
@@ -86,10 +86,12 @@ describe("user-settings-bus", () => {
    * not part of the bus contract — leaving `Partial<UserSettingsData>`
    * call sites to widen structurally.
    *
-   * Compile-time assertion: this file would not type-check on `main` before
-   * the bus payload was widened. If the type drifts back to a narrower
-   * subset, `pnpm check-types` flags the literals below as excess
-   * properties.
+   * The real regression gate is `pnpm check-types`: the literals below
+   * fail TS excess-property checking if `UserSettingsBusPayload` ever
+   * drifts back to a narrower subset. The runtime `expect` assertions
+   * are belt-and-braces — `CustomEvent` carries any payload regardless
+   * of type, so they catch only the orthogonal case where the bus
+   * starts mutating its payload (which would be a different regression).
    */
   it("round-trips weekStartDay / calendarWorkingHoursStart / calendarTransitionSpeed", () => {
     const handler = vi.fn();

--- a/src/lib/user-settings-bus.ts
+++ b/src/lib/user-settings-bus.ts
@@ -15,39 +15,23 @@
  * Server-safe: `window` is guarded so the module can be imported from
  * places that load on the server (e.g. shared hooks).
  */
+import type { UserSettingsData } from "@/types/user-settings";
 
 const EVENT_NAME = "user-settings-changed";
 
 /**
- * Closed payload type for bus events. Listing every column in the
- * `UserSettings` Prisma model that any in-tab consumer might care about
- * lets typo'd keys (`timeformat` instead of `timeFormat`) fail at
- * compile time rather than silently no-op at runtime. Add new fields
- * here as additional `UserSettings` columns get wired through to live
- * UI sync.
+ * Payload type for bus events: any partial of the settings shape the form
+ * can write. Derived from the shared `UserSettingsData` so the bus can
+ * never silently drift from the form — adding a column to
+ * `UserSettingsData` automatically extends the bus contract (#419).
  *
- * Value types intentionally mirror the existing `SettingsForm`
- * `UserSettingsData` shape (`string` for the literal-union columns
- * `timeFormat` / `dateFormat` / `theme`); subscribers validate the
- * values via `pickCalendarFields` or equivalent at the consumer
- * boundary. Tightening is a follow-up once `SettingsForm` adopts the
- * stronger types end-to-end.
+ * Subscribers validate individual keys at the consumer boundary
+ * (`pickCalendarFields` in `useUserSettings`); the bus itself does not
+ * narrow values. Typo'd keys (`timeformat` instead of `timeFormat`)
+ * continue to fail at compile time because `Partial<UserSettingsData>`
+ * is a closed key set.
  */
-export interface UserSettingsBusPayload {
-  timeFormat?: string;
-  dateFormat?: string;
-  theme?: string;
-  defaultZoomLevel?: number;
-  defaultTaskPoints?: number;
-  rewardSystemEnabled?: boolean;
-  showPointsOnCompletion?: boolean;
-  schedulerIntervalSeconds?: number;
-  schedulerPauseOnInteractionSeconds?: number;
-  calendarRefreshIntervalMinutes?: number;
-  calendarFetchMonthsAhead?: number;
-  calendarFetchMonthsBehind?: number;
-  calendarMaxEventsPerDay?: number;
-}
+export type UserSettingsBusPayload = Partial<UserSettingsData>;
 
 export type UserSettingsPartial = UserSettingsBusPayload;
 

--- a/src/lib/user-settings-bus.ts
+++ b/src/lib/user-settings-bus.ts
@@ -25,6 +25,11 @@ const EVENT_NAME = "user-settings-changed";
  * never silently drift from the form — adding a column to
  * `UserSettingsData` automatically extends the bus contract (#419).
  *
+ * The Prisma → `UserSettingsData` step remains manual: a new column on
+ * the `UserSettings` model must be added to `UserSettingsData` for it to
+ * flow through the bus. Only the `UserSettingsData` → bus link is
+ * type-enforced.
+ *
  * Subscribers validate individual keys at the consumer boundary
  * (`pickCalendarFields` in `useUserSettings`); the bus itself does not
  * narrow values. Typo'd keys (`timeformat` instead of `timeFormat`)

--- a/src/types/user-settings.ts
+++ b/src/types/user-settings.ts
@@ -1,0 +1,36 @@
+import type { CalendarTransitionSpeed } from "@/lib/calendar/transition-speed";
+import type { TDateFormat } from "@/lib/format-date";
+import type { TWeekStartDay } from "@/types/calendar";
+
+/**
+ * Shape of the `UserSettings` row as the settings form consumes it.
+ *
+ * Mirrors the columns on the Prisma `UserSettings` model that the settings
+ * UI can mutate, with the narrow-union columns retyped to their
+ * application-level unions (`dateFormat`, `weekStartDay`, and
+ * `calendarTransitionSpeed`).
+ *
+ * Lives in `src/types/` because more than one module needs the shape:
+ * the form renders it, and `src/lib/user-settings-bus.ts` derives the
+ * bus payload from it so the bus can never silently drift from the form
+ * (#419). Subscribers continue to validate individual keys at the
+ * consumer boundary (`pickCalendarFields` in `useUserSettings`).
+ */
+export interface UserSettingsData {
+  theme: string;
+  timeFormat: string;
+  dateFormat: TDateFormat;
+  defaultZoomLevel: number;
+  weekStartDay: TWeekStartDay;
+  rewardSystemEnabled: boolean;
+  defaultTaskPoints: number;
+  showPointsOnCompletion: boolean;
+  schedulerIntervalSeconds: number;
+  schedulerPauseOnInteractionSeconds: number;
+  calendarRefreshIntervalMinutes: number;
+  calendarFetchMonthsAhead: number;
+  calendarFetchMonthsBehind: number;
+  calendarMaxEventsPerDay: number;
+  calendarWorkingHoursStart: number;
+  calendarTransitionSpeed: CalendarTransitionSpeed;
+}


### PR DESCRIPTION
## Summary

- Extract `UserSettingsData` out of `settings-form.tsx` into a shared `src/types/user-settings.ts` module.
- Redefine `UserSettingsBusPayload` as `Partial<UserSettingsData>` so the bus payload faithfully models every column the form can write — including the three keys previously missing from the hand-maintained subset (`weekStartDay`, `calendarWorkingHoursStart`, `calendarTransitionSpeed`).
- Add a regression test in `src/lib/__tests__/user-settings-bus.test.ts` that exercises round-tripping of those keys; the test would not type-check before this change.

## Plan

Linked plan: `.claude/plans/user-settings-bus-payload-tightening-419.md`
Project: https://github.com/users/BenSeymourODB/projects/1

## Behaviour change

None at runtime. The bus already carried any payload via `CustomEvent.detail`; this PR closes the *typing* gap that let `Partial<UserSettingsData>` widen structurally into the narrower `UserSettingsBusPayload`. Subscribers (`useUserSettings` → `pickCalendarFields`) continue to validate individual keys at the consumer boundary, so no consumer change is required.

Adding a new column to `UserSettingsData` now automatically extends the bus contract — no more drift.

## Files

- `src/types/user-settings.ts` *(new)* — shared `UserSettingsData` interface.
- `src/lib/user-settings-bus.ts` — `UserSettingsBusPayload = Partial<UserSettingsData>`; docstring updated.
- `src/components/settings/settings-form.tsx` — drop the local `UserSettingsData`, import from the shared module.
- `src/lib/__tests__/user-settings-bus.test.ts` — round-trip test for the previously-missing keys.

## Test plan

- [x] `pnpm lint:fix` — clean (no new warnings).
- [x] `pnpm format:fix` — clean.
- [x] `pnpm check-types` — clean (would have failed before the widening; this is the type-level acceptance criterion).
- [x] `pnpm test` — 2542 tests pass, 155 files.
- [x] Visual smoke not applicable (type-only refactor; no UI affected).

## Relationship to #418

Independent. #418 only adds a 5-line block to the catch path of `updateSettings`; this PR touches the import and removed `UserSettingsData` block earlier in the same file (different region). If #418 lands first, the rebase is trivial — its new `emitUserSettingsChange(revert)` call accepts the widened payload automatically.

Closes #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0141322NpQ4WzdrDKkLyejqG)_