### PR TITLE
refactor(settings): extract isTimeFormat to server-safe @/lib/time-format (#453)

### DIFF
--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -7,7 +7,7 @@ import { isCalendarTransitionSpeed } from "@/lib/calendar/transition-speed";
 import { prisma } from "@/lib/db";
 import { VALID_DATE_FORMATS } from "@/lib/format-date";
 import { logger } from "@/lib/logger";
-import { isTimeFormat } from "@/lib/time-format";
+import { VALID_TIME_FORMATS, isTimeFormat } from "@/lib/time-format";
 import { NextRequest, NextResponse } from "next/server";
 
 // Keep in sync with `THEMES` in `src/components/providers/ThemeProvider.tsx`
@@ -92,7 +92,10 @@ export const PUT = withApiHandler(
 
     if (body.timeFormat !== undefined) {
       if (!isTimeFormat(body.timeFormat)) {
-        throw new ApiError("Invalid timeFormat. Must be one of: 12h, 24h", 400);
+        throw new ApiError(
+          `Invalid timeFormat. Must be one of: ${VALID_TIME_FORMATS.join(", ")}`,
+          400
+        );
       }
     }
 

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -1,4 +1,3 @@
-import { isTimeFormat } from "@/hooks/useUserSettings";
 import {
   ApiError,
   requireUserSession,
@@ -8,6 +7,7 @@ import { isCalendarTransitionSpeed } from "@/lib/calendar/transition-speed";
 import { prisma } from "@/lib/db";
 import { VALID_DATE_FORMATS } from "@/lib/format-date";
 import { logger } from "@/lib/logger";
+import { isTimeFormat } from "@/lib/time-format";
 import { NextRequest, NextResponse } from "next/server";
 
 // Keep in sync with `THEMES` in `src/components/providers/ThemeProvider.tsx`

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,5 +1,4 @@
 import { SettingsForm } from "@/components/settings/settings-form";
-import { isTimeFormat } from "@/hooks/useUserSettings";
 import { getSession } from "@/lib/auth";
 import {
   DEFAULT_CALENDAR_TRANSITION_SPEED,
@@ -7,6 +6,7 @@ import {
 } from "@/lib/calendar/transition-speed";
 import { prisma } from "@/lib/db";
 import { DEFAULT_DATE_FORMAT, isDateFormat } from "@/lib/format-date";
+import { isTimeFormat } from "@/lib/time-format";
 import { redirect } from "next/navigation";
 
 export default async function SettingsPage() {

--- a/src/components/providers/CalendarProvider.tsx
+++ b/src/components/providers/CalendarProvider.tsx
@@ -4,7 +4,7 @@ import type { CalendarsResponse } from "@/app/api/calendar/calendars/route";
 import { useProfileOptional } from "@/components/profiles/profile-context";
 import { useEventCacheVisibilitySweep } from "@/hooks/useEventCacheVisibilitySweep";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
-import { type TTimeFormat, useUserSettings } from "@/hooks/useUserSettings";
+import { useUserSettings } from "@/hooks/useUserSettings";
 import {
   type HiddenEventCounts,
   ZERO_HIDDEN_COUNTS,
@@ -29,6 +29,7 @@ import {
 import { resolveTransitionDurationMs } from "@/lib/calendar/transition-speed";
 import type { GoogleCalendarEvent } from "@/lib/google-calendar";
 import { logger } from "@/lib/logger";
+import type { TTimeFormat } from "@/lib/time-format";
 import type {
   ICalendarInfo,
   IEvent,

--- a/src/components/settings/display-section.tsx
+++ b/src/components/settings/display-section.tsx
@@ -3,8 +3,8 @@
 import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Slider } from "@/components/ui/slider";
-import { type TTimeFormat, isTimeFormat } from "@/hooks/useUserSettings";
 import type { TDateFormat } from "@/lib/format-date";
+import { type TTimeFormat, isTimeFormat } from "@/lib/time-format";
 import type { TWeekStartDay } from "@/types/calendar";
 import { useTheme } from "next-themes";
 import { SettingsSection } from "./settings-section";

--- a/src/hooks/__tests__/useUserSettings.test.tsx
+++ b/src/hooks/__tests__/useUserSettings.test.tsx
@@ -10,7 +10,6 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   DEFAULT_USER_CALENDAR_SETTINGS,
-  isTimeFormat,
   useUserSettings,
 } from "../useUserSettings";
 
@@ -798,26 +797,5 @@ describe("useUserSettings", () => {
       ).not.toThrow();
       expect(result.current.settings.timeFormat).toBe("12h");
     });
-  });
-});
-
-describe("isTimeFormat", () => {
-  it("accepts the two valid literal values", () => {
-    expect(isTimeFormat("12h")).toBe(true);
-    expect(isTimeFormat("24h")).toBe(true);
-  });
-
-  it("rejects similar-looking strings outside the allow-list", () => {
-    expect(isTimeFormat("13h")).toBe(false);
-    expect(isTimeFormat("12H")).toBe(false);
-    expect(isTimeFormat("12")).toBe(false);
-    expect(isTimeFormat("")).toBe(false);
-  });
-
-  it("rejects non-string inputs", () => {
-    expect(isTimeFormat(null)).toBe(false);
-    expect(isTimeFormat(undefined)).toBe(false);
-    expect(isTimeFormat(12)).toBe(false);
-    expect(isTimeFormat({})).toBe(false);
   });
 });

--- a/src/hooks/useUserSettings.ts
+++ b/src/hooks/useUserSettings.ts
@@ -11,6 +11,7 @@ import {
   isDateFormat,
 } from "@/lib/format-date";
 import { logger } from "@/lib/logger";
+import { type TTimeFormat, isTimeFormat } from "@/lib/time-format";
 import {
   type UserSettingsPartial,
   emitUserSettingsChange,
@@ -24,16 +25,6 @@ import { useSession } from "next-auth/react";
 // app-wide settings consolidation lands. The "Calendar" prefix is no longer
 // accurate now that non-calendar fields (e.g. defaultZoomLevel) flow through
 // this hook.
-export type TTimeFormat = "12h" | "24h";
-
-const VALID_TIME_FORMATS: readonly TTimeFormat[] = ["12h", "24h"] as const;
-
-export function isTimeFormat(value: unknown): value is TTimeFormat {
-  return (
-    typeof value === "string" &&
-    (VALID_TIME_FORMATS as readonly string[]).includes(value)
-  );
-}
 
 export interface UserCalendarSettings {
   calendarRefreshIntervalMinutes: number;

--- a/src/lib/__tests__/time-format.test.ts
+++ b/src/lib/__tests__/time-format.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { VALID_TIME_FORMATS, isTimeFormat } from "../time-format";
+
+describe("isTimeFormat", () => {
+  it("accepts the two valid literal values", () => {
+    expect(isTimeFormat("12h")).toBe(true);
+    expect(isTimeFormat("24h")).toBe(true);
+  });
+
+  it("accepts every entry from VALID_TIME_FORMATS", () => {
+    for (const fmt of VALID_TIME_FORMATS) {
+      expect(isTimeFormat(fmt)).toBe(true);
+    }
+  });
+
+  it("rejects similar-looking strings outside the allow-list", () => {
+    expect(isTimeFormat("13h")).toBe(false);
+    expect(isTimeFormat("12H")).toBe(false);
+    expect(isTimeFormat("12")).toBe(false);
+    expect(isTimeFormat("")).toBe(false);
+  });
+
+  it("rejects non-string inputs", () => {
+    expect(isTimeFormat(null)).toBe(false);
+    expect(isTimeFormat(undefined)).toBe(false);
+    expect(isTimeFormat(12)).toBe(false);
+    expect(isTimeFormat({})).toBe(false);
+  });
+});

--- a/src/lib/time-format.ts
+++ b/src/lib/time-format.ts
@@ -1,0 +1,25 @@
+/**
+ * The documented set of `UserSettings.timeFormat` choices. Lives in a
+ * server-safe module (no `"use client"`) so server-side route handlers and
+ * client components can share the same typeguard without crossing a client
+ * boundary. Mirrors the shape of `VALID_DATE_FORMATS` in `format-date.ts`.
+ */
+export type TTimeFormat = "12h" | "24h";
+
+export const VALID_TIME_FORMATS: readonly TTimeFormat[] = [
+  "12h",
+  "24h",
+] as const;
+
+/**
+ * Runtime guard for narrowing an `unknown` (e.g. a Prisma row, a JSON
+ * request body, or a payload pulled off the settings bus) into the typed
+ * union. Mirrors `isDateFormat` so settings consumers can validate
+ * uniformly.
+ */
+export function isTimeFormat(value: unknown): value is TTimeFormat {
+  return (
+    typeof value === "string" &&
+    (VALID_TIME_FORMATS as readonly string[]).includes(value)
+  );
+}

--- a/src/test/fixtures/user-settings.ts
+++ b/src/test/fixtures/user-settings.ts
@@ -16,9 +16,9 @@
  * supplied, and every consuming test inherits it for free.
  */
 import type { UserSettings } from "@/generated/prisma/client";
-import type { TTimeFormat } from "@/hooks/useUserSettings";
 import type { CalendarTransitionSpeed } from "@/lib/calendar/transition-speed";
 import type { TDateFormat } from "@/lib/format-date";
+import type { TTimeFormat } from "@/lib/time-format";
 import type { TWeekStartDay } from "@/types/calendar";
 
 /**

--- a/src/types/user-settings.ts
+++ b/src/types/user-settings.ts
@@ -1,6 +1,6 @@
-import type { TTimeFormat } from "@/hooks/useUserSettings";
 import type { CalendarTransitionSpeed } from "@/lib/calendar/transition-speed";
 import type { TDateFormat } from "@/lib/format-date";
+import type { TTimeFormat } from "@/lib/time-format";
 import type { TWeekStartDay } from "@/types/calendar";
 
 /**


### PR DESCRIPTION
## Summary

- PR #452 closed #427 by importing `isTimeFormat` from `src/hooks/useUserSettings.ts` into the server-side `src/app/api/settings/route.ts` PUT handler. The bundler tree-shakes the hook's React/client code, but routing a server-only validator through a `"use client"` module is the same boundary ambiguity that motivated `VALID_DATE_FORMATS` living in `src/lib/format-date.ts` (no `"use client"`).
- This PR extracts `TTimeFormat`, `VALID_TIME_FORMATS`, and `isTimeFormat` into a new server-safe module `src/lib/time-format.ts` that mirrors `format-date.ts` in shape and intent. Every consumer (route handler, hook, `/settings` page, display section, `CalendarProvider`, fixtures, types) is migrated in place rather than retained via a re-export — **no module re-imports these symbols from `@/hooks/*` anymore.**
- The `isTimeFormat` describe block previously in `src/hooks/__tests__/useUserSettings.test.tsx` moves to a new `src/lib/__tests__/time-format.test.ts` (test-first) so the typeguard's tests live next to the typeguard. New: an extra "every entry from `VALID_TIME_FORMATS`" sanity case so a future format addition fails the test if the allow-list and the typeguard drift.

## Why this shape

- A future contributor reading `src/hooks/useUserSettings.ts` could legitimately reach for `useState`/`useSession` and the top-level `"use client"` looks load-bearing — but it was also providing a pure-function typeguard to a server route. The two roles are mixed.
- Parallels the existing `src/lib/format-date.ts` pattern (`TDateFormat` / `VALID_DATE_FORMATS` / `isDateFormat`), so settings consumers can validate uniformly across `timeFormat`, `dateFormat`, and `calendarTransitionSpeed`.
- "Migrate consumers in place" (vs the re-export option) — the issue's stated cleaner path — drops the indirection completely.

## Plan

No `.claude/plans/` entry — the change is mechanical (one new ~25-line module + one new test file + 8 import-site edits) and the issue body (#453) prescribes the exact target shape. The original parent narrowing plan lives at `.claude/plans/timeformat-narrow-423.md`.

Project: https://github.com/users/BenSeymourODB/projects/1

## Acceptance criteria (from #453)

- [x] `TTimeFormat`, `VALID_TIME_FORMATS`, and `isTimeFormat` live in `src/lib/time-format.ts` (no `"use client"`).
- [x] No route handler imports from `src/hooks/*` (verified via repo-wide grep).
- [x] No behaviour change at any boundary — same tests pass, same error bodies (400 status + `"Invalid timeFormat. Must be one of: 12h, 24h"` on the PUT handler).
- [x] `pnpm lint:fix && pnpm format:fix && pnpm check-types && pnpm test && pnpm build` clean.

## Test plan

- [x] `npx vitest run src/lib/__tests__/time-format.test.ts` — 4 / 4 passing (covers the relocated cases plus the new VALID_TIME_FORMATS round-trip).
- [x] `npx vitest run src/lib/__tests__/time-format.test.ts src/hooks/__tests__/useUserSettings.test.tsx src/app/api/settings src/components/settings src/components/providers/__tests__/CalendarProvider.workingHours.test.tsx src/app/settings` — 194 / 194 passing (the touched consumers).
- [x] `pnpm test` — full suite 2709 / 2709 passing.
- [x] `pnpm check-types` — clean.
- [x] `pnpm lint:fix && pnpm format:fix` — no new issues (5 pre-existing warnings unchanged).
- [x] `pnpm build` — production build succeeds (the server route no longer crosses a `"use client"` boundary to validate `timeFormat`).

## Out of scope

The same shape applies to `VALID_THEMES` (still inline in `route.ts`) and `defaultTaskPoints` / `schedulerIntervalSeconds` / etc. (still inline). Issue #453 scopes to `timeFormat` and explicitly flags `VALID_THEMES` as a candidate for a follow-up; not bundled here to keep the diff narrow.

Closes #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01UncM1rfq19Uh1ExFvUf3kW)_