### PR TITLE
test(useUserSettings): two-concurrent-mutate coverage for same-key rollback race (#433)

### DIFF
--- a/.claude/plans/usersettings-concurrent-mutate-race-433.md
+++ b/.claude/plans/usersettings-concurrent-mutate-race-433.md
@@ -1,0 +1,51 @@
+# useUserSettings — two-concurrent-mutate coverage for same-key rollback race (#433)
+
+## Issue
+
+[#433](https://github.com/BenSeymourODB/next-digital-wall-calendar/issues/433) — follow-up to the #420 fix landed by PR #432. PR #432 introduced the CAS guard inside `useUserSettings.mutate`'s catch block: when a PUT rejects, only roll back keys whose live value still matches the one _this_ mutate set, so a concurrent successful mutate is not stomped by the rejection of an earlier in-flight one.
+
+PR #432 also added a test in `src/hooks/__tests__/useUserSettings.test.tsx` under `useUserSettings > same-key rollback race (#420)`. That test stands in for a parallel successful mutate by **emitting a same-key bus event** between A's optimistic write and A's PUT rejection — a legitimate test of the rollback guard, but it bypasses the exact sequencing of two real concurrent `mutate` calls.
+
+## Goal
+
+Add a second test case in the same describe block that exercises the **actual production race**:
+
+1. Initial state: `timeFormat = "12h"` (from GET).
+2. A: `mutate({ timeFormat: "24h" })` — `fetch` returns a deferred promise the test controls.
+3. B: `mutate({ timeFormat: "12h" })` — `fetch` returns an immediately-ok response. B's optimistic `setSettings` and bus emit run; React commits; `settingsRef.current.timeFormat` becomes `"12h"`.
+4. Reject A's PUT.
+5. Assert: no `{ timeFormat: ... }` bus event fires for A (the CAS guard suppresses the stale emit), and local state stays at `"12h"`.
+
+## Implementation notes
+
+- Keep the new test inside the existing `describe("same-key rollback race (#420)", ...)` block as a sibling `it(...)` — it's coverage for the same regression, just via a different driver.
+- Mock the fetch queue in order: GET (12h) → A's PUT (deferred) → B's PUT (immediate ok).
+- Use the `act` concurrency pattern flagged in the issue body:
+  1. `act` #1: kick off A without awaiting (`aMutate = mutate(...).catch(() => {})`), then `await Promise.resolve()` to flush A's synchronous prelude (setSettings + emit).
+  2. `act` #2: `await mutate(...)` for B (resolves immediately).
+  3. Subscribe a `busHandler` _after_ B's emit so we only observe whether A's rollback path re-emits.
+  4. `act` #3: `rejectA(new Error(...))` then `await aMutate` to drain the rejection.
+- Assertions: `expect(busHandler).not.toHaveBeenCalled()` and `expect(result.current.settings.timeFormat).toBe("12h")`.
+- Run the full suite afterwards (`pnpm test`) to verify no unresolved-promise leak into adjacent specs (the "bus subscription" tests immediately after are sensitive to leaked subscribers).
+
+## Verification that the test catches the regression
+
+If the CAS guard in `useUserSettings.ts` (the `Object.is(live[key], picked[key])` check) is removed and A's catch unconditionally re-emits its snapshot:
+
+- `liveRollback = { timeFormat: "12h" }` (A's snapshot of the pre-A value).
+- `emitUserSettingsChange({ timeFormat: "12h" })` fires.
+- `busHandler` records the call → assertion fails.
+
+Verified mentally against the file at `src/hooks/useUserSettings.ts:241-257`. Will not commit a temporary guard-removal patch; the inline reasoning is enough to confirm fault sensitivity.
+
+## Scope
+
+- One new `it(...)` block in `useUserSettings.test.tsx`.
+- No production code change.
+- No other test file change.
+
+## Out of scope
+
+- Any change to `useUserSettings.mutate` itself.
+- The `SettingsForm — same-key rollback race (#420)` component-level test (already covers the full two-mutate flow at a higher altitude).
+- Generalising the CAS guard to non-primitive `UserCalendarSettings` keys (none exist today; #433 explicitly scopes to the timeFormat case).

--- a/src/hooks/__tests__/useUserSettings.test.tsx
+++ b/src/hooks/__tests__/useUserSettings.test.tsx
@@ -749,6 +749,68 @@ describe("useUserSettings", () => {
 
       unsubscribe();
     });
+
+    it("suppresses A's rollback when a parallel mutate B has already committed (#433)", async () => {
+      mockUseSession.mockReturnValue({
+        data: { user: { id: "u1" } },
+        status: "authenticated",
+      });
+      // Initial GET — server says 12h.
+      vi.mocked(global.fetch).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ timeFormat: "12h" }),
+      } as Response);
+
+      const { result } = renderHook(() => useUserSettings());
+      await waitFor(() => {
+        expect(result.current.settings.timeFormat).toBe("12h");
+      });
+
+      // A: kick off a mutate to "24h" with a PUT that will be rejected later.
+      let rejectA: (reason?: unknown) => void = () => {};
+      const aPromise = new Promise<Response>((_resolve, reject) => {
+        rejectA = reject;
+      });
+      vi.mocked(global.fetch).mockImplementationOnce(() => aPromise);
+
+      let aMutate: Promise<void> | undefined;
+      await act(async () => {
+        aMutate = result.current.mutate({ timeFormat: "24h" }).catch(() => {});
+        // Let A's synchronous prelude (setSettings + bus emit) flush.
+        await Promise.resolve();
+      });
+      expect(result.current.settings.timeFormat).toBe("24h");
+
+      // B: a parallel mutate whose PUT resolves immediately. Drives the
+      // optimistic state-and-bus path for real (not a bus-emit stand-in),
+      // so settingsRef ends at B's value via the same code paths the
+      // production race traverses.
+      vi.mocked(global.fetch).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({}),
+      } as Response);
+      await act(async () => {
+        await result.current.mutate({ timeFormat: "12h" });
+      });
+      expect(result.current.settings.timeFormat).toBe("12h");
+
+      // Subscribe AFTER B's emit so we only observe whether A's rollback
+      // path re-emits the stale snapshot.
+      const busHandler = vi.fn();
+      const unsubscribe = subscribeUserSettings(busHandler);
+
+      // Reject A — the CAS guard should compare live "12h" to A's
+      // optimistic "24h", suppress the rollback, and fire no emit.
+      await act(async () => {
+        rejectA(new Error("boom"));
+        await aMutate;
+      });
+
+      expect(busHandler).not.toHaveBeenCalled();
+      expect(result.current.settings.timeFormat).toBe("12h");
+
+      unsubscribe();
+    });
   });
 
   describe("bus subscription (#337)", () => {


### PR DESCRIPTION
## Summary

- Adds a sibling `it(...)` inside `useUserSettings > same-key rollback race (#420)` that drives the **actual production race** — two real concurrent `mutate` calls — rather than the bus-emit stand-in already covered by PR #432.
- A: `mutate({ timeFormat: "24h" })` against a deferred PUT (test rejects it later). B: `mutate({ timeFormat: "12h" })` against an immediately-ok PUT. After B commits the CAS guard at `src/hooks/useUserSettings.ts:241-257` must observe `settingsRef.current.timeFormat === "12h"` ≠ A's `picked.timeFormat === "24h"` and suppress the rollback + emit.
- No production code change.

## Plan

Linked plan: [`.claude/plans/usersettings-concurrent-mutate-race-433.md`](.claude/plans/usersettings-concurrent-mutate-race-433.md)
Project: https://github.com/users/BenSeymourODB/projects/1

## Regression sensitivity (acceptance criterion check)

Verified locally by temporarily stripping the `Object.is(live[key], picked[key])` check in `useUserSettings.ts` — `liveRollback` then unconditionally re-emits A's snapshot and the test's `busHandler` records `{ timeFormat: "12h" }`. The patch was not committed; the inline reasoning at `src/hooks/useUserSettings.ts:229-240` describes the same guard the test now exercises end-to-end.

## Test plan

- [x] `pnpm test:run src/hooks/__tests__/useUserSettings.test.tsx` — 41/41 passing (40 existing + 1 new).
- [x] Targeted regression sweep with the CAS guard temporarily disabled — 2 failures (the existing #420 test + the new #433 test), as expected. Patch reverted.
- [x] `pnpm test:run` — full suite 2709/2709 passing (no unresolved-promise leak into adjacent specs; the `bus subscription (#337)` describe immediately after stays green).
- [x] `pnpm lint:fix` — clean (5 pre-existing warnings unchanged).
- [x] `pnpm format:fix` — clean.
- [x] `pnpm check-types` — clean.

## Notes for review

The `act` concurrency pattern flagged in #433 is followed exactly:
1. `act` #1 — kick off A without awaiting (`aMutate = mutate(...).catch(() => {})`), then `await Promise.resolve()` to flush A's synchronous prelude.
2. `act` #2 — `await mutate(...)` for B (immediate-ok fetch).
3. `act` #3 — `rejectA(...)` and `await aMutate` to drain the rejection.

`busHandler` is subscribed *after* B's emit so only A's potential rollback emit is captured. The `unsubscribe()` call at the end (mirroring the existing #420 test) prevents subscriber leakage into `bus subscription (#337)`.

Closes #433

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BuCT6GpRgXB5GfY8MzBg1Q)_