### PR TITLE
fix(http): make withRetry's inter-attempt sleep signal-aware (#434)

### DIFF
--- a/.claude/plans/retry-signal-aware-sleep-434.md
+++ b/.claude/plans/retry-signal-aware-sleep-434.md
@@ -1,0 +1,65 @@
+# Signal-aware sleep in `withRetry` (#434)
+
+## Problem
+
+`withRetry` in `src/lib/http/retry.ts` accepts an `AbortSignal` via `options.signal` but only checks it (a) before the first attempt, (b) immediately before/after the inter-attempt sleep. The sleep itself is _not_ abortable — once it starts, it runs to completion. The abort is observed only when the next iteration begins.
+
+When `refreshGoogleAccessToken` (post-#430) passes `AbortSignal.timeout(N)` via `init.signal`, the per-flight signal aborts the in-flight `fetch()` but cannot interrupt the wait between attempts. Worst-case wall time is `timeout + maxDelayMs` (~15s with defaults), not `timeout`.
+
+Additionally, `fetchWithRetry` never propagates `init.signal` into `withRetry` via `options.signal`. So even with a signal-aware sleep, the timeout signal in `refreshGoogleAccessToken`'s call site is invisible to the retry loop.
+
+## Scope of this change
+
+1. **Make `withRetry`'s inter-attempt sleep signal-aware**, with proper listener cleanup so listeners do not leak on success or non-abort failure paths.
+2. **Promote `init.signal` to `options.signal` in `fetchWithRetry`** when the caller did not pass `options.signal`. Preserves the existing "init.signal wins over options.signal in the both-set case" contract.
+3. **TDD**: new unit tests in `src/lib/http/__tests__/retry.test.ts` covering:
+   - Sleep rejects immediately when the signal aborts mid-sleep.
+   - Abort listener is removed when the sleep completes naturally (no leak).
+   - Abort listener is removed when retries succeed (no leak).
+   - `fetchWithRetry` threads `init.signal` into `withRetry`'s sleep when `options.signal` is unset.
+
+## Out of scope
+
+- Touching `refreshGoogleAccessToken` (PR #430 does that). When both #430 and this issue ship, the worst-case wall-time bound is tightened automatically.
+- Switching to `AbortSignal.any` to merge `init.signal` and `options.signal` — would break the existing "caller signal wins" contract documented in the test at retry.test.ts:625. If desirable in future, file a follow-up.
+
+## Design notes
+
+Helper inside `retry.ts`:
+
+```ts
+async function abortableSleep(
+  ms: number,
+  sleep: (ms: number) => Promise<void>,
+  signal: AbortSignal | undefined
+): Promise<void> {
+  if (!signal) return sleep(ms);
+  if (signal.aborted) throw abortError();
+
+  let onAbort: (() => void) | undefined;
+  const abortPromise = new Promise<never>((_, reject) => {
+    onAbort = () => reject(abortError());
+    signal.addEventListener("abort", onAbort);
+  });
+
+  try {
+    await Promise.race([sleep(ms), abortPromise]);
+  } finally {
+    if (onAbort) signal.removeEventListener("abort", onAbort);
+  }
+}
+```
+
+`{ once: true }` would auto-remove on fire but leak on the sleep-wins path. Always manually `removeEventListener` in a `finally` block — `removeEventListener` is a no-op if the listener already auto-removed, so this is safe in every branch.
+
+`fetchWithRetry` change:
+
+```ts
+const effectiveOptions: RetryOptions =
+  options.signal == null && init?.signal != null ? { ...options, signal: init.signal } : options;
+```
+
+## Validation
+
+- `pnpm test src/lib/http/__tests__/retry.test.ts` — new tests green, all existing tests still green.
+- `pnpm lint:fix && pnpm format:fix && pnpm check-types && pnpm test`.

--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -11,8 +11,8 @@ import { PrismaAdapter } from "@auth/prisma-adapter";
 import { encryptLinkedAccount } from "./link-account";
 import { refreshGoogleAccessToken } from "./refresh-google-token";
 import { lastSix, shouldAllowSignIn } from "./sign-in-guard";
-import { validateGoogleOAuthEnv } from "./validate-google-oauth-env";
 import { getOrStartSessionRefresh } from "./token-refresh-singleflight";
+import { validateGoogleOAuthEnv } from "./validate-google-oauth-env";
 
 // Fail fast on a missing / misconfigured server-side secret. Without these
 // boot checks the failure manifests later, after a user has signed in, as a

--- a/src/lib/http/__tests__/retry.test.ts
+++ b/src/lib/http/__tests__/retry.test.ts
@@ -385,6 +385,120 @@ describe("withRetry", () => {
 
     expect(fn).toHaveBeenCalledTimes(3);
   });
+
+  it("aborts the inter-attempt sleep when the signal fires mid-sleep (#434)", async () => {
+    // Without a signal-aware sleep, an abort that fires while we are between
+    // attempts only takes effect on the next iteration — the sleep runs to
+    // completion first. With the fix, the sleep itself rejects.
+    const controller = new AbortController();
+
+    // Manually-resolved sleep: we never resolve it, so the only way for the
+    // race to settle is via the abort path. If the implementation still
+    // ignores the signal during sleep, the test will time out.
+    let resolveSleep: (() => void) | undefined;
+    const sleep = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSleep = resolve;
+        })
+    );
+
+    const fn = vi.fn().mockRejectedValue(new HttpRetryError(503, null));
+
+    const pending = withRetry(fn, {
+      maxAttempts: 3,
+      baseDelayMs: 1,
+      jitter: "none",
+      sleep,
+      signal: controller.signal,
+      random: midpointRandom,
+    });
+
+    // Wait a microtask so the first attempt runs and the sleep is entered.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(sleep).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    controller.abort();
+
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    // The second attempt was never reached.
+    expect(fn).toHaveBeenCalledTimes(1);
+    // Defensive: avoid an unresolved-promise leak between tests.
+    resolveSleep?.();
+  });
+
+  it("removes the abort listener after the sleep completes naturally", async () => {
+    // If the listener leaked it would accumulate on every retry across a
+    // long-lived signal (e.g. one tied to a session). Track add/remove to
+    // prove cleanup discipline.
+    const controller = new AbortController();
+    const addSpy = vi.spyOn(controller.signal, "addEventListener");
+    const removeSpy = vi.spyOn(controller.signal, "removeEventListener");
+
+    const { sleep } = createSleep();
+    let callCount = 0;
+    const fn = vi.fn(async () => {
+      callCount += 1;
+      if (callCount < 3) throw new HttpRetryError(503, null);
+      return "ok";
+    });
+
+    const result = await withRetry(fn, {
+      maxAttempts: 3,
+      baseDelayMs: 1,
+      jitter: "none",
+      sleep,
+      signal: controller.signal,
+    });
+
+    expect(result).toBe("ok");
+    // Two sleeps occurred (between attempts 1↔2 and 2↔3); each must add and
+    // remove exactly one abort listener.
+    const abortAdds = addSpy.mock.calls.filter(([type]) => type === "abort");
+    const abortRemoves = removeSpy.mock.calls.filter(
+      ([type]) => type === "abort"
+    );
+    expect(abortAdds.length).toBe(2);
+    expect(abortRemoves.length).toBe(2);
+  });
+
+  it("removes the abort listener when the signal fires during sleep", async () => {
+    // The abort path also has to clean up — `{ once: true }` would do this
+    // implicitly but the implementation uses `finally` for symmetry with
+    // the sleep-wins path, so verify it explicitly.
+    const controller = new AbortController();
+    const addSpy = vi.spyOn(controller.signal, "addEventListener");
+    const removeSpy = vi.spyOn(controller.signal, "removeEventListener");
+
+    const sleep = vi.fn(
+      () => new Promise<void>(() => {}) // never resolves
+    );
+    const fn = vi.fn().mockRejectedValue(new HttpRetryError(503, null));
+
+    const pending = withRetry(fn, {
+      maxAttempts: 3,
+      baseDelayMs: 1,
+      jitter: "none",
+      sleep,
+      signal: controller.signal,
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+    controller.abort();
+
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+
+    const abortAdds = addSpy.mock.calls.filter(([type]) => type === "abort");
+    const abortRemoves = removeSpy.mock.calls.filter(
+      ([type]) => type === "abort"
+    );
+    expect(abortAdds.length).toBe(1);
+    expect(abortRemoves.length).toBe(1);
+  });
 });
 
 describe("fetchWithRetry", () => {
@@ -646,6 +760,46 @@ describe("fetchWithRetry", () => {
       "https://example.com/x",
       expect.objectContaining({ signal: innerController.signal })
     );
+  });
+
+  it("threads init.signal into withRetry's sleep when options.signal is unset (#434)", async () => {
+    // `refreshGoogleAccessToken` passes `AbortSignal.timeout(N)` via
+    // `init.signal`. Without forwarding it to `withRetry`, the inter-attempt
+    // sleep cannot observe the per-flight timeout, so the worst-case wall
+    // time is `timeout + maxDelayMs` instead of `timeout`. Verify the
+    // forwarding by aborting init.signal mid-sleep and asserting that the
+    // retry loop short-circuits with AbortError rather than continuing.
+    mockFetch.mockResolvedValue(errorResponse(503));
+    const controller = new AbortController();
+
+    let resolveSleep: (() => void) | undefined;
+    const sleep = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSleep = resolve;
+        })
+    );
+
+    const pending = fetchWithRetry(
+      "https://example.com/x",
+      { method: "GET", signal: controller.signal },
+      { sleep, random: midpointRandom, maxAttempts: 3, baseDelayMs: 1 }
+    );
+
+    // Let the first fetch and the sleep entry run.
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(sleep).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    controller.abort();
+
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    // The second fetch was never issued.
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    resolveSleep?.();
   });
 });
 

--- a/src/lib/http/retry.ts
+++ b/src/lib/http/retry.ts
@@ -282,11 +282,16 @@ export async function withRetry<T>(
  * contract. If `init.signal` is absent and `options.signal` is provided, the
  * outer signal is threaded through.
  *
- * The signal that `withRetry` observes for its inter-attempt sleep is derived
- * from the same precedence: `options.signal` if set, otherwise `init.signal`.
+ * The signal that `withRetry` observes for its inter-attempt sleep follows
+ * the *opposite* precedence: `options.signal` if set, otherwise `init.signal`.
  * This makes the per-flight `AbortSignal.timeout(N)` that callers pass via
  * `init` bound the *entire* retry loop's wall time, not just each individual
- * fetch attempt (issue #434).
+ * fetch attempt (issue #434). When both signals are set the two contracts
+ * become asymmetric: each `fetch()` call observes `init.signal`, while the
+ * inter-attempt sleep observes `options.signal`. That's an artefact of the
+ * "caller signal wins" rule for fetch; merging the two via `AbortSignal.any`
+ * is the natural next step but is intentionally deferred to keep this change
+ * minimal.
  */
 export async function fetchWithRetry(
   input: Parameters<typeof fetch>[0],

--- a/src/lib/http/retry.ts
+++ b/src/lib/http/retry.ts
@@ -177,6 +177,40 @@ function defaultSleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/**
+ * Race a sleep against an AbortSignal so the inter-attempt wait short-circuits
+ * the moment the signal fires. Without this, `withRetry`'s wall-clock cost on
+ * an aborted run is `pending-attempt + one backoff`, not the bare timeout the
+ * caller asked for (issue #434).
+ *
+ * `{ once: true }` would self-remove on fire but leak on the sleep-wins path.
+ * Always remove the listener in a `finally` block; `removeEventListener` is a
+ * no-op if the listener already auto-removed, so this is safe in every branch.
+ */
+async function abortableSleep(
+  ms: number,
+  sleep: (ms: number) => Promise<void>,
+  signal: AbortSignal | undefined
+): Promise<void> {
+  if (!signal) {
+    await sleep(ms);
+    return;
+  }
+  if (signal.aborted) throw abortError();
+
+  let onAbort: (() => void) | undefined;
+  const abortPromise = new Promise<never>((_, reject) => {
+    onAbort = () => reject(abortError());
+    signal.addEventListener("abort", onAbort);
+  });
+
+  try {
+    await Promise.race([sleep(ms), abortPromise]);
+  } finally {
+    if (onAbort) signal.removeEventListener("abort", onAbort);
+  }
+}
+
 function abortError(): Error {
   // DOMException isn't guaranteed in every runtime; a plain Error with
   // `name: "AbortError"` is what the Web `fetch` spec surfaces and what
@@ -226,7 +260,7 @@ export async function withRetry<T>(
 
       onRetry?.({ attempt, delayMs, error, retryAfterMs });
 
-      await sleep(delayMs);
+      await abortableSleep(delayMs, sleep, signal);
 
       if (signal?.aborted) throw abortError();
     }
@@ -247,6 +281,12 @@ export async function withRetry<T>(
  * two signals requires `AbortSignal.any` (Node 20+) and we want one simple
  * contract. If `init.signal` is absent and `options.signal` is provided, the
  * outer signal is threaded through.
+ *
+ * The signal that `withRetry` observes for its inter-attempt sleep is derived
+ * from the same precedence: `options.signal` if set, otherwise `init.signal`.
+ * This makes the per-flight `AbortSignal.timeout(N)` that callers pass via
+ * `init` bound the *entire* retry loop's wall time, not just each individual
+ * fetch attempt (issue #434).
  */
 export async function fetchWithRetry(
   input: Parameters<typeof fetch>[0],
@@ -259,6 +299,11 @@ export async function fetchWithRetry(
   if (!effectiveInit.signal && options.signal) {
     effectiveInit.signal = options.signal;
   }
+
+  const effectiveOptions: RetryOptions =
+    options.signal == null && init?.signal != null
+      ? { ...options, signal: init.signal }
+      : options;
 
   // `fetchWithRetry` reads its own copy of maxAttempts so the inner function
   // can decide between "throw HttpRetryError" (ask `withRetry` to retry) and
@@ -297,7 +342,7 @@ export async function fetchWithRetry(
         retryAfterMs,
         `HTTP ${response.status} from ${safeUrl(input)}`
       );
-    }, options);
+    }, effectiveOptions);
   } catch (error) {
     // Only substitute the stored transient response when the retry loop
     // escalated *this* attempt via HttpRetryError. If the final attempt


### PR DESCRIPTION
## Summary

- Make `withRetry`'s inter-attempt sleep signal-aware via a new `abortableSleep` helper that races the sleep against the abort signal.
- Always `removeEventListener` in a `finally` block so the abort listener does not leak on the sleep-wins path.
- Promote `init.signal` to `options.signal` in `fetchWithRetry` when the caller did not pass `options.signal`, so the per-flight signal reaches the retry loop. The existing "`init.signal` wins when both are set" contract is preserved.

This tightens `refreshGoogleAccessToken`'s worst-case wall time on a 503 → hang sequence from `timeout + maxDelayMs` (~15 s) to `timeout` (the value the call site passes to `AbortSignal.timeout`).

## Plan

Linked plan: `.claude/plans/retry-signal-aware-sleep-434.md`
Project: https://github.com/users/BenSeymourODB/projects/1

## Test plan

- [x] `pnpm test src/lib/http/__tests__/retry.test.ts` — 47/47 pass (43 existing + 4 new).
- [x] `pnpm test` — 2585/2585 pass (158 files).
- [x] `pnpm lint:fix && pnpm format:fix && pnpm check-types` — clean.

New tests added to `src/lib/http/__tests__/retry.test.ts`:

- `withRetry` aborts the inter-attempt sleep when the signal fires mid-sleep.
- `withRetry` removes the abort listener after the sleep completes naturally (no leak).
- `withRetry` removes the abort listener when the signal fires during sleep.
- `fetchWithRetry` threads `init.signal` into `withRetry`'s sleep when `options.signal` is unset.

## Notes

- Independent of PR #430. When #430 lands and wires `AbortSignal.timeout(N)` into `refreshGoogleAccessToken` via `init.signal`, this PR's forwarding makes that signal bound the entire retry loop, not just each individual fetch attempt.
- Deferred to #436: switching the "both signals set" case to `AbortSignal.any(...)` to merge them. That would break the documented "caller `init.signal` wins" contract pinned by the existing test at `retry.test.ts:739`. Updated JSDoc on `fetchWithRetry` now flags the asymmetry between fetch's signal and the sleep's signal in the both-set case.

Closes #434

🤖 Generated with [Claude Code](https://claude.com/claude-code)