### PR TITLE
fix(settings): suppress same-key rollback when a later PUT has committed (#420)

### DIFF
--- a/.claude/plans/user-settings-bus-rollback-race-420.md
+++ b/.claude/plans/user-settings-bus-rollback-race-420.md
@@ -1,0 +1,100 @@
+# Plan — guard user-settings-bus subscribers against same-key PUT-race rollback (#420)
+
+## Problem
+
+Two `updateSettings` calls in flight against the same key:
+
+1. A: `theme: "dark"`, snapshots `previousPartial = { theme: "light" }`, optimistic state → `dark`.
+2. B: `theme: "system"`, snapshots `previousPartial = { theme: "dark" }` (A's optimistic value), optimistic state → `system`.
+3. B's PUT succeeds first → `emitUserSettingsChange({ theme: "system" })`. Subscribers and form both at `system`.
+4. A's PUT fails → catch path runs `setSettings(curr => ({ ...curr, ...{ theme: "light" } }))` and `emitUserSettingsChange({ theme: "light" })`. Both the form and bus subscribers regress to `light`, even though B's later, successful PUT was the most-recent truth.
+
+The same shape exists at the second emit site in `src/hooks/useUserSettings.ts` (`mutate` catch block, lines 207–216) — `settingsRef` is already wired but the rollback writes `snapshot` unconditionally.
+
+## Approach — compare-and-swap rollback
+
+For each key in the saved `previousPartial`, before reverting:
+
+- Read the current state from a `settingsRef` (mirror of `settings`, updated in `useEffect`).
+- If `settingsRef.current[key] === thisCallOptimisticValue[key]`, this call's optimistic write is still in place → safe to revert.
+- If they differ, a later call has touched the key → leave it alone.
+
+Emit only the keys actually reverted. Rolls back both local state and bus emit in lockstep, fixes both same-key and different-key cases (latter already covered by #363; this is a strict generalization).
+
+Pseudo-code (SettingsForm):
+
+```ts
+const settingsRef = useRef(settings);
+useEffect(() => {
+  settingsRef.current = settings;
+}, [settings]);
+
+const updateSettings = async (partial: Partial<UserSettingsData>) => {
+  const optimistic = partial; // values this call wrote
+  let previousPartial: Partial<UserSettingsData> | undefined;
+  setSettings((curr) => {
+    previousPartial = Object.fromEntries(
+      (Object.keys(partial) as Array<keyof UserSettingsData>).map((k) => [k, curr[k]])
+    ) as Partial<UserSettingsData>;
+    return { ...curr, ...partial };
+  });
+
+  try {
+    /* PUT, throw on !ok, emit(partial) */
+  } catch {
+    toast.error("Failed to save settings");
+    if (!previousPartial) return;
+
+    // Build the actual-revert subset from settingsRef (post-render).
+    const liveRevert: Partial<UserSettingsData> = {};
+    const curr = settingsRef.current;
+    for (const key of Object.keys(previousPartial) as Array<keyof UserSettingsData>) {
+      if (Object.is(curr[key], optimistic[key])) {
+        (liveRevert as Record<string, unknown>)[key] = previousPartial[key];
+      }
+    }
+
+    if (Object.keys(liveRevert).length === 0) return;
+    setSettings((prev) => ({ ...prev, ...liveRevert }));
+    emitUserSettingsChange(liveRevert);
+  }
+};
+```
+
+`useUserSettings.mutate` gets the analogous change — it already has `settingsRef`, just needs the per-key compare-and-swap before the rollback + emit.
+
+## Test plan (TDD)
+
+In `src/components/settings/__tests__/settings-form.test.tsx`:
+
+1. Same-key race (the headline acceptance case):
+   - Click `Dark` (A), then `System` (B) before either resolves.
+   - Resolve B as ok, reject A.
+   - Assert: bus handler observed `{ theme: "dark" }` (B's optimistic emit on success) but NOT `{ theme: "light" }` (A's stale rollback). Local form still shows System checked, not Light.
+2. Different-key behaviour preserved (#363 + #414 — exists for happy path; add explicit bus-side mirror): rapid theme=dark + timeFormat=24h, A theme fails, B succeeds → bus saw `{ theme: "dark" }` rolled back, `{ timeFormat: "24h" }` preserved.
+
+In `src/hooks/__tests__/useUserSettings.test.tsx`:
+
+3. Same-key race at the hook level: two `mutate` calls in flight on the same key, second succeeds, first fails → snapshot's revert is suppressed, no `{ theme: "light" }` emit.
+
+Regression: existing `SettingsForm — bus rollback on PUT failure (#414)` cases must continue to pass (single-call failure still emits the rolled-back partial).
+
+## Files touched
+
+- `src/components/settings/settings-form.tsx` — add `settingsRef`, rewrite catch block.
+- `src/hooks/useUserSettings.ts` — rewrite catch block to compare-and-swap against `settingsRef`.
+- `src/components/settings/__tests__/settings-form.test.tsx` — new test cases.
+- `src/hooks/__tests__/useUserSettings.test.tsx` — new test case.
+
+## Out of scope
+
+- Cross-tab race (storage event) — different bus, not in the user-settings-bus contract.
+- Sequence-numbering scheme (Option 1 from the issue) — heavier than required for the observed race.
+- `updateTaskSettings` race (different store, tracked separately by #413 / #416).
+
+## Acceptance criteria (from issue)
+
+- [x] Test: rapid B-succeeds → A-fails sequence leaves the bus subscriber holding B's value, not A's pre-call value.
+- [x] Same key updated twice with the second succeeding does not regress on the first's failure.
+- [x] No regression of the #363 `setSettings` rollback semantics.
+- [x] `pnpm lint:fix && pnpm format:fix && pnpm check-types && pnpm test` clean.

--- a/src/components/settings/__tests__/settings-form.test.tsx
+++ b/src/components/settings/__tests__/settings-form.test.tsx
@@ -632,3 +632,125 @@ describe("SettingsForm — bus rollback on PUT failure (#414)", () => {
     expect(busHandler).not.toHaveBeenCalledWith({ theme: "light" });
   });
 });
+
+/**
+ * Tests for SettingsForm — same-key rollback race (#420).
+ *
+ * Two `updateSettings` calls in flight on the same key. The second succeeds,
+ * the first fails. The first's rollback path must NOT regress the second's
+ * successful value — neither in local form state nor on the user-settings
+ * bus. Without the guard, the failed call's `previousPartial` snapshot
+ * (captured from the second call's optimistic value) becomes the rolled-back
+ * value, stomping on the most-recent committed truth.
+ */
+describe("SettingsForm — same-key rollback race (#420)", () => {
+  let unsubscribeBus: (() => void) | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockActiveProfile(ACTIVE_PROFILE_ID);
+    unsubscribeBus = undefined;
+  });
+
+  afterEach(() => {
+    unsubscribeBus?.();
+    unsubscribeBus = undefined;
+    vi.unstubAllGlobals();
+  });
+
+  it("does not emit the stale snapshot on the bus when a later same-key PUT succeeded", async () => {
+    const user = userEvent.setup();
+    const first = deferred<Response>();
+    const second = deferred<Response>();
+    let userSettingsCallIndex = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url: string) => {
+        if (typeof url === "string" && url.startsWith("/api/profiles/")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              taskSortOrder: "dueDate",
+              showCompletedTasks: false,
+            }),
+          } as unknown as Response);
+        }
+        userSettingsCallIndex += 1;
+        return userSettingsCallIndex === 1 ? first.promise : second.promise;
+      })
+    );
+
+    const busHandler = vi.fn();
+    unsubscribeBus = subscribeUserSettings(busHandler);
+
+    renderSettings();
+
+    await screen.findByRole("switch", { name: /show completed tasks/i });
+
+    const lightRadio = screen.getByLabelText(/^light$/i);
+    const darkRadio = screen.getByLabelText(/^dark$/i);
+    const systemRadio = screen.getByLabelText(/^system$/i);
+
+    // A then B on the same key — `theme`. B captures A's optimistic value
+    // ("dark") as its `previousPartial`; A captured the original ("light").
+    await user.click(darkRadio);
+    await user.click(systemRadio);
+
+    // Resolve B first (success), then fail A. The order matters — we need
+    // B's success emit to land before A's catch path runs.
+    second.resolve({ ok: true } as Response);
+    first.reject(new Error("network failure"));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Failed to save settings");
+    });
+
+    // Bus subscribers must hold B's value, not A's pre-call snapshot.
+    expect(busHandler).not.toHaveBeenCalledWith({ theme: "light" });
+    // B's optimistic emit must still have landed.
+    expect(busHandler).toHaveBeenCalledWith({ theme: "system" });
+
+    // Local form must also hold B's value, not A's pre-call snapshot.
+    expect(systemRadio).toBeChecked();
+    expect(darkRadio).not.toBeChecked();
+    expect(lightRadio).not.toBeChecked();
+  });
+
+  it("still emits the rolled-back partial when no concurrent same-key PUT touched the field", async () => {
+    // Regression guard for the #414 single-call path — the new race guard
+    // must not suppress rollback when no later call has overwritten the key.
+    const user = userEvent.setup();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url: string) => {
+        if (typeof url === "string" && url.startsWith("/api/profiles/")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              taskSortOrder: "dueDate",
+              showCompletedTasks: false,
+            }),
+          } as unknown as Response);
+        }
+        return Promise.resolve({ ok: false } as Response);
+      })
+    );
+
+    const busHandler = vi.fn();
+    unsubscribeBus = subscribeUserSettings(busHandler);
+
+    renderSettings();
+
+    await screen.findByRole("switch", { name: /show completed tasks/i });
+
+    const darkRadio = screen.getByLabelText(/^dark$/i);
+    await user.click(darkRadio);
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Failed to save settings");
+    });
+
+    expect(busHandler).toHaveBeenCalledTimes(1);
+    expect(busHandler).toHaveBeenCalledWith({ theme: "light" });
+  });
+});

--- a/src/components/settings/settings-form.tsx
+++ b/src/components/settings/settings-form.tsx
@@ -8,6 +8,7 @@ import {
   saveScheduleConfig,
 } from "@/lib/scheduler/schedule-storage";
 import { emitUserSettingsChange } from "@/lib/user-settings-bus";
+import type { UserSettingsData } from "@/types/user-settings";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { AccountSection } from "./account-section";

--- a/src/components/settings/settings-form.tsx
+++ b/src/components/settings/settings-form.tsx
@@ -83,6 +83,14 @@ export function SettingsForm({
   // render commits (#420). Reading the live state outside the `setSettings`
   // functional callback lets us compare-and-swap per-key without emitting
   // from inside the setter (which double-fires under StrictMode).
+  //
+  // The ref is updated in a `useEffect`, which runs after commit but before
+  // the next render. UI-triggered `updateSettings` calls are always separated
+  // by at least one event-loop tick (the user clicks again after the previous
+  // click's handler returns), so by the time a concurrent `catch` fires the
+  // ref reflects every preceding optimistic write. A synchronous same-tick
+  // race (e.g. programmatic rapid-fire) would not be guarded — see the
+  // analogous pattern at `useUserSettings.ts:104`.
   const settingsRef = useRef(settings);
   useEffect(() => {
     settingsRef.current = settings;
@@ -170,6 +178,12 @@ export function SettingsForm({
       // (its PUT succeeded after we snapshotted but before we failed) must
       // not be regressed to our stale snapshot. Reads through `settingsRef`
       // so the comparison sees the truly-current state, post-render.
+      //
+      // `Object.is` is the correct comparator for the current all-primitive
+      // shape of `UserSettingsData`. If a future field becomes an array or
+      // object reference, the comparison would degenerate to reference
+      // equality and the guard would never fire — switch to a structural
+      // comparator at that point.
       const live = settingsRef.current;
       const liveRevert: Partial<UserSettingsData> = {};
       for (const key of Object.keys(revert) as Array<keyof UserSettingsData>) {

--- a/src/components/settings/settings-form.tsx
+++ b/src/components/settings/settings-form.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/lib/scheduler/schedule-storage";
 import { emitUserSettingsChange } from "@/lib/user-settings-bus";
 import type { TWeekStartDay } from "@/types/calendar";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { AccountSection } from "./account-section";
 import { CalendarSection } from "./calendar-section";
@@ -78,6 +78,15 @@ export function SettingsForm({
   const [transitionConfig, setTransitionConfig] = useState<TransitionConfig>(
     () => DEFAULT_TRANSITION_CONFIG
   );
+
+  // Mirror of `settings` for the rollback path to read after the optimistic
+  // render commits (#420). Reading the live state outside the `setSettings`
+  // functional callback lets us compare-and-swap per-key without emitting
+  // from inside the setter (which double-fires under StrictMode).
+  const settingsRef = useRef(settings);
+  useEffect(() => {
+    settingsRef.current = settings;
+  }, [settings]);
 
   // Load transition config from localStorage on mount
   useEffect(() => {
@@ -153,14 +162,30 @@ export function SettingsForm({
     } catch {
       toast.error("Failed to save settings");
       const revert = previousPartial;
-      if (revert) {
-        setSettings((curr) => ({ ...curr, ...revert }));
-        // #414 — pair the local rollback with a bus emit so in-tab
-        // subscribers (e.g. `CalendarProvider` via `useUserSettings`)
-        // converge on the rolled-back value rather than holding any
-        // earlier optimistic value they may have consumed.
-        emitUserSettingsChange(revert);
+      if (!revert) return;
+
+      // #420 — compare-and-swap rollback. For each key in `revert`, only
+      // restore the pre-call value if the live state still matches this
+      // call's optimistic value. A later call that overwrote the same key
+      // (its PUT succeeded after we snapshotted but before we failed) must
+      // not be regressed to our stale snapshot. Reads through `settingsRef`
+      // so the comparison sees the truly-current state, post-render.
+      const live = settingsRef.current;
+      const liveRevert: Partial<UserSettingsData> = {};
+      for (const key of Object.keys(revert) as Array<keyof UserSettingsData>) {
+        if (Object.is(live[key], partial[key])) {
+          (liveRevert as Record<string, unknown>)[key] = revert[key];
+        }
       }
+
+      if (Object.keys(liveRevert).length === 0) return;
+
+      setSettings((curr) => ({ ...curr, ...liveRevert }));
+      // #414 — pair the local rollback with a bus emit so in-tab
+      // subscribers (e.g. `CalendarProvider` via `useUserSettings`)
+      // converge on the rolled-back value rather than holding any
+      // earlier optimistic value they may have consumed.
+      emitUserSettingsChange(liveRevert);
     }
   };
 

--- a/src/components/settings/settings-form.tsx
+++ b/src/components/settings/settings-form.tsx
@@ -8,9 +8,7 @@ import {
   saveScheduleConfig,
 } from "@/lib/scheduler/schedule-storage";
 import { emitUserSettingsChange } from "@/lib/user-settings-bus";
-import type { TWeekStartDay } from "@/types/calendar";
 import { useEffect, useRef, useState } from "react";
-import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { AccountSection } from "./account-section";
 import { CalendarSection } from "./calendar-section";

--- a/src/hooks/__tests__/useUserSettings.test.tsx
+++ b/src/hooks/__tests__/useUserSettings.test.tsx
@@ -2,7 +2,10 @@
  * Tests for useUserSettings hook
  * Following TDD - tests written before implementation
  */
-import { emitUserSettingsChange } from "@/lib/user-settings-bus";
+import {
+  emitUserSettingsChange,
+  subscribeUserSettings,
+} from "@/lib/user-settings-bus";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -631,6 +634,66 @@ describe("useUserSettings", () => {
 
       // Local state is rolled back to the pre-mutate value.
       expect(result.current.settings.timeFormat).toBe("12h");
+    });
+  });
+
+  describe("same-key rollback race (#420)", () => {
+    it("does not roll back when the current state no longer matches this mutate's optimistic value", async () => {
+      mockUseSession.mockReturnValue({
+        data: { user: { id: "u1" } },
+        status: "authenticated",
+      });
+      // Initial GET — server says 12h.
+      vi.mocked(global.fetch).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ timeFormat: "12h" }),
+      } as Response);
+
+      const { result } = renderHook(() => useUserSettings());
+      await waitFor(() => {
+        expect(result.current.settings.timeFormat).toBe("12h");
+      });
+
+      // A: kick off a mutate to "24h" with a PUT that will be rejected later.
+      let rejectA: (reason?: unknown) => void = () => {};
+      const aPromise = new Promise<Response>((_resolve, reject) => {
+        rejectA = reject;
+      });
+      vi.mocked(global.fetch).mockImplementationOnce(() => aPromise);
+
+      let aMutate: Promise<void> | undefined;
+      await act(async () => {
+        aMutate = result.current.mutate({ timeFormat: "24h" }).catch(() => {});
+        // Let the optimistic setSettings + bus emit run.
+        await Promise.resolve();
+      });
+      expect(result.current.settings.timeFormat).toBe("24h");
+
+      // Simulate B's success — a later same-key bus event overrides to "12h",
+      // standing in for a parallel `mutate({ timeFormat: "12h" })` whose PUT
+      // resolved before A's.
+      await act(async () => {
+        emitUserSettingsChange({ timeFormat: "12h" });
+      });
+      expect(result.current.settings.timeFormat).toBe("12h");
+
+      // Subscribe AFTER B's emit so we only observe whether A's rollback
+      // path re-emits the stale snapshot.
+      const busHandler = vi.fn();
+      const unsubscribe = subscribeUserSettings(busHandler);
+
+      // Reject A — the catch should compare the current state ("12h") to
+      // this call's optimistic value ("24h"). They differ, so the rollback
+      // and emit should be suppressed.
+      await act(async () => {
+        rejectA(new Error("boom"));
+        await aMutate;
+      });
+
+      expect(busHandler).not.toHaveBeenCalled();
+      expect(result.current.settings.timeFormat).toBe("12h");
+
+      unsubscribe();
     });
   });
 

--- a/src/hooks/useUserSettings.ts
+++ b/src/hooks/useUserSettings.ts
@@ -212,6 +212,12 @@ export function useUserSettings(): UseUserSettingsResult {
       // already moved local state past our optimistic value; reverting it
       // to our pre-call snapshot would stomp on the most-recent truth and
       // re-broadcast a stale value to every other in-tab subscriber.
+      //
+      // `settingsRef.current` is updated post-commit via `useEffect`; UI-
+      // driven mutates always have an event-loop tick between them, so the
+      // ref reflects every preceding optimistic write by the time a
+      // concurrent rejection lands. `Object.is` is the right comparator
+      // for the all-primitive `UserCalendarSettings` shape today.
       if (snapshot && Object.keys(snapshot).length > 0) {
         const live = settingsRef.current;
         const liveRollback: Partial<UserCalendarSettings> = {};

--- a/src/hooks/useUserSettings.ts
+++ b/src/hooks/useUserSettings.ts
@@ -206,12 +206,28 @@ export function useUserSettings(): UseUserSettingsResult {
         throw new Error(`Failed to update user settings (${response.status})`);
       }
     } catch (error) {
-      // Roll back the optimistic write. Re-emit the snapshot to revert
-      // every other in-tab subscriber too.
+      // #420 — compare-and-swap rollback. Only restore the snapshot for
+      // keys whose live value still matches what *this* mutate set. A
+      // concurrent successful mutate (or bus event) on the same key has
+      // already moved local state past our optimistic value; reverting it
+      // to our pre-call snapshot would stomp on the most-recent truth and
+      // re-broadcast a stale value to every other in-tab subscriber.
       if (snapshot && Object.keys(snapshot).length > 0) {
-        const rollback = snapshot;
-        setSettings((prev) => ({ ...prev, ...rollback }));
-        emitUserSettingsChange(rollback as UserSettingsPartial);
+        const live = settingsRef.current;
+        const liveRollback: Partial<UserCalendarSettings> = {};
+        for (const key of Object.keys(snapshot) as Array<
+          keyof UserCalendarSettings
+        >) {
+          if (Object.is(live[key], (picked as Record<string, unknown>)[key])) {
+            (liveRollback as Record<string, unknown>)[key] = (
+              snapshot as Record<string, unknown>
+            )[key];
+          }
+        }
+        if (Object.keys(liveRollback).length > 0) {
+          setSettings((prev) => ({ ...prev, ...liveRollback }));
+          emitUserSettingsChange(liveRollback as UserSettingsPartial);
+        }
       }
       throw error;
     }


### PR DESCRIPTION
## Summary

- `SettingsForm.updateSettings` and `useUserSettings.mutate` both snapshot pre-call values for rollback and re-emit on the user-settings bus on PUT failure. When two calls touch the **same key**, the failing call's rollback wiped a later successful PUT's committed value from local state and every in-tab bus subscriber.
- Switch the rollback to compare-and-swap: read the live state through a `settingsRef` (`SettingsForm` gains the same wiring `useUserSettings` already has) and only revert keys whose current value still equals what *this* call set. Other keys (and other calls' values) are left alone.
- Strict generalization of the existing #363 different-key semantics; single-call failure path (#414) is unchanged.

## Plan

Linked plan: `.claude/plans/user-settings-bus-rollback-race-420.md`
Project: https://github.com/users/BenSeymourODB/projects/1

## Test plan

- [x] New `SettingsForm — same-key rollback race (#420)` test: rapid `theme=dark` then `theme=system`, second succeeds first, first fails → bus and local form stay at `system`, no `{ theme: "light" }` emit lands.
- [x] Regression guard in the same describe block: single-call failure still emits the reverted partial (`{ theme: "light" }`) so the #414 contract is intact.
- [x] New `useUserSettings > same-key rollback race (#420)` test: optimistic `24h` mutate held mid-PUT, a same-key bus event flips state back to `12h`, then the PUT fails — no stale rollback emit, no local regression.
- [x] Full suite: `pnpm test` → 2546/2546 passing.
- [x] `pnpm lint:fix && pnpm format:fix && pnpm check-types` clean.

## Deferred to follow-ups

- #433 — direct two-concurrent-`mutate` test at the hook level (this PR uses a same-key bus-emit stand-in inside the hook test; the integration test in `settings-form.test.tsx` covers the full two-mutate flow at the component level).

Closes #420

🤖 Generated with [Claude Code](https://claude.com/claude-code)