### PR TITLE
refactor(calendar): drop gapi cast at Zod/mapper boundary (#403)

### DIFF
--- a/.claude/plans/gapi-cast-mapper-boundary-403.md
+++ b/.claude/plans/gapi-cast-mapper-boundary-403.md
@@ -1,0 +1,104 @@
+# Plan: drop `gapi.client.calendar.Event` cast at Zod/mapper boundary (#403)
+
+Issue: https://github.com/BenSeymourODB/next-digital-wall-calendar/issues/403
+
+## Context
+
+Item 3 from the PR #325 review (tracked in #386). Items 1, 2, 4, 5 shipped in
+PR #402. Item 3 was deferred because it ripples beyond a single boundary fix.
+
+## The problem
+
+The `events/route.ts` GET (line 159) and POST (line 422) paths Zod-parse the
+Google response into `GoogleEventPayload`, then cast that value to
+`gapi.client.calendar.Event` to pass it to `normalizeFetchedEvent`:
+
+```ts
+normalizeFetchedEvent(event as gapi.client.calendar.Event, calendarId);
+normalizeFetchedEvent(created as gapi.client.calendar.Event, event.calendarId);
+```
+
+The cast is safe at runtime (Zod `.loose()` preserves unknown fields; the
+mapper just spreads + adds `summary: ""` fallback + `calendarId`), but it
+defeats the trust boundary the Zod schema exists to enforce: we validate to
+produce `GoogleEventPayload`, then immediately discard that type. The mapper
+should accept the validated type directly.
+
+`src/app/api/calendar/events/[id]/route.ts:255` has the same anti-pattern in
+the PATCH success path — except it casts the _raw_ `await response.json()`,
+not a Zod-validated value. Once the mapper's input type tightens to
+`GoogleEventPayload`, that PATCH path stops compiling, so it must be wired
+through `parseGoogleResponse` in the same PR.
+
+## The fix (as implemented)
+
+The issue lists two resolution paths. Option A (cleanest on paper) was to
+make `GoogleCalendarEvent extends Omit<GoogleEventPayload, "summary">` —
+flip the canonical domain type so every consumer reads the Zod-derived
+shape directly. That broke `src/lib/calendar-transform.ts` immediately:
+Zod 4 infers `z.object(...).loose()` as `{ ... [k: string]: unknown }`,
+which widens inner fields (`start.dateTime`, `creator.email`,
+`extendedProperties.shared.category`) to `unknown` and makes the transform
+fail strict TS. Reshaping `calendar-transform.ts` to defensively narrow
+each access would have ballooned the diff and risked behaviour changes far
+from the issue's stated goal.
+
+Option B (Option 1 in the issue body) is what shipped:
+
+1. Keep `GoogleCalendarEvent extends Omit<gapi.client.calendar.Event, "summary">`
+   so every consumer keeps the structural shape it relies on.
+2. Tighten `normalizeFetchedEvent`'s input to `GoogleEventPayload` so the
+   route call sites pass the Zod-validated payload directly with no cast.
+3. The single structural assertion that bridges the loose Zod inference and
+   the gapi-derived domain type lives **inside the mapper**, where the
+   contract is documented: Zod has already validated the payload; the
+   mapper is the only place where "wire shape" becomes "internal canonical
+   event". Both schemas describe the same JSON, so the assertion is safe
+   and the doc-comment on `normalizeFetchedEvent` explains exactly that.
+4. Wire `parseGoogleResponse` into the PATCH success path of
+   `events/[id]/route.ts` so the raw-JSON cast also goes away — pulled in
+   because the mapper-signature tightening made it a strict requirement,
+   not an opportunistic extension.
+5. Wire `parseGoogleResponse` into the legacy client-side helper
+   `fetchCalendarEvents` so it produces `GoogleEventPayload[]` for the
+   mapper. The module's own docstring already recommended this for any
+   future production caller; this brings the legacy path into alignment.
+
+Net effect: zero `event as gapi.client.calendar.Event` casts at the route
+boundary, zero raw-JSON casts at the PATCH success path, one documented
+structural assertion inside the mapper itself.
+
+## Files touched
+
+- `src/lib/google-calendar-mappers.ts` — `normalizeFetchedEvent` accepts
+  `GoogleEventPayload`; doc comments explain the trust-boundary contract.
+- `src/app/api/calendar/events/route.ts` — drop both casts (GET line 159,
+  POST line 422) and the cast-justification comment.
+- `src/app/api/calendar/events/[id]/route.ts` — drop the raw-JSON cast on
+  PATCH, wire `parseGoogleResponse(GoogleEventSchema)` to mirror POST.
+- `src/lib/google-calendar.ts` — `fetchCalendarEvents` validates
+  `response.result` through `GoogleEventsListResponseSchema` before mapping.
+- `src/lib/__tests__/google-calendar-mappers.test.ts` — switch
+  `normalizeFetchedEvent` fixture annotations to `GoogleEventPayload`. The
+  end-to-end test still asserts the gapi-typed `EventsListResponse`
+  fixture, but now parses it through `parseGoogleResponse` first so the
+  flow mirrors production.
+
+## Verification
+
+`pnpm lint:fix && pnpm format:fix && pnpm check-types && pnpm test:run` — all
+green (2708 tests pass).
+
+## Out of scope
+
+- `normalizeCalendarListEntry` retyping — no cast at the calendars route
+  boundary, so the analogous flip is non-urgent. Bundle with a future
+  `gapi.d.ts` retirement when one happens.
+- `src/types/gapi.d.ts` retirement — still required by the runtime
+  `window.gapi.client.calendar.*` calls in the legacy helpers, so it stays.
+  Tracked separately if/when those helpers are removed.
+
+## Commits / push cadence
+
+Single commit (the changes are tightly coupled — splitting them leaves
+intermediate states that don't compile). First push opens the draft PR.

--- a/src/app/api/calendar/events/[id]/__tests__/route.test.ts
+++ b/src/app/api/calendar/events/[id]/__tests__/route.test.ts
@@ -11,6 +11,7 @@ import {
   mockSession,
   mockSessionWithError,
 } from "@/lib/auth/__tests__/fixtures";
+import { logger } from "@/lib/logger";
 import {
   type ApiErrorResponse,
   createMockRequest,
@@ -875,5 +876,68 @@ describe("PATCH /api/calendar/events/[id]", () => {
     const calledUrl = String(mockFetch.mock.calls[0][0]);
     expect(calledUrl).toContain("/calendars/primary/events/evt-1");
     expect(calledUrl).not.toContain("sneaky");
+  });
+
+  describe("Zod validation of Google patch response (#403)", () => {
+    it("returns 502 with structured log when Google's patch response is missing the required id", async () => {
+      vi.mocked(getSession).mockResolvedValue(mockSession);
+      vi.mocked(getAccessToken).mockResolvedValue(
+        mockGoogleAccount.access_token!
+      );
+
+      // 200 from Google but the body fails `GoogleEventSchema` — no `id`.
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            summary: "Updated event",
+            start: { dateTime: "2026-05-01T15:00:00.000Z" },
+            end: { dateTime: "2026-05-01T16:00:00.000Z" },
+          }),
+      });
+
+      const request = createMockRequest(
+        "/api/calendar/events/evt-1?calendarId=primary",
+        { method: "PATCH", body: makeBody() }
+      );
+      const response = await PATCH(request, { params: createParams("evt-1") });
+      const { status, data } = await parseResponse<ApiErrorResponse>(response);
+
+      expect(status).toBe(502);
+      expect(data.error).toMatch(/update/i);
+      expect(vi.mocked(logger.error)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "GoogleApiValidationError",
+        }),
+        expect.objectContaining({
+          endpoint: "events.patch",
+          calendarId: "primary",
+        })
+      );
+    });
+
+    it("returns 502 when Google's patch response is the wrong type (array instead of object)", async () => {
+      vi.mocked(getSession).mockResolvedValue(mockSession);
+      vi.mocked(getAccessToken).mockResolvedValue(
+        mockGoogleAccount.access_token!
+      );
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(["not", "an", "object"]),
+      });
+
+      const request = createMockRequest(
+        "/api/calendar/events/evt-1?calendarId=primary",
+        { method: "PATCH", body: makeBody() }
+      );
+      const response = await PATCH(request, { params: createParams("evt-1") });
+      const { status } = await parseResponse<ApiErrorResponse>(response);
+
+      expect(status).toBe(502);
+      expect(vi.mocked(logger.error)).toHaveBeenCalled();
+    });
   });
 });

--- a/src/app/api/calendar/events/[id]/route.ts
+++ b/src/app/api/calendar/events/[id]/route.ts
@@ -19,7 +19,14 @@ import {
   validateEventBody,
 } from "@/lib/calendar/event-body";
 import { normalizeFetchedEvent } from "@/lib/google-calendar-mappers";
-import { parseGoogleErrorBody } from "@/lib/google-calendar-schemas";
+import {
+  GoogleApiValidationError,
+  type GoogleEventPayload,
+  GoogleEventSchema,
+  VALIDATION_ISSUES_SUMMARY_COUNT,
+  parseGoogleErrorBody,
+  parseGoogleResponse,
+} from "@/lib/google-calendar-schemas";
 import { fetchWithRetry } from "@/lib/http/retry";
 import { logger } from "@/lib/logger";
 import { NextRequest, NextResponse } from "next/server";
@@ -252,7 +259,37 @@ export async function PATCH(request: NextRequest, { params }: RouteContext) {
     });
 
     if (response.ok) {
-      const updated = (await response.json()) as gapi.client.calendar.Event;
+      // Validate Google's response through the Zod schema before mapping,
+      // matching the POST handler (#403). The mapper now takes
+      // `GoogleEventPayload`, so a raw-JSON cast at this boundary is the
+      // same anti-pattern #403 removed elsewhere.
+      const rawUpdated: unknown = await response.json();
+      let updated: GoogleEventPayload;
+      try {
+        updated = parseGoogleResponse(rawUpdated, GoogleEventSchema, {
+          endpoint: "events.patch",
+          calendarId,
+        });
+      } catch (validationError) {
+        if (validationError instanceof GoogleApiValidationError) {
+          logger.error(validationError, {
+            endpoint: validationError.endpoint,
+            ...(validationError.calendarId
+              ? { calendarId: validationError.calendarId }
+              : {}),
+            userId: session.user.id,
+            validationIssues: validationError.issues
+              .slice(0, VALIDATION_ISSUES_SUMMARY_COUNT)
+              .map((i) => `${i.path.join(".") || "<root>"}: ${i.message}`)
+              .join("; "),
+          });
+          return NextResponse.json(
+            { error: "Failed to update calendar event" },
+            { status: 502 }
+          );
+        }
+        throw validationError;
+      }
       const normalized = normalizeFetchedEvent(updated, calendarId);
 
       logger.event("CalendarEventUpdated", {

--- a/src/app/api/calendar/events/route.ts
+++ b/src/app/api/calendar/events/route.ts
@@ -150,13 +150,11 @@ async function fetchEventsFromCalendar(
     throw error;
   }
 
-  // The mappers spread `{ ...event }` so unknown Google fields pass through
-  // unchanged (the Zod schema is `.loose()` for the same reason). The cast
-  // is safe because the schema requires `id` — the contract our mapper relies
-  // on — and treats every other field as optional, matching the Google API.
-  const events: GoogleCalendarEvent[] = (parsed.items ?? []).map(
-    (event: GoogleEventPayload) =>
-      normalizeFetchedEvent(event as gapi.client.calendar.Event, calendarId)
+  // The mapper accepts `GoogleEventPayload` directly (#403) and spreads
+  // `{ ...event }` so unknown Google fields pass through unchanged — the Zod
+  // schema is `.loose()` for the same reason.
+  const events: GoogleCalendarEvent[] = (parsed.items ?? []).map((event) =>
+    normalizeFetchedEvent(event, calendarId)
   );
 
   return {
@@ -418,10 +416,7 @@ export async function POST(request: NextRequest) {
         throw validationError;
       }
 
-      const normalized = normalizeFetchedEvent(
-        created as gapi.client.calendar.Event,
-        event.calendarId
-      );
+      const normalized = normalizeFetchedEvent(created, event.calendarId);
 
       logger.event("CalendarEventCreated", {
         userId: session.user.id,

--- a/src/lib/__tests__/google-calendar-mappers.test.ts
+++ b/src/lib/__tests__/google-calendar-mappers.test.ts
@@ -1,13 +1,20 @@
 /**
  * Unit tests for Google Calendar API response mappers.
  *
- * These tests exercise the pure mappers that translate raw Google Calendar API
+ * These tests exercise the pure mappers that translate Google Calendar API
  * responses into the app's `GoogleCalendarEvent` and `UserCalendar` shapes.
  *
  * They serve as regression guards for two concerns:
- *  1. Extended optional fields surfaced by the richer `gapi.d.ts` types are
- *     preserved through the mappers (issue #76).
+ *  1. Extended optional fields surfaced by the schemas (and the richer
+ *     `gapi.d.ts` types used by the legacy client helpers) are preserved
+ *     through the mappers (issue #76).
  *  2. Comments/semantics around `fetchCalendarColorMappings` stay stable (#77).
+ *
+ * Per #403, `normalizeFetchedEvent` now accepts the Zod-validated
+ * `GoogleEventPayload` rather than `gapi.client.calendar.Event`. The
+ * end-to-end test below intentionally still asserts the gapi-typed wire
+ * fixture parses through `parseGoogleResponse` cleanly, so `gapi.d.ts`
+ * drift against the Google API surface still trips at compile time.
  */
 import type { CalendarColorMapping } from "@/lib/calendar-storage";
 import {
@@ -17,11 +24,16 @@ import {
   normalizeFetchedEvent,
 } from "@/lib/google-calendar";
 import { canWriteToCalendar } from "@/lib/google-calendar-mappers";
+import {
+  type GoogleEventPayload,
+  GoogleEventsListResponseSchema,
+  parseGoogleResponse,
+} from "@/lib/google-calendar-schemas";
 import { describe, expect, it } from "vitest";
 
 describe("normalizeFetchedEvent", () => {
   it("preserves required fields and stamps calendarId", () => {
-    const apiEvent: gapi.client.calendar.Event = {
+    const apiEvent: GoogleEventPayload = {
       id: "evt-1",
       summary: "Standup",
       start: { dateTime: "2026-05-01T09:00:00-04:00" },
@@ -38,7 +50,7 @@ describe("normalizeFetchedEvent", () => {
   });
 
   it("passes through extended optional fields from Google Calendar v3", () => {
-    const apiEvent: gapi.client.calendar.Event = {
+    const apiEvent: GoogleEventPayload = {
       id: "evt-rich",
       summary: "Board meeting",
       description: "Quarterly review",
@@ -94,7 +106,7 @@ describe("normalizeFetchedEvent", () => {
     // Google marks Event.summary as optional. Downstream UI code (see
     // `transformGoogleEvent` → `title: event.summary || "Untitled Event"`)
     // expects a string, so the mapper defensively normalises.
-    const apiEvent: gapi.client.calendar.Event = {
+    const apiEvent: GoogleEventPayload = {
       id: "evt-no-title",
       start: { dateTime: "2026-05-01T09:00:00Z" },
       end: { dateTime: "2026-05-01T09:30:00Z" },
@@ -115,7 +127,7 @@ describe("normalizeFetchedEvent", () => {
     // If `GoogleCalendarEvent` ever stops `extends Omit<Event, "summary">`,
     // these assertions fail at the type layer and the runtime round-trip
     // here fails as well.
-    const apiEvent: gapi.client.calendar.Event = {
+    const apiEvent: GoogleEventPayload = {
       id: "evt-full",
       summary: "All fields",
       start: { dateTime: "2026-05-01T09:00:00Z" },
@@ -158,7 +170,7 @@ describe("normalizeFetchedEvent", () => {
   });
 
   it("handles recurring-event instance fields (recurringEventId + originalStartTime)", () => {
-    const apiEvent: gapi.client.calendar.Event = {
+    const apiEvent: GoogleEventPayload = {
       id: "evt-instance_20260501T140000Z",
       summary: "Weekly sync (moved)",
       start: { dateTime: "2026-05-01T15:00:00Z" },
@@ -174,7 +186,7 @@ describe("normalizeFetchedEvent", () => {
   });
 
   it("accepts all-day events (date-only start/end with no dateTime)", () => {
-    const apiEvent: gapi.client.calendar.Event = {
+    const apiEvent: GoogleEventPayload = {
       id: "evt-allday",
       summary: "Holiday",
       start: { date: "2026-12-25" },
@@ -292,8 +304,17 @@ describe("end-to-end: enriched API responses flow through the mappers", () => {
       ],
     };
 
-    const mapped: GoogleCalendarEvent[] = (apiResponse.items ?? []).map(
-      (event) => normalizeFetchedEvent(event, "primary")
+    // #403: production now validates Google's wire payload through the
+    // Zod schema before handing items to the mapper. Mirror that here so
+    // the test exercises the real flow (gapi-typed fixture → Zod parse →
+    // GoogleEventPayload → mapper) end-to-end.
+    const parsed = parseGoogleResponse(
+      apiResponse,
+      GoogleEventsListResponseSchema,
+      { endpoint: "events.list", calendarId: "primary" }
+    );
+    const mapped: GoogleCalendarEvent[] = (parsed.items ?? []).map((event) =>
+      normalizeFetchedEvent(event, "primary")
     );
 
     expect(mapped).toHaveLength(1);

--- a/src/lib/google-calendar-mappers.ts
+++ b/src/lib/google-calendar-mappers.ts
@@ -10,6 +10,7 @@
  * references browser-only globals — if you need that, put it in
  * `src/lib/google-calendar.ts` and import the mappers from here.
  */
+import type { GoogleEventPayload } from "@/lib/google-calendar-schemas";
 import type { TCalendarAccessRole } from "@/types/calendar";
 
 /**
@@ -32,6 +33,16 @@ export function canWriteToCalendar(
  * `normalizeFetchedEvent` without any silent widening. `summary` is narrowed
  * to a required `string` because the mapper applies a `?? ""` fallback,
  * which matches what downstream UI code expects.
+ *
+ * Why the gapi-derived shape rather than `GoogleEventPayload` from the Zod
+ * schema? `GoogleEventSchema` uses `z.object(...).loose()` so unknown
+ * Google-API fields survive validation, but Zod's inferred type for a loose
+ * object widens every defined inner field to `unknown` — accessing
+ * `event.start.dateTime` or `event.creator.email` then fails strict TS
+ * checks throughout `calendar-transform.ts`. The gapi typings give the
+ * domain the structural shape it actually needs; the Zod schema remains the
+ * runtime trust boundary. {@link normalizeFetchedEvent} bridges the two
+ * once (#403), so routes no longer cast at every call site.
  */
 export interface GoogleCalendarEvent extends Omit<
   gapi.client.calendar.Event,
@@ -65,23 +76,35 @@ export interface UserCalendar {
 }
 
 /**
- * Normalise a raw Google Calendar API event into our {@link GoogleCalendarEvent}
- * shape, stamping the source `calendarId` so cached events can be looked up by
- * calendar later.
+ * Normalise a Zod-validated Google Calendar API event ({@link GoogleEventPayload})
+ * into our {@link GoogleCalendarEvent} shape, stamping the source `calendarId`
+ * so cached events can be looked up by calendar later.
  *
  * Applies a `summary ?? ""` fallback because the Google API marks
  * `Event.summary` as optional but our UI code (`transformGoogleEvent`) expects
  * a string.
+ *
+ * The input is the Zod-parsed `GoogleEventPayload` so the routes no longer
+ * cast at every call site (#403). The single structural assertion that
+ * bridges the Zod schema's loose-object inference and the gapi-derived
+ * domain shape lives here — the mapper IS the trust-boundary between
+ * "wire payload" and "internal canonical event". Both schemas describe the
+ * same JSON; the assertion is documented and safe because:
+ *
+ *   - Zod `.loose()` preserves unknown fields, so the spread carries every
+ *     gapi-declared property forward unchanged.
+ *   - `GoogleEventSchema` requires `id: string`, the only field the mapper
+ *     relies on for the canonical contract.
  */
 export function normalizeFetchedEvent(
-  event: gapi.client.calendar.Event,
+  event: GoogleEventPayload,
   calendarId: string
 ): GoogleCalendarEvent {
   return {
     ...event,
     summary: event.summary ?? "",
     calendarId,
-  };
+  } as GoogleCalendarEvent;
 }
 
 /**

--- a/src/lib/google-calendar.ts
+++ b/src/lib/google-calendar.ts
@@ -38,6 +38,10 @@ import {
   normalizeCalendarListEntry,
   normalizeFetchedEvent,
 } from "./google-calendar-mappers";
+import {
+  GoogleEventsListResponseSchema,
+  parseGoogleResponse,
+} from "./google-calendar-schemas";
 
 export {
   type GoogleCalendarEvent,
@@ -460,7 +464,16 @@ export async function fetchCalendarEvents(
       orderBy: "startTime",
     });
 
-    const events = response.result.items || [];
+    // Validate the gapi-typed wire payload through the same Zod schema the
+    // server routes use (#403). This realigns the legacy client helper with
+    // the trust boundary established by #277 — the mapper now accepts
+    // `GoogleEventPayload`, not the looser `gapi.client.calendar.Event`.
+    const parsed = parseGoogleResponse(
+      response.result,
+      GoogleEventsListResponseSchema,
+      { endpoint: "events.list", calendarId }
+    );
+    const events = parsed.items ?? [];
     logger.log("Fetched calendar events", {
       calendarId,
       count: events.length,


### PR DESCRIPTION
## Summary

- Tightens `normalizeFetchedEvent`'s input type to `GoogleEventPayload` so the routes no longer cast Zod-validated payloads back to `gapi.client.calendar.Event`. Both call sites in `src/app/api/calendar/events/route.ts` drop their casts.
- Wires `parseGoogleResponse(GoogleEventSchema)` into the PATCH success path of `src/app/api/calendar/events/[id]/route.ts`, replacing a raw-JSON cast that bypassed validation entirely. Mirrors the POST handler's pattern.
- Wires `parseGoogleResponse(GoogleEventsListResponseSchema)` into the legacy client-side `fetchCalendarEvents` helper so it produces `GoogleEventPayload[]` for the mapper. The module's own docstring already recommended this for production callers.

## Why this shape

The issue lists two resolution paths. Option A (flip `GoogleCalendarEvent` to extend `Omit<GoogleEventPayload, "summary">`) immediately broke `calendar-transform.ts`: Zod 4 infers `z.object(...).loose()` with a `[k: string]: unknown` index signature that widens every inner field, so `event.start.dateTime` / `event.creator.email` / `event.extendedProperties.shared.category` all fail strict TS. Reshaping that transform would have ballooned the diff and risked behaviour changes far from the issue's stated goal.

So this PR takes Option B: keep `GoogleCalendarEvent extends Omit<gapi.client.calendar.Event, "summary">` for consumer ergonomics, and put the single structural assertion that bridges the loose Zod inference and the gapi-derived domain type **inside the mapper itself** — the only place where "wire shape" becomes "internal canonical event". The mapper's doc-comment explains exactly that.

## Plan

Linked plan: `.claude/plans/gapi-cast-mapper-boundary-403.md`  
Project: https://github.com/users/BenSeymourODB/projects/1

## Verification

`pnpm lint:fix && pnpm format:fix && pnpm check-types && pnpm test:run` — clean, all 2708 tests pass.

## Test plan

- [x] `pnpm test:run` — all unit/integration tests pass
- [x] `pnpm check-types` — clean
- [x] `pnpm lint` — no new errors (5 pre-existing warnings remain)
- [x] `pnpm format` — clean
- [x] Mapper tests retyped to `GoogleEventPayload`; end-to-end test now parses gapi-typed fixture through `parseGoogleResponse` first (production-aligned flow)
- [x] PATCH handler's new validation branch mirrors POST's existing one — same 502 response shape, same `validationIssues` log line

Closes #403

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LU2SSCdrFMbCStestsYxG5)_