### PR TITLE
refactor(api): use isTimeFormat typeguard from useUserSettings (#427)

### DIFF
--- a/src/app/api/settings/__tests__/route.test.ts
+++ b/src/app/api/settings/__tests__/route.test.ts
@@ -214,7 +214,46 @@ describe("/api/settings", () => {
       const { status, data } = await parseResponse<ApiErrorResponse>(response);
 
       expect(status).toBe(400);
-      expect(data.error).toContain("Invalid timeFormat");
+      // Locks in the exact error body so the #427 refactor (route ↔
+      // useUserSettings allow-list consolidation) cannot regress the
+      // API surface — the message is part of the wire contract.
+      expect(data.error).toBe("Invalid timeFormat. Must be one of: 12h, 24h");
+    });
+
+    it.each(["12h", "24h"])(
+      "accepts %s as a valid timeFormat",
+      async (timeFormat) => {
+        vi.mocked(getSession).mockResolvedValue(mockSession);
+        const updatedSettings = { ...mockSettings, timeFormat };
+        mockPrisma.userSettings.upsert.mockResolvedValue(updatedSettings);
+
+        const request = createMockRequest("/api/settings", {
+          method: "PUT",
+          body: { timeFormat },
+        });
+
+        const response = await PUT(request);
+        const { status, data } =
+          await parseResponse<typeof updatedSettings>(response);
+
+        expect(status).toBe(200);
+        expect(data.timeFormat).toBe(timeFormat);
+      }
+    );
+
+    it("rejects non-string timeFormat values", async () => {
+      vi.mocked(getSession).mockResolvedValue(mockSession);
+
+      const request = createMockRequest("/api/settings", {
+        method: "PUT",
+        body: { timeFormat: 24 },
+      });
+
+      const response = await PUT(request);
+      const { status, data } = await parseResponse<ApiErrorResponse>(response);
+
+      expect(status).toBe(400);
+      expect(data.error).toBe("Invalid timeFormat. Must be one of: 12h, 24h");
     });
 
     it("validates dateFormat value", async () => {

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -1,3 +1,4 @@
+import { isTimeFormat } from "@/hooks/useUserSettings";
 import {
   ApiError,
   requireUserSession,
@@ -13,7 +14,6 @@ import { NextRequest, NextResponse } from "next/server";
 // and `THEME_OPTIONS` in `src/components/settings/display-section.tsx`.
 // `auto` is a legacy alias for `system` (display-section maps it on display).
 const VALID_THEMES = ["light", "dark", "auto", "system", "wall-projector"];
-const VALID_TIME_FORMATS = ["12h", "24h"];
 
 /**
  * GET /api/settings - Returns user settings
@@ -91,7 +91,7 @@ export const PUT = withApiHandler(
     }
 
     if (body.timeFormat !== undefined) {
-      if (!VALID_TIME_FORMATS.includes(body.timeFormat as string)) {
+      if (!isTimeFormat(body.timeFormat)) {
         throw new ApiError("Invalid timeFormat. Must be one of: 12h, 24h", 400);
       }
     }


### PR DESCRIPTION
## Summary

- Drops the duplicated `VALID_TIME_FORMATS = ["12h", "24h"]` array from `src/app/api/settings/route.ts` in favour of the canonical `isTimeFormat` typeguard already exported by `src/hooks/useUserSettings.ts`.
- The PUT handler now calls `isTimeFormat(body.timeFormat)` — same membership check, but the typeguard's own `typeof value === "string"` guard means the previous `body.timeFormat as string` cast is no longer needed.
- **Wire contract is unchanged**: same 400 status and same error body (`"Invalid timeFormat. Must be one of: 12h, 24h"`) for the same invalid input.

## Why

Surfaced by the PR #426 review (issue #427) — the route's local allow-list and the `VALID_TIME_FORMATS` array inside `useUserSettings.ts` were in sync today but maintained in two places. A future "add `24h-padded`" change would have required a coordinated edit; this PR collapses it to one source of truth.

## Plan

No `.claude/plans/` entry — the change is a 2-line production edit + 3 new tests. The original plan for the parent narrowing work lives at `.claude/plans/timeformat-narrow-423.md` (which explicitly flagged this server-side consolidation as out of scope for #423; this PR closes that gap).

Project: https://github.com/users/BenSeymourODB/projects/1

## Acceptance criteria (from #427)

- [x] `src/app/api/settings/route.ts` imports the allow-list from `useUserSettings.ts` (no local re-declaration).
- [x] No behaviour change at the API boundary — 400 response and error body identical for the same invalid input.
- [x] Existing `src/app/api/settings/__tests__/*` tests pass unchanged. Added a positive test covering `12h` / `24h` plus an explicit non-string rejection, and tightened the existing negative test to assert the full error string (was `.toContain("Invalid timeFormat")`).
- [x] `pnpm lint:fix && pnpm format:fix && pnpm check-types && pnpm test` clean.

## Test plan

- [x] `npx vitest run src/app/api/settings/__tests__/route.test.ts` — 39 / 39 passing (was 36; added 3).
- [x] `pnpm test` — full suite 2662 / 2662 passing.
- [x] `pnpm check-types` — clean.
- [x] `pnpm lint:fix && pnpm format:fix` — no new issues (5 pre-existing warnings unchanged).
- [x] `pnpm build` — production build succeeds; the cross-boundary import from a `"use client"` hook into the server route handler does not regress bundling.

## Deferred follow-ups

- **#453** — Move `isTimeFormat` out of the `"use client"` hook into `src/lib/time-format.ts`. Surfaced in the first-pass review of this PR (the `"use client"` → server-route import works via tree-shaking but is the wrong long-term shape; cleaner pattern already in use for `VALID_DATE_FORMATS` in `src/lib/format-date.ts`). This PR honours the original #427 proposal verbatim; the extraction is the natural next step.

## Out of scope

The same shape applies to `VALID_THEMES` (still inline) and `VALID_DATE_FORMATS` (already in `@/lib/format-date`) in the same file. The issue body explicitly narrows scope to `timeFormat`, so the other allow-lists are tracked separately.

Closes #427

🤖 Generated with [Claude Code](https://claude.com/claude-code)