### PR TITLE
feat(calendar): wire onEdit + onDelete into AgendaList (#451)

### DIFF
--- a/.claude/plans/agenda-list-wire-edit-delete-451.md
+++ b/.claude/plans/agenda-list-wire-edit-delete-451.md
@@ -1,0 +1,71 @@
+# Plan: Wire `onEdit` + `onDelete` into `AgendaList` (#451)
+
+## Why
+
+PR #392 (event detail edit, completes #115) wired `onEdit` + `onDelete` into
+the three calendar surfaces that already passed `onDelete`:
+
+- `SimpleCalendar` (month view)
+- `AgendaCalendar` (legacy `/test/calendar?view=agenda`)
+- `AnalogClockView` (clock view)
+
+`AgendaList` — the production surface for day/week agenda mode after #264 —
+was deferred and tracked as #451. Today, clicking an event in day or week
+agenda mode opens the `EventDetailModal` but neither the Edit nor the Delete
+button ever renders, even on writable calendars.
+
+## What ships
+
+1. `src/components/calendar/AgendaList.tsx`
+   - Import `useEventEdit` from `@/hooks/useEventEdit`
+   - Import `useEventDelete` from `@/hooks/useEventDelete`
+   - Inside `AgendaList`: `const handleEdit = useEventEdit();` and
+     `const handleDelete = useEventDelete();`
+   - Pass `onEdit={handleEdit}` and `onDelete={handleDelete}` to the
+     `<EventDetailModal>` instance at the bottom of the component.
+
+2. `src/components/calendar/__tests__/AgendaList.test.tsx`
+   - New `describe` block: `event detail modal — edit + delete wiring (#451)`.
+   - Three tests:
+     1. Clicking an event card opens the modal; both `Edit event` and
+        `Delete event` buttons render when `getAccessRole` returns
+        `undefined` (default — treated as writable).
+     2. Buttons are hidden when `getAccessRole` returns `"reader"`
+        (regression guard for #266 gating).
+     3. Buttons are hidden when `getAccessRole` returns `"freeBusyReader"`
+        (same gate; explicit second case so a future split between the two
+        cannot regress the cover).
+
+## Test strategy
+
+- TDD: write the failing tests first; verify they fail because the buttons
+  don't render today; then add the two-prop wiring and watch them go green.
+- No CalendarProvider needed — the existing fixture
+  `makeCalendarContext` + `CalendarContext.Provider` already mocks
+  `editEvent` / `deleteEvent`, so the hooks will hand-off into the mock
+  context without touching the network.
+- The sonner toast inside the hooks fires only when the user actually
+  invokes Save / Delete — these tests stop at button-render assertions, so
+  no `Toaster` is needed in the mount.
+- Use `userEvent.click` on the event card to open the modal (matches the
+  existing search tests' interaction pattern in this file).
+- Assert via `screen.getByRole("button", { name: /edit event/i })` and the
+  delete equivalent, plus `queryByRole` for the hidden case.
+
+## Out of scope
+
+- Re-asserting click→`onEdit(event, patch)` plumbing — that contract is
+  already exhaustively tested in `EventDetailModal.test.tsx` (the modal is
+  the same instance we hand the handler to). Re-asserting here would
+  shadow #266 / #265 tests without adding signal.
+- Wiring the create-event path in agenda mode (#391-class follow-up) —
+  out of scope for #451.
+
+## Acceptance criteria (from #451)
+
+- [x] `AgendaList` passes `onEdit` and `onDelete` to `EventDetailModal`
+- [x] Component test renders the modal for a writable event and asserts
+      both buttons are present
+- [x] Same test confirms the buttons are hidden when `accessRole` is
+      `reader` / `freeBusyReader`
+- [x] `pnpm lint:fix && pnpm format:fix && pnpm check-types && pnpm test` clean

--- a/src/components/calendar/AgendaList.tsx
+++ b/src/components/calendar/AgendaList.tsx
@@ -3,6 +3,8 @@
 import { useCalendar } from "@/components/providers/CalendarProvider";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { useEventDelete } from "@/hooks/useEventDelete";
+import { useEventEdit } from "@/hooks/useEventEdit";
 import type { IEvent, TEventColor } from "@/types/calendar";
 import { useRef, useState } from "react";
 import { format, isAfter, isBefore } from "date-fns";
@@ -200,6 +202,8 @@ export function AgendaList({
   const [selectedEvent, setSelectedEvent] = useState<IEvent | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
   const triggerRef = useRef<HTMLElement | SVGElement | null>(null);
+  const handleDelete = useEventDelete();
+  const handleEdit = useEventEdit();
 
   const openModal = (event: IEvent, trigger: HTMLElement) => {
     triggerRef.current = trigger;
@@ -375,6 +379,8 @@ export function AgendaList({
         onClose={() => setSelectedEvent(null)}
         use24HourFormat={use24HourFormat}
         returnFocusTo={triggerRef}
+        onDelete={handleDelete}
+        onEdit={handleEdit}
         accessRole={
           selectedEvent ? getAccessRole(selectedEvent.calendarId) : undefined
         }

--- a/src/components/calendar/__tests__/AgendaList.test.tsx
+++ b/src/components/calendar/__tests__/AgendaList.test.tsx
@@ -343,6 +343,67 @@ describe("AgendaList", () => {
     });
   });
 
+  describe("event detail modal — edit + delete wiring (#451)", () => {
+    const writableEvent = makeEvent(
+      "writable",
+      "2026-05-04T09:00:00.000Z",
+      "2026-05-04T10:00:00.000Z",
+      { title: "Writable Event" }
+    );
+    const range = {
+      rangeStart: new Date("2026-05-04T00:00:00.000Z"),
+      rangeEnd: new Date("2026-05-04T23:59:59.999Z"),
+    };
+
+    it("renders Edit and Delete buttons in the modal when the calendar is writable", async () => {
+      const user = userEvent.setup();
+      renderList({ events: [writableEvent], ...range });
+
+      await user.click(screen.getByText("Writable Event"));
+
+      expect(
+        screen.getByRole("button", { name: /edit event/i })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /delete event/i })
+      ).toBeInTheDocument();
+    });
+
+    it("hides Edit and Delete buttons when accessRole is 'reader' (#266 gate)", async () => {
+      const user = userEvent.setup();
+      renderList(
+        { events: [writableEvent], ...range },
+        { getAccessRole: () => "reader" }
+      );
+
+      await user.click(screen.getByText("Writable Event"));
+
+      expect(
+        screen.queryByRole("button", { name: /edit event/i })
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: /delete event/i })
+      ).not.toBeInTheDocument();
+    });
+
+    it("hides Edit and Delete buttons when accessRole is 'freeBusyReader' (#266 gate)", async () => {
+      const user = userEvent.setup();
+      renderList(
+        { events: [writableEvent], ...range },
+        { getAccessRole: () => "freeBusyReader" }
+      );
+
+      await user.click(screen.getByText("Writable Event"));
+
+      expect(
+        screen.queryByRole("button", { name: /edit event/i })
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: /delete event/i })
+      ).not.toBeInTheDocument();
+    });
+  });
+
   it("collapses empty time gaps — does not render any hour-grid scaffolding", () => {
     const events: IEvent[] = [
       makeEvent(


### PR DESCRIPTION
## Summary

PR #392 wired the event detail edit/delete handlers into `SimpleCalendar`, `AgendaCalendar`, and `AnalogClockView` but explicitly left `AgendaList` — the production surface for day/week agenda mode (#264) — for follow-up. Without those props, clicking an event in agenda mode opened the modal with no Edit or Delete buttons, even on writable calendars.

This PR mirrors the three-call pattern from #392 inside `AgendaList`:

- import `useEventEdit` + `useEventDelete`
- construct the handlers in the component body
- pass `onEdit` / `onDelete` to the existing `EventDetailModal` instance

The `accessRole` gate from #266 stays untouched — `reader` / `freeBusyReader` still hide both buttons via the modal's existing `canWriteToCalendar` check.

## Plan

Linked plan: [`.claude/plans/agenda-list-wire-edit-delete-451.md`](.claude/plans/agenda-list-wire-edit-delete-451.md)
Project: https://github.com/users/BenSeymourODB/projects/1

## Acceptance criteria (from #451)

- [x] `AgendaList` passes `onEdit` and `onDelete` to `EventDetailModal`
- [x] Component test renders the modal for a writable event and asserts both buttons are present
- [x] Same test confirms the buttons are hidden when `accessRole` is `reader` / `freeBusyReader` (regression guard for #266 gating)
- [x] `pnpm lint:fix && pnpm format:fix && pnpm check-types && pnpm test` clean

## Test plan

- [x] **Added** three tests in `src/components/calendar/__tests__/AgendaList.test.tsx` under a new `event detail modal — edit + delete wiring (#451)` describe block:
  - writable role renders both `Edit event` and `Delete event` buttons after clicking the event card
  - `accessRole="reader"` hides both
  - `accessRole="freeBusyReader"` hides both
- [x] Verified TDD red: the writable test failed before the wiring went in (the hidden cases pass trivially today but guard regressions once the wiring exists)
- [x] `pnpm test:run src/components/calendar/__tests__/AgendaList.test.tsx` — **18 / 18 pass**
- [x] `pnpm test:run` — full suite **2711 / 2711 pass** (160 files)
- [x] `pnpm lint:fix` — clean (5 pre-existing warnings in unrelated files)
- [x] `pnpm format:fix` — clean
- [x] `pnpm check-types` — clean

## Out of scope

- Re-asserting click → `onEdit(event, patch)` plumbing — already exhaustively tested in `EventDetailModal.test.tsx` (same modal instance receives the handler). Re-asserting in `AgendaList` would shadow #266 / #265 tests without adding signal.
- Wiring the create-event path in agenda mode — that's a separate follow-up.

Closes #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtBeCuQrmU3LTw3PFQpxf5)_