### PR TITLE
feat(clock): standalone /clock route for chrome-free wall display (#398)

### DIFF
--- a/.claude/plans/clock-route-398.md
+++ b/.claude/plans/clock-route-398.md
@@ -1,0 +1,89 @@
+# Plan: `/clock` standalone route (Issue #398)
+
+## Goal
+
+A dedicated `/clock` route that renders **only** the analog clock, suitable
+for mounting on an always-on wall display. No `ViewSwitcher`, no
+`CalendarSettingsPanel`, no `AccountManager`, no `SideNavigation`, no
+`PointsBadge`, no `ScreenTransition`.
+
+The screen-rotation scheduler plan already enumerates `/clock` as a
+rotation target — this route makes that reference real.
+
+## Scope (this PR)
+
+- `src/app/clock/page.tsx` — full-bleed page mounting its own
+  `CalendarProvider` seeded with `initialView="clock"` and rendering
+  `AnalogClockView` + `Toaster`. No header, no controls.
+- `src/components/navigation/app-shell.tsx` — add `/clock` to
+  `UNWRAPPED_EXACT` so `AppShell` returns `children` plainly (no nav, no
+  badge, no transition).
+- Tests:
+  - Unit: `AppShell` does not wrap `/clock`.
+  - Component: `/clock` page renders `AnalogClockView` inside a
+    `CalendarProvider` and does not render `ViewSwitcher` / page header /
+    settings controls.
+  - E2E (unauthenticated): `/clock` redirects to `/auth/signin` (matches
+    the rest of the calendar surface) — confirms the route exists and is
+    auth-gated.
+  - E2E (authenticated, via shared fixture from #278): visiting `/clock`
+    renders `analog-clock-view` and does **not** render
+    `view-switcher`, `mobile-side-nav-toggle`, or the page header.
+  - Capture a screenshot of the rendered `/clock` page in the
+    authenticated E2E and embed it in the PR body (per `CLAUDE.md`).
+
+## Explicitly out of scope (deferred to existing issues)
+
+- `?calendars=…&profiles=…` URL filter / saved-config wiring — **#399**
+- Upcoming-events list + current-event "time remaining" countdown — **#400**
+- Auto-rotation scheduling behaviour (already implemented; this route
+  simply becomes a valid target).
+
+If anything else surfaces during review that we choose not to ship here,
+file an issue and link it from the PR body.
+
+## AppShell decision (documented)
+
+The issue presents two options:
+
+1. **Unwrap** `/clock` from `AppShell` (add to `UNWRAPPED_EXACT`).
+2. Wrap `/clock` with `SideNavigation`, but auto-hide the nav.
+
+**Choice: option 1 (unwrap).** A wall display is always-on, chrome-free,
+and not interacted with. The nav, points badge, and screen-transition
+wrapper all add weight and visual noise (the transition's
+`translate-x-full` reveal would also be jarring on a stationary
+display). Unwrapping is also a single-line edit in one well-tested file
+(`UNWRAPPED_EXACT.add("/clock")`) and keeps the door open to option 2
+later if a user-facing reason emerges.
+
+The `/clock` page is still client-side and still goes through
+`CalendarProvider`, so event clicks → `EventDetailModal` continue to
+work and the wall-projector emphasis toggle keeps its existing
+behaviour.
+
+## Files touched
+
+- `src/app/clock/page.tsx` (new)
+- `src/components/navigation/app-shell.tsx`
+- `src/components/navigation/__tests__/app-shell.test.tsx`
+- `src/app/clock/__tests__/page.test.tsx` (new)
+- `e2e/clock-route.spec.ts` (new, unauthenticated — redirect assertion)
+- `e2e/authenticated/clock-route.spec.ts` (new — full chrome-free render +
+  screenshot)
+
+## Acceptance criteria
+
+- [ ] `/clock` renders `AnalogClockView` alone — no view switcher, page
+      header, or settings/account chrome
+- [ ] Route mounts its own `CalendarProvider` and loads events
+      independently of `/calendar`
+- [ ] `AppShell` behaviour on `/clock` is decided and documented
+      (unwrapped — see above)
+- [ ] Event click → `EventDetailModal` still works (covered by existing
+      `AnalogClockView` tests; not regressed by route work)
+- [ ] All-day aside still renders (sourced from `AnalogClockView`; not
+      regressed)
+- [ ] Wall-projector emphasis toggle still works on the standalone page
+      (sourced from `AnalogClockView`; not regressed)
+- [ ] Component + E2E coverage, with a screenshot in the PR

--- a/.claude/plans/clock-route-398.md
+++ b/.claude/plans/clock-route-398.md
@@ -12,25 +12,35 @@ rotation target — this route makes that reference real.
 
 ## Scope (this PR)
 
-- `src/app/clock/page.tsx` — full-bleed page mounting its own
-  `CalendarProvider` seeded with `initialView="clock"` and rendering
-  `AnalogClockView` + `Toaster`. No header, no controls.
+- `src/app/clock/page.tsx` — page mounting its own `CalendarProvider`
+  seeded with `initialView="clock"` and rendering `AnalogClockView` +
+  `Toaster`. No header, no controls. Uses `min-h-screen p-4 sm:p-8` +
+  `mx-auto max-w-7xl` (the same shell `/calendar` uses) so the clock
+  and its all-day aside aren't vertically crushed by `items-center`.
 - `src/components/navigation/app-shell.tsx` — add `/clock` to
   `UNWRAPPED_EXACT` so `AppShell` returns `children` plainly (no nav, no
   badge, no transition).
+- `src/proxy.ts` — add `/clock` to `PROTECTED_PAGE_ROUTES` so the
+  middleware redirects unauthenticated visitors to `/auth/signin` with
+  `?callbackUrl=/clock`, matching `/calendar` / `/settings` /
+  `/dashboard`.
 - Tests:
   - Unit: `AppShell` does not wrap `/clock`.
   - Component: `/clock` page renders `AnalogClockView` inside a
-    `CalendarProvider` and does not render `ViewSwitcher` / page header /
-    settings controls.
-  - E2E (unauthenticated): `/clock` redirects to `/auth/signin` (matches
-    the rest of the calendar surface) — confirms the route exists and is
-    auth-gated.
+    `CalendarProvider` and does not render `ViewSwitcher` /
+    `CalendarSettingsPanel` / `AccountManager` (chrome components are
+    explicitly mocked so the negative assertions bind to real testids
+    that would appear on regression).
+  - E2E (unauthenticated, `e2e/clock-route.spec.ts`): `/clock` redirects
+    to `/auth/signin` with `callbackUrl=%2Fclock`.
   - E2E (authenticated, via shared fixture from #278): visiting `/clock`
-    renders `analog-clock-view` and does **not** render
-    `view-switcher`, `mobile-side-nav-toggle`, or the page header.
+    renders `analog-clock-view`; the `view-switcher` container,
+    `calendar-settings-panel`, and the "Wall Calendar" heading are all
+    absent; `SideNavigation`, `ScreenTransition`, and `PointsBadge` are
+    not rendered.
   - Capture a screenshot of the rendered `/clock` page in the
-    authenticated E2E and embed it in the PR body (per `CLAUDE.md`).
+    authenticated E2E (`test-results/screenshots/clock-route-wall-
+display.png`) and embed it in the PR body (per `CLAUDE.md`).
 
 ## Explicitly out of scope (deferred to existing issues)
 
@@ -68,6 +78,7 @@ behaviour.
 - `src/components/navigation/app-shell.tsx`
 - `src/components/navigation/__tests__/app-shell.test.tsx`
 - `src/app/clock/__tests__/page.test.tsx` (new)
+- `src/proxy.ts` (auth-gate `/clock`)
 - `e2e/clock-route.spec.ts` (new, unauthenticated — redirect assertion)
 - `e2e/authenticated/clock-route.spec.ts` (new — full chrome-free render +
   screenshot)

--- a/e2e/authenticated/clock-route.spec.ts
+++ b/e2e/authenticated/clock-route.spec.ts
@@ -67,7 +67,11 @@ test.describe("/clock standalone wall-display route (#398)", () => {
     await expect(
       page.getByRole("heading", { name: "Wall Calendar" })
     ).toHaveCount(0);
-    await expect(page.getByTestId("view-switcher-clock")).toHaveCount(0);
+    // Use the container testid (`view-switcher`), not an inner button
+    // (`view-switcher-clock`) — the container guard catches a regression
+    // where the whole switcher is imported even if the clock button
+    // happened to be filtered out.
+    await expect(page.getByTestId("view-switcher")).toHaveCount(0);
     await expect(page.getByTestId("calendar-settings-panel")).toHaveCount(0);
     await expect(
       page.getByRole("button", { name: /account manager/i })
@@ -96,9 +100,11 @@ test.describe("/clock standalone wall-display route (#398)", () => {
     await expect(page.getByTestId("analog-clock")).toBeVisible();
 
     // Saved to playwright artifacts; the PR body embeds the rendered
-    // image so reviewers can eyeball the chrome-free wall view.
+    // image so reviewers can eyeball the chrome-free wall view. The
+    // `screenshots/` subdir matches the convention used by other specs
+    // (e.g. `e2e/analog-clock.spec.ts`).
     await page.screenshot({
-      path: "test-results/clock-route-wall-display.png",
+      path: "test-results/screenshots/clock-route-wall-display.png",
       fullPage: true,
     });
   });

--- a/e2e/authenticated/clock-route.spec.ts
+++ b/e2e/authenticated/clock-route.spec.ts
@@ -1,0 +1,105 @@
+/**
+ * Production `/clock` standalone wall-display route (issue #398).
+ *
+ * The route must render only `AnalogClockView` — no `ViewSwitcher`, no
+ * page header, no settings/account chrome — and `AppShell` must skip
+ * `SideNavigation`, `PointsBadge`, and `ScreenTransition` so the clock
+ * fills the screen.
+ *
+ * Lives under `e2e/authenticated/` so the `authenticated-chromium`
+ * project picks it up (other browser projects skip it; see
+ * `playwright.config.ts`). Uses the shared auth fixture from #278.
+ */
+import { expect, test } from "@playwright/test";
+
+test.describe("/clock standalone wall-display route (#398)", () => {
+  // Match `e2e/authenticated/calendar-view-deeplink.spec.ts` and stub
+  // the internal Next.js API routes the CalendarProvider hits, so the
+  // page renders deterministically without depending on a real Google
+  // account behind the shared session.
+  test.beforeEach(async ({ page }) => {
+    await page.route("**/api/calendar/events**", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ items: [], nextSyncToken: null }),
+      });
+    });
+    await page.route("**/api/calendar/calendars", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ items: [] }),
+      });
+    });
+    await page.route("**/api/calendar/colors", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ event: {}, calendar: {} }),
+      });
+    });
+    await page.route("**/api/settings", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({}),
+      });
+    });
+  });
+
+  test("renders AnalogClockView at the page root", async ({ page }) => {
+    await page.goto("/clock");
+
+    await expect(page.getByTestId("clock-page")).toBeVisible();
+    await expect(page.getByTestId("analog-clock-view")).toBeVisible();
+    await expect(page.getByTestId("analog-clock")).toBeVisible();
+  });
+
+  test("does not render the /calendar header, view switcher, or settings chrome", async ({
+    page,
+  }) => {
+    await page.goto("/clock");
+
+    // Wait for the clock to commit before negative-asserting the chrome.
+    await expect(page.getByTestId("analog-clock-view")).toBeVisible();
+
+    await expect(
+      page.getByRole("heading", { name: "Wall Calendar" })
+    ).toHaveCount(0);
+    await expect(page.getByTestId("view-switcher-clock")).toHaveCount(0);
+    await expect(page.getByTestId("calendar-settings-panel")).toHaveCount(0);
+    await expect(
+      page.getByRole("button", { name: /account manager/i })
+    ).toHaveCount(0);
+  });
+
+  test("AppShell does not wrap /clock — no SideNavigation, no ScreenTransition, no PointsBadge", async ({
+    page,
+  }) => {
+    await page.goto("/clock");
+
+    await expect(page.getByTestId("analog-clock-view")).toBeVisible();
+
+    await expect(
+      page.getByRole("navigation", { name: /main navigation/i })
+    ).toHaveCount(0);
+    await expect(page.getByTestId("screen-transition")).toHaveCount(0);
+    await expect(page.getByTestId("points-badge")).toHaveCount(0);
+  });
+
+  test("captures a wall-display screenshot of the rendered /clock page", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.goto("/clock");
+    await expect(page.getByTestId("analog-clock")).toBeVisible();
+
+    // Saved to playwright artifacts; the PR body embeds the rendered
+    // image so reviewers can eyeball the chrome-free wall view.
+    await page.screenshot({
+      path: "test-results/clock-route-wall-display.png",
+      fullPage: true,
+    });
+  });
+});

--- a/e2e/clock-route.spec.ts
+++ b/e2e/clock-route.spec.ts
@@ -1,0 +1,26 @@
+/**
+ * `/clock` standalone wall-display route — auth-gating (issue #398).
+ *
+ * Companion to `e2e/authenticated/clock-route.spec.ts`. This spec
+ * runs in the unauthenticated browser projects (chromium / firefox /
+ * webkit / mobile-chrome / tablet) and asserts that the proxy
+ * (`src/proxy.ts`) redirects an unauthenticated visitor at `/clock`
+ * through `/auth/signin` with the original path captured in
+ * `?callbackUrl=`, matching the other protected pages
+ * (`/calendar`, `/settings`, `/dashboard`).
+ */
+import { expect, test } from "@playwright/test";
+
+test.describe("/clock auth-gating (#398)", () => {
+  test("redirects unauthenticated visitors to /auth/signin with callbackUrl", async ({
+    page,
+  }) => {
+    await page.goto("/clock");
+
+    // The middleware redirects before the page renders, so the final
+    // URL must land on /auth/signin and preserve /clock as the
+    // post-sign-in destination.
+    await expect(page).toHaveURL(/\/auth\/signin/);
+    expect(page.url()).toContain("callbackUrl=%2Fclock");
+  });
+});

--- a/src/app/clock/__tests__/page.test.tsx
+++ b/src/app/clock/__tests__/page.test.tsx
@@ -5,7 +5,18 @@
  * CalendarProvider — no ViewSwitcher, no page header, no settings or
  * account controls. AppShell-level unwrap is covered separately in
  * `app-shell.test.tsx`.
+ *
+ * The chrome components (`ViewSwitcher`, `CalendarSettingsPanel`,
+ * `AccountManager`) are mocked here so the negative assertions below
+ * would fail loudly if any of them were accidentally imported into the
+ * page — without the mocks, importing the real components would either
+ * throw under the mocked `CalendarProvider` or render their real DOM,
+ * neither of which exercises a meaningful regression guard. (Surfaced
+ * by PR #431 review — the prior `mock-view-switcher` / `mock-calendar-
+ * settings-panel` testids never existed because the mocks were never
+ * declared.)
  */
+import type { TCalendarView } from "@/types/calendar";
 import type { ReactNode } from "react";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
@@ -19,7 +30,7 @@ vi.mock("@/components/providers/CalendarProvider", () => ({
     ...props
   }: {
     children: ReactNode;
-    initialView?: string;
+    initialView?: TCalendarView;
   }) => {
     calendarProviderProps(props);
     return <div data-testid="mock-calendar-provider">{children}</div>;
@@ -34,6 +45,23 @@ vi.mock("@/components/ui/sonner", () => ({
   Toaster: () => <div data-testid="mock-toaster" />,
 }));
 
+// Chrome components must NOT appear on /clock. Mock them so the
+// negative assertions below have something to bind to if the page is
+// accidentally regressed.
+vi.mock("@/components/calendar/ViewSwitcher", () => ({
+  ViewSwitcher: () => <div data-testid="mock-view-switcher" />,
+}));
+
+vi.mock("@/components/calendar/CalendarSettingsPanel", () => ({
+  CalendarSettingsPanel: () => (
+    <div data-testid="mock-calendar-settings-panel" />
+  ),
+}));
+
+vi.mock("@/components/calendar/AccountManager", () => ({
+  AccountManager: () => <div data-testid="mock-account-manager" />,
+}));
+
 describe("ClockPage (/clock)", () => {
   it("mounts AnalogClockView inside a CalendarProvider seeded with view=clock", () => {
     render(<ClockPage />);
@@ -41,7 +69,7 @@ describe("ClockPage (/clock)", () => {
     expect(screen.getByTestId("mock-calendar-provider")).toBeInTheDocument();
     expect(screen.getByTestId("mock-analog-clock-view")).toBeInTheDocument();
     expect(calendarProviderProps).toHaveBeenCalledWith(
-      expect.objectContaining({ initialView: "clock" })
+      expect.objectContaining({ initialView: "clock" satisfies TCalendarView })
     );
   });
 
@@ -55,13 +83,15 @@ describe("ClockPage (/clock)", () => {
     ).not.toBeInTheDocument();
 
     // ViewSwitcher / settings / account-manager controls live on /calendar
-    // and must not appear on /clock.
+    // and must not appear on /clock. These assertions are wired to mock
+    // testids declared above so they fail loudly if any of these
+    // components are accidentally imported into the page.
     expect(screen.queryByTestId("mock-view-switcher")).not.toBeInTheDocument();
     expect(
-      screen.queryByTestId("calendar-settings-panel")
+      screen.queryByTestId("mock-calendar-settings-panel")
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: /account manager/i })
+      screen.queryByTestId("mock-account-manager")
     ).not.toBeInTheDocument();
   });
 

--- a/src/app/clock/__tests__/page.test.tsx
+++ b/src/app/clock/__tests__/page.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * Tests for /clock standalone wall-display page (issue #398).
+ *
+ * The route must render only AnalogClockView inside its own
+ * CalendarProvider — no ViewSwitcher, no page header, no settings or
+ * account controls. AppShell-level unwrap is covered separately in
+ * `app-shell.test.tsx`.
+ */
+import type { ReactNode } from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import ClockPage from "../page";
+
+const calendarProviderProps = vi.fn();
+
+vi.mock("@/components/providers/CalendarProvider", () => ({
+  CalendarProvider: ({
+    children,
+    ...props
+  }: {
+    children: ReactNode;
+    initialView?: string;
+  }) => {
+    calendarProviderProps(props);
+    return <div data-testid="mock-calendar-provider">{children}</div>;
+  },
+}));
+
+vi.mock("@/components/calendar/AnalogClockView", () => ({
+  AnalogClockView: () => <div data-testid="mock-analog-clock-view" />,
+}));
+
+vi.mock("@/components/ui/sonner", () => ({
+  Toaster: () => <div data-testid="mock-toaster" />,
+}));
+
+describe("ClockPage (/clock)", () => {
+  it("mounts AnalogClockView inside a CalendarProvider seeded with view=clock", () => {
+    render(<ClockPage />);
+
+    expect(screen.getByTestId("mock-calendar-provider")).toBeInTheDocument();
+    expect(screen.getByTestId("mock-analog-clock-view")).toBeInTheDocument();
+    expect(calendarProviderProps).toHaveBeenCalledWith(
+      expect.objectContaining({ initialView: "clock" })
+    );
+  });
+
+  it("does not render the /calendar page header or controls", () => {
+    render(<ClockPage />);
+
+    // Production /calendar header text — must not leak into the wall display.
+    expect(screen.queryByText(/Wall Calendar/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/Your family's digital calendar/i)
+    ).not.toBeInTheDocument();
+
+    // ViewSwitcher / settings / account-manager controls live on /calendar
+    // and must not appear on /clock.
+    expect(screen.queryByTestId("mock-view-switcher")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("calendar-settings-panel")
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /account manager/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders a Toaster so EventDetailModal feedback still works", () => {
+    render(<ClockPage />);
+    expect(screen.getByTestId("mock-toaster")).toBeInTheDocument();
+  });
+});

--- a/src/app/clock/page.tsx
+++ b/src/app/clock/page.tsx
@@ -21,9 +21,9 @@ export default function ClockPage() {
     <CalendarProvider initialView="clock">
       <main
         data-testid="clock-page"
-        className="bg-background flex min-h-screen items-center justify-center p-4 sm:p-8"
+        className="bg-background min-h-screen p-4 sm:p-8"
       >
-        <div className="w-full max-w-7xl">
+        <div className="mx-auto max-w-7xl">
           <AnalogClockView />
         </div>
       </main>

--- a/src/app/clock/page.tsx
+++ b/src/app/clock/page.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+/**
+ * /clock — standalone chrome-free wall-display route (issue #398).
+ *
+ * Mounts its own `CalendarProvider` seeded with `initialView="clock"` and
+ * renders only `AnalogClockView`. No header, no `ViewSwitcher`, no
+ * settings/account controls; `AppShell` also skips `SideNavigation`,
+ * `PointsBadge`, and `ScreenTransition` for this path (see
+ * `src/components/navigation/app-shell.tsx`).
+ *
+ * Out of scope (tracked separately): URL/saved-config filter wiring
+ * (#399) and the upcoming-events / countdown UI (#400).
+ */
+import { AnalogClockView } from "@/components/calendar/AnalogClockView";
+import { CalendarProvider } from "@/components/providers/CalendarProvider";
+import { Toaster } from "@/components/ui/sonner";
+
+export default function ClockPage() {
+  return (
+    <CalendarProvider initialView="clock">
+      <main
+        data-testid="clock-page"
+        className="bg-background flex min-h-screen items-center justify-center p-4 sm:p-8"
+      >
+        <div className="w-full max-w-7xl">
+          <AnalogClockView />
+        </div>
+      </main>
+      <Toaster />
+    </CalendarProvider>
+  );
+}

--- a/src/components/navigation/__tests__/app-shell.test.tsx
+++ b/src/components/navigation/__tests__/app-shell.test.tsx
@@ -107,9 +107,11 @@ describe("AppShell", () => {
     expect(screen.getByTestId("screen-transition")).toBeInTheDocument();
   });
 
-  // Issue #398 — /clock is a chrome-free wall display target. It must render
-  // without SideNavigation, ScreenTransition, or PointsBadge so the analog
-  // clock fills the whole screen.
+  // Issue #398 — /clock is a chrome-free wall display target. When the
+  // shell does not wrap a path, the early return drops `SideNavigation`,
+  // `ScreenTransition`, AND the `PointsBadge` (they all live under the
+  // `shouldWrap` branch of the same component), so the two negative
+  // assertions below transitively cover the badge as well.
   it("renders children plainly on /clock for the chrome-free wall display", () => {
     mockPathname = "/clock";
     render(

--- a/src/components/navigation/__tests__/app-shell.test.tsx
+++ b/src/components/navigation/__tests__/app-shell.test.tsx
@@ -106,4 +106,22 @@ describe("AppShell", () => {
     ).toBeInTheDocument();
     expect(screen.getByTestId("screen-transition")).toBeInTheDocument();
   });
+
+  // Issue #398 — /clock is a chrome-free wall display target. It must render
+  // without SideNavigation, ScreenTransition, or PointsBadge so the analog
+  // clock fills the whole screen.
+  it("renders children plainly on /clock for the chrome-free wall display", () => {
+    mockPathname = "/clock";
+    render(
+      <AppShell>
+        <div data-testid="page-content">Clock</div>
+      </AppShell>
+    );
+
+    expect(
+      screen.queryByRole("navigation", { name: /main navigation/i })
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("screen-transition")).not.toBeInTheDocument();
+    expect(screen.getByTestId("page-content")).toBeInTheDocument();
+  });
 });

--- a/src/components/navigation/app-shell.tsx
+++ b/src/components/navigation/app-shell.tsx
@@ -23,8 +23,14 @@ import { NAV_ITEMS, SideNavigation } from "./side-navigation";
 /** Path prefixes that should NOT be wrapped by the AppShell. */
 const UNWRAPPED_PREFIXES = ["/auth", "/test", "/api"] as const;
 
-/** Exact paths that should NOT be wrapped by the AppShell. */
-const UNWRAPPED_EXACT = new Set<string>(["/"]);
+/**
+ * Exact paths that should NOT be wrapped by the AppShell.
+ *
+ * `/clock` is the chrome-free wall-display target (#398) — it deliberately
+ * skips `SideNavigation`, the `PointsBadge`, and `ScreenTransition` so the
+ * analog clock fills the whole screen.
+ */
+const UNWRAPPED_EXACT = new Set<string>(["/", "/clock"]);
 
 function shouldWrap(pathname: string): boolean {
   if (UNWRAPPED_EXACT.has(pathname)) return false;

--- a/src/components/providers/CalendarProvider.tsx
+++ b/src/components/providers/CalendarProvider.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import type { CalendarsResponse } from "@/app/api/calendar/calendars/route";
-import { useEventCacheVisibilitySweep } from "@/hooks/useEventCacheVisibilitySweep";
 import { useProfileOptional } from "@/components/profiles/profile-context";
+import { useEventCacheVisibilitySweep } from "@/hooks/useEventCacheVisibilitySweep";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
 import { type TTimeFormat, useUserSettings } from "@/hooks/useUserSettings";
 import {

--- a/src/lib/__tests__/calendar-helpers.test.ts
+++ b/src/lib/__tests__/calendar-helpers.test.ts
@@ -807,7 +807,11 @@ describe("getEventsForX bare-date inclusion (#375)", () => {
       }),
     ];
 
-    const result = getEventsForWeek(events, new Date(2026, 2, 10));
+    const result = getEventsForWeek(
+      events,
+      new Date(2026, 2, 10),
+      WEEK_STARTS_ON
+    );
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe("bare-week-start");
   });
@@ -823,7 +827,11 @@ describe("getEventsForX bare-date inclusion (#375)", () => {
       }),
     ];
 
-    const result = getEventsForWeek(events, new Date(2026, 2, 10));
+    const result = getEventsForWeek(
+      events,
+      new Date(2026, 2, 10),
+      WEEK_STARTS_ON
+    );
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe("bare-week-end");
   });

--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -11,8 +11,8 @@ import { PrismaAdapter } from "@auth/prisma-adapter";
 import { encryptLinkedAccount } from "./link-account";
 import { refreshGoogleAccessToken } from "./refresh-google-token";
 import { lastSix, shouldAllowSignIn } from "./sign-in-guard";
-import { validateGoogleOAuthEnv } from "./validate-google-oauth-env";
 import { getOrStartSessionRefresh } from "./token-refresh-singleflight";
+import { validateGoogleOAuthEnv } from "./validate-google-oauth-env";
 
 // Fail fast on a missing / misconfigured server-side secret. Without these
 // boot checks the failure manifests later, after a user has signed in, as a

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -17,7 +17,12 @@ interface MiddlewareDecision {
 /**
  * Routes that require authentication (redirect to sign-in if not authenticated)
  */
-const PROTECTED_PAGE_ROUTES = ["/dashboard", "/settings", "/calendar"];
+const PROTECTED_PAGE_ROUTES = [
+  "/dashboard",
+  "/settings",
+  "/calendar",
+  "/clock",
+];
 
 /**
  * API routes that require authentication (return 401 if not authenticated)


### PR DESCRIPTION
## Summary

- New `/clock` route mounts its own `CalendarProvider` (`initialView="clock"`) and renders `AnalogClockView` standalone — no `ViewSwitcher`, no page header, no settings/account controls.
- `AppShell` adds `/clock` to `UNWRAPPED_EXACT`, so the route also skips `SideNavigation`, `PointsBadge`, and `ScreenTransition`. Chrome-free for the wall display.
- The screen-rotation scheduler plan already enumerated `/clock` as a rotation target; this PR makes the path real.

## Plan

Linked plan: [`.claude/plans/clock-route-398.md`](./.claude/plans/clock-route-398.md)
Project: https://github.com/users/BenSeymourODB/projects/1

### AppShell decision (option 1: unwrap)

The issue called out two options — unwrap `/clock` from `AppShell` vs. wrap-with-auto-hidden-nav. We chose unwrap:

- Always-on wall displays aren't interacted with; the nav, points badge, and screen-transition wrapper all add weight and visual noise (the transition's reveal would be jarring on a stationary display).
- Unwrap is a one-line edit in a single well-tested file (`UNWRAPPED_EXACT.add("/clock")`).
- The door stays open to option 2 later if a user-facing reason emerges.

The page is still client-side and still goes through `CalendarProvider`, so event clicks → `EventDetailModal` and the wall-projector emphasis toggle keep their existing behaviour (covered by the existing `AnalogClockView` tests).

## Test plan

- [x] Unit: `AppShell` test asserts `/clock` is unwrapped (no nav, no `screen-transition`).
- [x] Component: new `src/app/clock/__tests__/page.test.tsx` asserts the page mounts `AnalogClockView` inside `CalendarProvider` and does **not** render the `/calendar` header / view switcher / settings controls.
- [x] Full suite green: `pnpm test` — **156 files, 2545 tests passing**.
- [x] Code-quality gate green: `pnpm lint:fix && pnpm format:fix && pnpm check-types`.
- [x] Production build smoke-test confirms `/clock` is a real route (`○ /clock` in the build output).
- [ ] E2E (authenticated, shared #278 fixture): `e2e/authenticated/clock-route.spec.ts` covers chrome-free render + screenshot capture. The remote dev container this PR was prepared in has no Postgres, so the auth fixture can't initialise here — the spec is committed for the user's local Playwright run (`pnpm test:e2e`).

## Out of scope (deferred to existing issues)

- `?calendars=…&profiles=…` URL filter / saved-config wiring — **#399**
- Upcoming-events list + current-event "time remaining" countdown — **#400**
- Auto-rotation scheduling — already implemented; this PR simply makes `/clock` a valid rotation target.

Closes #398

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Khr3CNpxXGqkcYattivukv)_