### PR TITLE
refactor(auth): extract requireGoogleTasksSession across Tasks routes (#441)

### DIFF
--- a/.claude/plans/441-google-tasks-session-helper.md
+++ b/.claude/plans/441-google-tasks-session-helper.md
@@ -1,0 +1,155 @@
+# Plan: Extract requireGoogleTasksSession (Issue #441 slice 1 of 3)
+
+Issue: [#441 Repeated auth/token/PIN validation patterns duplicated across API routes](https://github.com/BenSeymourODB/next-digital-wall-calendar/issues/441)
+
+## Scope (this PR)
+
+Issue #441 calls out **three** distinct duplications:
+
+1. **Session existence + `RefreshTokenError` 401 + Google-Tasks access-token acquisition** repeated across 4 task routes and 1 auth route.
+2. **Profile-ownership check** repeated across PIN routes (set/reset/verify).
+3. **PIN lockout + bcrypt** logic inlined in `verify-pin` route — should be a service.
+
+**This PR delivers slice 1 only.** Slices 2 and 3 are deferred to follow-up issues filed alongside this PR, to keep the diff focused and reviewable.
+
+## Pattern being extracted
+
+Every Google-Tasks route opens with this 15-line preamble:
+
+```ts
+const session = await getSession();
+if (!session?.user) {
+  return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+}
+
+if (session.error === "RefreshTokenError") {
+  return NextResponse.json(
+    {
+      error: "Session expired. Please sign in again.",
+      requiresReauth: true,
+    },
+    { status: 401 }
+  );
+}
+
+const accessToken = await requireGoogleTasksAccessToken(session);
+```
+
+Plus a duplicated `catch` arm for `AuthError`:
+
+```ts
+if (error instanceof AuthError) {
+  const requiresReauth = error.status === 401 || error.status === 403;
+  return NextResponse.json({ error: error.message, requiresReauth }, { status: error.status });
+}
+```
+
+That's ~20 lines repeated across 4 task routes (`tasks/route.ts`, `tasks/[taskId]/route.ts`, `tasks/[taskId]/complete/route.ts`, `tasks/lists/route.ts`) and the first half (~10 lines) in `auth/account/route.ts`.
+
+## Design
+
+### `AuthError` extension
+
+Add an explicit `requiresReauth?: boolean` property + constructor option. When set, the catch block uses it verbatim; when unset, the catch block keeps the current `status === 401 || 403` fallback so existing throw-sites are unchanged.
+
+```ts
+export class AuthError extends Error {
+  status: number;
+  requiresReauth?: boolean;
+
+  constructor(message: string, status: number = 401, options?: { requiresReauth?: boolean }) {
+    super(message);
+    this.name = "AuthError";
+    this.status = status;
+    this.requiresReauth = options?.requiresReauth;
+  }
+}
+```
+
+### Two new helpers in `src/lib/auth/helpers.ts`
+
+```ts
+// Session existence + RefreshTokenError. Throws AuthError tagged with
+// the correct requiresReauth flag.
+export async function requireAuthenticatedSession(): Promise<{
+  session: Session & { user: { id: string } };
+}> {
+  const session = await getSession();
+  if (!session?.user?.id) {
+    throw new AuthError("Unauthorized", 401, { requiresReauth: false });
+  }
+  if (session.error === "RefreshTokenError") {
+    throw new AuthError("Session expired. Please sign in again.", 401, {
+      requiresReauth: true,
+    });
+  }
+  return { session };
+}
+
+// Composes the above with the existing requireGoogleTasksAccessToken.
+export async function requireGoogleTasksSession(): Promise<{
+  session: Session & { user: { id: string } };
+  accessToken: string;
+}> {
+  const { session } = await requireAuthenticatedSession();
+  const accessToken = await requireGoogleTasksAccessToken(session);
+  return { session, accessToken };
+}
+```
+
+### Route catch-block update
+
+The migrated routes change their `AuthError` catch arm from:
+
+```ts
+const requiresReauth = error.status === 401 || error.status === 403;
+return NextResponse.json({ error: error.message, requiresReauth }, { status: error.status });
+```
+
+to:
+
+```ts
+const requiresReauth = error.requiresReauth ?? (error.status === 401 || error.status === 403);
+const body: Record<string, unknown> = { error: error.message };
+if (requiresReauth) body.requiresReauth = true;
+return NextResponse.json(body, { status: error.status });
+```
+
+This is **observably equivalent** for every existing throw-site:
+
+- Missing-session response: `{ error: "Unauthorized" }` (no `requiresReauth` field, because the new helper sets the flag to `false` explicitly). Existing tests assert `data.error === "Unauthorized"` without an opinion on the field's presence.
+- `RefreshTokenError` response: `{ error: "Session expired. Please sign in again.", requiresReauth: true }` — same as today.
+- Scope-missing (403) response: `{ error: "...", requiresReauth: true }` — same as today (no flag set, status falls back to 403 → true).
+- Other AuthErrors from `requireGoogleTasksAccessToken`: same as today.
+
+## Files
+
+### Phase 1 — helper + AuthError extension (TDD)
+
+- `src/lib/auth/helpers.ts` (modify)
+- `src/lib/auth/__tests__/helpers.test.ts` (add tests for the two new helpers + `AuthError.requiresReauth`)
+
+### Phase 2 — migrate 5 routes
+
+- `src/app/api/tasks/route.ts`
+- `src/app/api/tasks/[taskId]/route.ts`
+- `src/app/api/tasks/[taskId]/complete/route.ts`
+- `src/app/api/tasks/lists/route.ts`
+- `src/app/api/auth/account/route.ts`
+
+Existing tests in each route's `__tests__/route.test.ts` must pass **without modification** — they encode the public contract this refactor must preserve.
+
+## Out of scope (follow-up issues to file alongside this PR)
+
+1. **PIN routes — extract `withProfileOwnershipCheck`** (#441 item 2). Covers `profiles/[id]/set-pin/route.ts`, `.../reset-pin/route.ts`, `.../verify-pin/route.ts`.
+2. **PIN routes — extract `pinVerificationService`** (#441 item 3). Move bcrypt + `MAX_FAILED_ATTEMPTS` + `LOCKOUT_DURATION_MS` out of `verify-pin/route.ts` into `lib/services/pin-verification.ts`.
+
+Both are deliberately deferred to keep this PR's diff small and the auth helper change isolated from the PIN-specific logic.
+
+## Acceptance criteria
+
+- `pnpm lint:fix && pnpm format:fix && pnpm check-types && pnpm test` all green.
+- Existing route tests pass without modification.
+- Helper tests cover: missing session → `AuthError("Unauthorized", 401, { requiresReauth: false })`; `RefreshTokenError` → `AuthError("Session expired. ...", 401, { requiresReauth: true })`; happy path returns `{ session }` / `{ session, accessToken }`; `requireGoogleTasksSession` delegates scope failure to `requireGoogleTasksAccessToken`.
+- Net LOC reduction across the 5 migrated routes.
+- Follow-up issues filed and linked from PR body.

--- a/src/app/api/auth/account/__tests__/route.test.ts
+++ b/src/app/api/auth/account/__tests__/route.test.ts
@@ -15,11 +15,45 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AccountInfo } from "../route";
 import { GET } from "../route";
 
-// Mock modules BEFORE imports
-vi.mock("@/lib/auth", () => ({
-  getSession: vi.fn(),
-  getGoogleAccount: vi.fn(),
-}));
+// Mock modules BEFORE imports. The route imports `requireAuthenticatedSession`
+// post-#441; we wire its mock to delegate through the existing
+// `getSession` mock so test setup keeps driving behavior the same way it did
+// before the refactor.
+vi.mock("@/lib/auth", () => {
+  class MockAuthError extends Error {
+    status: number;
+    requiresReauth?: boolean;
+    constructor(
+      message: string,
+      status: number = 401,
+      options?: { requiresReauth?: boolean }
+    ) {
+      super(message);
+      this.name = "AuthError";
+      this.status = status;
+      this.requiresReauth = options?.requiresReauth;
+    }
+  }
+  const getSession = vi.fn();
+  const requireAuthenticatedSession = vi.fn(async () => {
+    const session = await getSession();
+    if (!session?.user?.id) {
+      throw new MockAuthError("Unauthorized", 401, { requiresReauth: false });
+    }
+    if (session.error === "RefreshTokenError") {
+      throw new MockAuthError("Session expired. Please sign in again.", 401, {
+        requiresReauth: true,
+      });
+    }
+    return { session };
+  });
+  return {
+    AuthError: MockAuthError,
+    getSession,
+    getGoogleAccount: vi.fn(),
+    requireAuthenticatedSession,
+  };
+});
 
 vi.mock("@/lib/logger", () => ({
   logger: {

--- a/src/app/api/auth/account/route.ts
+++ b/src/app/api/auth/account/route.ts
@@ -2,7 +2,11 @@
  * API endpoint for fetching authenticated user's Google account info
  * Used by client components to display account information
  */
-import { getGoogleAccount, getSession } from "@/lib/auth";
+import {
+  AuthError,
+  getGoogleAccount,
+  requireAuthenticatedSession,
+} from "@/lib/auth";
 import { logger } from "@/lib/logger";
 import { NextResponse } from "next/server";
 
@@ -15,22 +19,8 @@ export interface AccountInfo {
 
 export async function GET() {
   try {
-    const session = await getSession();
-
-    if (!session?.user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    // Check if token refresh failed
-    if (session.error === "RefreshTokenError") {
-      return NextResponse.json(
-        {
-          error: "Session expired. Please sign in again.",
-          requiresReauth: true,
-        },
-        { status: 401 }
-      );
-    }
+    // Handles session existence + RefreshTokenError in one place (#441).
+    const { session } = await requireAuthenticatedSession();
 
     // Get Google account data
     const googleAccount = await getGoogleAccount();
@@ -60,6 +50,14 @@ export async function GET() {
 
     return NextResponse.json(accountInfo);
   } catch (error) {
+    if (error instanceof AuthError) {
+      const requiresReauth =
+        error.requiresReauth ?? (error.status === 401 || error.status === 403);
+      const body: Record<string, unknown> = { error: error.message };
+      if (requiresReauth) body.requiresReauth = true;
+      return NextResponse.json(body, { status: error.status });
+    }
+
     logger.error(error as Error, {
       endpoint: "/api/auth/account",
       errorType: "fetch_account",

--- a/src/app/api/tasks/[taskId]/__tests__/route.test.ts
+++ b/src/app/api/tasks/[taskId]/__tests__/route.test.ts
@@ -19,19 +19,47 @@ import {
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { PATCH } from "../route";
 
-// Mock modules BEFORE imports
-vi.mock("@/lib/auth", () => ({
-  getSession: vi.fn(),
-  requireGoogleTasksAccessToken: vi.fn(),
-  AuthError: class AuthError extends Error {
+// Mock modules BEFORE imports. The route imports `requireGoogleTasksSession`
+// post-#441; we wire its mock to delegate through the existing
+// `getSession` + `requireGoogleTasksAccessToken` mocks so test setup keeps
+// driving behavior the same way it did before the refactor.
+vi.mock("@/lib/auth", () => {
+  class MockAuthError extends Error {
     status: number;
-    constructor(message: string, status: number = 401) {
+    requiresReauth?: boolean;
+    constructor(
+      message: string,
+      status: number = 401,
+      options?: { requiresReauth?: boolean }
+    ) {
       super(message);
       this.name = "AuthError";
       this.status = status;
+      this.requiresReauth = options?.requiresReauth;
     }
-  },
-}));
+  }
+  const getSession = vi.fn();
+  const requireGoogleTasksAccessToken = vi.fn();
+  const requireGoogleTasksSession = vi.fn(async () => {
+    const session = await getSession();
+    if (!session?.user?.id) {
+      throw new MockAuthError("Unauthorized", 401, { requiresReauth: false });
+    }
+    if (session.error === "RefreshTokenError") {
+      throw new MockAuthError("Session expired. Please sign in again.", 401, {
+        requiresReauth: true,
+      });
+    }
+    const accessToken = await requireGoogleTasksAccessToken(session);
+    return { session, accessToken };
+  });
+  return {
+    AuthError: MockAuthError,
+    getSession,
+    requireGoogleTasksAccessToken,
+    requireGoogleTasksSession,
+  };
+});
 
 vi.mock("@/lib/logger", () => ({
   logger: {

--- a/src/app/api/tasks/[taskId]/complete/__tests__/route.test.ts
+++ b/src/app/api/tasks/[taskId]/complete/__tests__/route.test.ts
@@ -21,18 +21,47 @@ import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { POST } from "../route";
 
-vi.mock("@/lib/auth", () => ({
-  getSession: vi.fn(),
-  requireGoogleTasksAccessToken: vi.fn(),
-  AuthError: class AuthError extends Error {
+// Wire `requireGoogleTasksSession` (the helper the route uses post-#441)
+// to delegate through the existing `getSession` + `requireGoogleTasksAccessToken`
+// mocks. Test setup that calls `vi.mocked(getSession).mockResolvedValue(...)`
+// keeps driving the route's auth path end-to-end.
+vi.mock("@/lib/auth", () => {
+  class MockAuthError extends Error {
     status: number;
-    constructor(message: string, status: number = 401) {
+    requiresReauth?: boolean;
+    constructor(
+      message: string,
+      status: number = 401,
+      options?: { requiresReauth?: boolean }
+    ) {
       super(message);
       this.name = "AuthError";
       this.status = status;
+      this.requiresReauth = options?.requiresReauth;
     }
-  },
-}));
+  }
+  const getSession = vi.fn();
+  const requireGoogleTasksAccessToken = vi.fn();
+  const requireGoogleTasksSession = vi.fn(async () => {
+    const session = await getSession();
+    if (!session?.user?.id) {
+      throw new MockAuthError("Unauthorized", 401, { requiresReauth: false });
+    }
+    if (session.error === "RefreshTokenError") {
+      throw new MockAuthError("Session expired. Please sign in again.", 401, {
+        requiresReauth: true,
+      });
+    }
+    const accessToken = await requireGoogleTasksAccessToken(session);
+    return { session, accessToken };
+  });
+  return {
+    AuthError: MockAuthError,
+    getSession,
+    requireGoogleTasksAccessToken,
+    requireGoogleTasksSession,
+  };
+});
 
 vi.mock("@/lib/logger", () => ({
   logger: {

--- a/src/app/api/tasks/[taskId]/complete/route.ts
+++ b/src/app/api/tasks/[taskId]/complete/route.ts
@@ -4,11 +4,7 @@
  *
  * POST - Complete a task and update streak
  */
-import {
-  AuthError,
-  getSession,
-  requireGoogleTasksAccessToken,
-} from "@/lib/auth";
+import { AuthError, requireGoogleTasksSession } from "@/lib/auth";
 import { patchTask } from "@/lib/google/tasks-api";
 import { GoogleTasksApiError } from "@/lib/google/tasks-types";
 import { logger } from "@/lib/logger";
@@ -41,23 +37,9 @@ export async function POST(
   { params }: RouteContext
 ): Promise<NextResponse> {
   try {
-    const session = await getSession();
-    if (!session?.user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    if (session.error === "RefreshTokenError") {
-      return NextResponse.json(
-        {
-          error: "Session expired. Please sign in again.",
-          requiresReauth: true,
-        },
-        { status: 401 }
-      );
-    }
-
-    // Combined scope check + token decryption in a single DB call (#260).
-    const accessToken = await requireGoogleTasksAccessToken(session);
+    // Single helper handles session existence, RefreshTokenError, scope
+    // check, and decrypted-token acquisition (#441).
+    const { accessToken } = await requireGoogleTasksSession();
 
     const { taskId } = await params;
 
@@ -93,11 +75,11 @@ export async function POST(
     return NextResponse.json({ task, streak });
   } catch (error) {
     if (error instanceof AuthError) {
-      const requiresReauth = error.status === 401 || error.status === 403;
-      return NextResponse.json(
-        { error: error.message, requiresReauth },
-        { status: error.status }
-      );
+      const requiresReauth =
+        error.requiresReauth ?? (error.status === 401 || error.status === 403);
+      const body: Record<string, unknown> = { error: error.message };
+      if (requiresReauth) body.requiresReauth = true;
+      return NextResponse.json(body, { status: error.status });
     }
 
     if (error instanceof GoogleTasksApiError) {

--- a/src/app/api/tasks/[taskId]/route.ts
+++ b/src/app/api/tasks/[taskId]/route.ts
@@ -2,11 +2,7 @@
  * API endpoint for updating a Google Task
  * Uses server-side authentication with NextAuth.js
  */
-import {
-  AuthError,
-  getSession,
-  requireGoogleTasksAccessToken,
-} from "@/lib/auth";
+import { AuthError, requireGoogleTasksSession } from "@/lib/auth";
 import { patchTask } from "@/lib/google/tasks-api";
 import {
   GoogleTasksApiError,
@@ -31,23 +27,9 @@ export async function PATCH(
   { params }: { params: Promise<{ taskId: string }> }
 ) {
   try {
-    const session = await getSession();
-    if (!session?.user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    if (session.error === "RefreshTokenError") {
-      return NextResponse.json(
-        {
-          error: "Session expired. Please sign in again.",
-          requiresReauth: true,
-        },
-        { status: 401 }
-      );
-    }
-
-    // Combined scope check + token decryption in a single DB call (#260).
-    const accessToken = await requireGoogleTasksAccessToken(session);
+    // Single helper handles session existence, RefreshTokenError, scope
+    // check, and decrypted-token acquisition (#441).
+    const { session, accessToken } = await requireGoogleTasksSession();
 
     const { taskId } = await params;
     const { searchParams } = new URL(request.url);
@@ -81,11 +63,11 @@ export async function PATCH(
     return NextResponse.json({ task: updatedTask });
   } catch (error) {
     if (error instanceof AuthError) {
-      const requiresReauth = error.status === 401 || error.status === 403;
-      return NextResponse.json(
-        { error: error.message, requiresReauth },
-        { status: error.status }
-      );
+      const requiresReauth =
+        error.requiresReauth ?? (error.status === 401 || error.status === 403);
+      const body: Record<string, unknown> = { error: error.message };
+      if (requiresReauth) body.requiresReauth = true;
+      return NextResponse.json(body, { status: error.status });
     }
 
     if (error instanceof GoogleTasksApiError) {

--- a/src/app/api/tasks/__tests__/route.test.ts
+++ b/src/app/api/tasks/__tests__/route.test.ts
@@ -21,19 +21,50 @@ import {
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GET, POST } from "../route";
 
-// Mock modules BEFORE imports
-vi.mock("@/lib/auth", () => ({
-  getSession: vi.fn(),
-  requireGoogleTasksAccessToken: vi.fn(),
-  AuthError: class AuthError extends Error {
+// Mock modules BEFORE imports.
+//
+// `requireGoogleTasksSession` is the helper the route actually imports
+// post-#441. We wire its mock factory to delegate through the same
+// `getSession` and `requireGoogleTasksAccessToken` mocks the existing
+// tests already drive — so test setup (`vi.mocked(getSession)…`) keeps
+// working end-to-end through the new helper.
+vi.mock("@/lib/auth", () => {
+  class MockAuthError extends Error {
     status: number;
-    constructor(message: string, status: number = 401) {
+    requiresReauth?: boolean;
+    constructor(
+      message: string,
+      status: number = 401,
+      options?: { requiresReauth?: boolean }
+    ) {
       super(message);
       this.name = "AuthError";
       this.status = status;
+      this.requiresReauth = options?.requiresReauth;
     }
-  },
-}));
+  }
+  const getSession = vi.fn();
+  const requireGoogleTasksAccessToken = vi.fn();
+  const requireGoogleTasksSession = vi.fn(async () => {
+    const session = await getSession();
+    if (!session?.user?.id) {
+      throw new MockAuthError("Unauthorized", 401, { requiresReauth: false });
+    }
+    if (session.error === "RefreshTokenError") {
+      throw new MockAuthError("Session expired. Please sign in again.", 401, {
+        requiresReauth: true,
+      });
+    }
+    const accessToken = await requireGoogleTasksAccessToken(session);
+    return { session, accessToken };
+  });
+  return {
+    AuthError: MockAuthError,
+    getSession,
+    requireGoogleTasksAccessToken,
+    requireGoogleTasksSession,
+  };
+});
 
 vi.mock("@/lib/logger", () => ({
   logger: {

--- a/src/app/api/tasks/lists/__tests__/route.test.ts
+++ b/src/app/api/tasks/lists/__tests__/route.test.ts
@@ -19,19 +19,47 @@ import {
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GET } from "../route";
 
-// Mock modules BEFORE imports
-vi.mock("@/lib/auth", () => ({
-  getSession: vi.fn(),
-  requireGoogleTasksAccessToken: vi.fn(),
-  AuthError: class AuthError extends Error {
+// Mock modules BEFORE imports. The route imports `requireGoogleTasksSession`
+// post-#441; we wire its mock to delegate through the existing
+// `getSession` + `requireGoogleTasksAccessToken` mocks so test setup keeps
+// driving behavior the same way it did before the refactor.
+vi.mock("@/lib/auth", () => {
+  class MockAuthError extends Error {
     status: number;
-    constructor(message: string, status: number = 401) {
+    requiresReauth?: boolean;
+    constructor(
+      message: string,
+      status: number = 401,
+      options?: { requiresReauth?: boolean }
+    ) {
       super(message);
       this.name = "AuthError";
       this.status = status;
+      this.requiresReauth = options?.requiresReauth;
     }
-  },
-}));
+  }
+  const getSession = vi.fn();
+  const requireGoogleTasksAccessToken = vi.fn();
+  const requireGoogleTasksSession = vi.fn(async () => {
+    const session = await getSession();
+    if (!session?.user?.id) {
+      throw new MockAuthError("Unauthorized", 401, { requiresReauth: false });
+    }
+    if (session.error === "RefreshTokenError") {
+      throw new MockAuthError("Session expired. Please sign in again.", 401, {
+        requiresReauth: true,
+      });
+    }
+    const accessToken = await requireGoogleTasksAccessToken(session);
+    return { session, accessToken };
+  });
+  return {
+    AuthError: MockAuthError,
+    getSession,
+    requireGoogleTasksAccessToken,
+    requireGoogleTasksSession,
+  };
+});
 
 vi.mock("@/lib/logger", () => ({
   logger: {

--- a/src/app/api/tasks/lists/route.ts
+++ b/src/app/api/tasks/lists/route.ts
@@ -2,11 +2,7 @@
  * API endpoint for Google Task Lists
  * Uses server-side authentication with NextAuth.js
  */
-import {
-  AuthError,
-  getSession,
-  requireGoogleTasksAccessToken,
-} from "@/lib/auth";
+import { AuthError, requireGoogleTasksSession } from "@/lib/auth";
 import { listTaskLists } from "@/lib/google/tasks-api";
 import { GoogleTasksApiError } from "@/lib/google/tasks-types";
 import { logger } from "@/lib/logger";
@@ -17,25 +13,9 @@ import { NextResponse } from "next/server";
  */
 export async function GET() {
   try {
-    const session = await getSession();
-    if (!session?.user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    if (session.error === "RefreshTokenError") {
-      return NextResponse.json(
-        {
-          error: "Session expired. Please sign in again.",
-          requiresReauth: true,
-        },
-        { status: 401 }
-      );
-    }
-
-    // Combined scope check + token decryption in a single DB call (#260).
-    // Short-circuits users missing the Tasks scope (#237) without burning a
-    // separate prisma.account.findMany.
-    const accessToken = await requireGoogleTasksAccessToken(session);
+    // Single helper handles session existence, RefreshTokenError, scope
+    // check, and decrypted-token acquisition (#441).
+    const { session, accessToken } = await requireGoogleTasksSession();
     const lists = await listTaskLists(accessToken);
 
     logger.event("TaskListsFetched", {
@@ -46,11 +26,11 @@ export async function GET() {
     return NextResponse.json({ lists });
   } catch (error) {
     if (error instanceof AuthError) {
-      const requiresReauth = error.status === 401 || error.status === 403;
-      return NextResponse.json(
-        { error: error.message, requiresReauth },
-        { status: error.status }
-      );
+      const requiresReauth =
+        error.requiresReauth ?? (error.status === 401 || error.status === 403);
+      const body: Record<string, unknown> = { error: error.message };
+      if (requiresReauth) body.requiresReauth = true;
+      return NextResponse.json(body, { status: error.status });
     }
 
     if (error instanceof GoogleTasksApiError) {

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -2,11 +2,7 @@
  * API endpoint for Google Tasks
  * Uses server-side authentication with NextAuth.js
  */
-import {
-  AuthError,
-  getSession,
-  requireGoogleTasksAccessToken,
-} from "@/lib/auth";
+import { AuthError, requireGoogleTasksSession } from "@/lib/auth";
 import { createTask, listTasks } from "@/lib/google/tasks-api";
 import { GoogleTasksApiError } from "@/lib/google/tasks-types";
 import { logger } from "@/lib/logger";
@@ -20,11 +16,6 @@ interface CreateTaskBody {
   due?: string;
 }
 
-interface GoogleTaskItem {
-  id: string;
-  [key: string]: unknown;
-}
-
 /**
  * GET /api/tasks - List tasks from a task list
  * Query params:
@@ -34,25 +25,9 @@ interface GoogleTaskItem {
  */
 export async function GET(request: NextRequest) {
   try {
-    const session = await getSession();
-    if (!session?.user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    if (session.error === "RefreshTokenError") {
-      return NextResponse.json(
-        {
-          error: "Session expired. Please sign in again.",
-          requiresReauth: true,
-        },
-        { status: 401 }
-      );
-    }
-
-    // Combined scope check + token decryption in a single DB call (#260).
-    // Short-circuits users missing the Tasks scope (#237) before URL
-    // parsing, matching the original assertGoogleTasksScope ordering.
-    const accessToken = await requireGoogleTasksAccessToken(session);
+    // Single helper handles session existence, RefreshTokenError, scope
+    // check, and decrypted-token acquisition (#441).
+    const { session, accessToken } = await requireGoogleTasksSession();
 
     const { searchParams } = new URL(request.url);
     const listId = searchParams.get("listId");
@@ -131,23 +106,7 @@ export async function GET(request: NextRequest) {
  */
 export async function POST(request: NextRequest) {
   try {
-    const session = await getSession();
-    if (!session?.user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    if (session.error === "RefreshTokenError") {
-      return NextResponse.json(
-        {
-          error: "Session expired. Please sign in again.",
-          requiresReauth: true,
-        },
-        { status: 401 }
-      );
-    }
-
-    // Combined scope check + token decryption in a single DB call (#260).
-    const accessToken = await requireGoogleTasksAccessToken(session);
+    const { session, accessToken } = await requireGoogleTasksSession();
 
     const body = (await request.json()) as CreateTaskBody;
     const { listId, title, notes, due } = body;
@@ -178,13 +137,13 @@ function handleTasksApiError(
   errorType: "fetch_tasks" | "create_task"
 ): NextResponse {
   if (error instanceof AuthError) {
-    // Both 401 (no/expired session) and 403 (scope missing) are recoverable
-    // by re-authenticating, so the client uses the same `requiresReauth` flow.
-    const requiresReauth = error.status === 401 || error.status === 403;
-    return NextResponse.json(
-      { error: error.message, requiresReauth },
-      { status: error.status }
-    );
+    // Explicit AuthError.requiresReauth wins; otherwise fall back to the
+    // status-based inference so existing throw-sites are unchanged (#441).
+    const requiresReauth =
+      error.requiresReauth ?? (error.status === 401 || error.status === 403);
+    const body: Record<string, unknown> = { error: error.message };
+    if (requiresReauth) body.requiresReauth = true;
+    return NextResponse.json(body, { status: error.status });
   }
 
   if (error instanceof GoogleTasksApiError) {

--- a/src/lib/auth/__tests__/helpers.test.ts
+++ b/src/lib/auth/__tests__/helpers.test.ts
@@ -747,6 +747,23 @@ describe("auth helpers", () => {
       });
     });
 
+    it("throws AuthError(401, requiresReauth: false) when user.id is an empty string", async () => {
+      // user.id is typed `string` but JS can hand us an empty string through
+      // a malformed session. `!session?.user?.id` already treats "" as falsy;
+      // this pins that behavior so a future refactor can't loosen the guard
+      // by switching to a `user.id === undefined` check.
+      mockAuth.mockResolvedValue({
+        ...mockSession,
+        user: { ...mockSession.user, id: "" },
+      } as unknown as typeof mockSession);
+
+      await expect(requireAuthenticatedSession()).rejects.toMatchObject({
+        status: 401,
+        message: "Unauthorized",
+        requiresReauth: false,
+      });
+    });
+
     it("throws AuthError(401, requiresReauth: true) when session.error === RefreshTokenError", async () => {
       mockAuth.mockResolvedValue(mockSessionWithError);
 

--- a/src/lib/auth/__tests__/helpers.test.ts
+++ b/src/lib/auth/__tests__/helpers.test.ts
@@ -27,7 +27,9 @@ import {
   isAuthenticated,
   needsReauthentication,
   requireAuth,
+  requireAuthenticatedSession,
   requireGoogleTasksAccessToken,
+  requireGoogleTasksSession,
   withAuth,
 } from "../helpers";
 import {
@@ -672,6 +674,159 @@ describe("auth helpers", () => {
 
       expect(error).toBeInstanceOf(Error);
       expect(error).toBeInstanceOf(AuthError);
+    });
+
+    it("leaves requiresReauth undefined by default so the route catch-block can keep its status-based fallback", () => {
+      // Existing AuthError throw-sites do not set this flag. The route
+      // catch-block falls back to `status === 401 || 403` for them, so
+      // their response shape is unchanged after this refactor.
+      const error = new AuthError("Unauthorized", 401);
+
+      expect(error.requiresReauth).toBeUndefined();
+    });
+
+    it("accepts an explicit requiresReauth: false to suppress the re-auth CTA on plain unauthenticated requests", () => {
+      // The new requireAuthenticatedSession helper uses this to differentiate
+      // "no session at all" (no re-auth UI — could just be a logged-out user)
+      // from "session error — definitely needs re-auth".
+      const error = new AuthError("Unauthorized", 401, {
+        requiresReauth: false,
+      });
+
+      expect(error.requiresReauth).toBe(false);
+    });
+
+    it("accepts an explicit requiresReauth: true so the route catch-block can render the CTA without inferring from status", () => {
+      const error = new AuthError(
+        "Session expired. Please sign in again.",
+        401,
+        {
+          requiresReauth: true,
+        }
+      );
+
+      expect(error.requiresReauth).toBe(true);
+    });
+  });
+
+  describe("requireAuthenticatedSession", () => {
+    it("returns the session when authenticated and not in a refresh-error state", async () => {
+      mockAuth.mockResolvedValue(mockSession);
+
+      const { session } = await requireAuthenticatedSession();
+
+      expect(session).toEqual(mockSession);
+    });
+
+    it("throws AuthError(401, requiresReauth: false) when there is no session", async () => {
+      // Distinct from RefreshTokenError: a missing session is just "not signed
+      // in" — the client should NOT pop a re-auth modal because the user may
+      // never have signed in at all.
+      mockAuth.mockResolvedValue(null);
+
+      const promise = requireAuthenticatedSession();
+
+      await expect(promise).rejects.toBeInstanceOf(AuthError);
+      await expect(promise).rejects.toMatchObject({
+        status: 401,
+        message: "Unauthorized",
+        requiresReauth: false,
+      });
+    });
+
+    it("throws AuthError(401, requiresReauth: false) when the session has no user.id", async () => {
+      mockAuth.mockResolvedValue({
+        ...mockSession,
+        user: undefined,
+      } as unknown as typeof mockSession);
+
+      await expect(requireAuthenticatedSession()).rejects.toMatchObject({
+        status: 401,
+        message: "Unauthorized",
+        requiresReauth: false,
+      });
+    });
+
+    it("throws AuthError(401, requiresReauth: true) when session.error === RefreshTokenError", async () => {
+      mockAuth.mockResolvedValue(mockSessionWithError);
+
+      const promise = requireAuthenticatedSession();
+
+      await expect(promise).rejects.toBeInstanceOf(AuthError);
+      await expect(promise).rejects.toMatchObject({
+        status: 401,
+        message: "Session expired. Please sign in again.",
+        requiresReauth: true,
+      });
+    });
+  });
+
+  describe("requireGoogleTasksSession", () => {
+    it("returns { session, accessToken } on the happy path", async () => {
+      mockAuth.mockResolvedValue(mockSession);
+      vi.mocked(prisma.account.findFirst).mockResolvedValue(mockGoogleAccount);
+
+      const { session, accessToken } = await requireGoogleTasksSession();
+
+      expect(session).toEqual(mockSession);
+      expect(accessToken).toBe(mockGoogleAccount.access_token);
+    });
+
+    it("does not call prisma when there is no session (short-circuits in requireAuthenticatedSession)", async () => {
+      mockAuth.mockResolvedValue(null);
+
+      await expect(requireGoogleTasksSession()).rejects.toMatchObject({
+        status: 401,
+        message: "Unauthorized",
+        requiresReauth: false,
+      });
+      expect(prisma.account.findFirst).not.toHaveBeenCalled();
+    });
+
+    it("does not call prisma when the session is in RefreshTokenError", async () => {
+      mockAuth.mockResolvedValue(mockSessionWithError);
+
+      await expect(requireGoogleTasksSession()).rejects.toMatchObject({
+        status: 401,
+        requiresReauth: true,
+      });
+      expect(prisma.account.findFirst).not.toHaveBeenCalled();
+    });
+
+    it("propagates a 403 from requireGoogleTasksAccessToken when scope is missing", async () => {
+      mockAuth.mockResolvedValue(mockSession);
+      vi.mocked(prisma.account.findFirst).mockResolvedValue({
+        ...mockGoogleAccount,
+        scope:
+          "openid email profile https://www.googleapis.com/auth/calendar.readonly",
+      });
+
+      const promise = requireGoogleTasksSession();
+
+      await expect(promise).rejects.toBeInstanceOf(AuthError);
+      await expect(promise).rejects.toMatchObject({
+        status: 403,
+        message: expect.stringContaining("Google Tasks"),
+      });
+    });
+
+    it("propagates a 401 from requireGoogleTasksAccessToken when no Google account is linked", async () => {
+      mockAuth.mockResolvedValue(mockSession);
+      vi.mocked(prisma.account.findFirst).mockResolvedValue(null);
+
+      await expect(requireGoogleTasksSession()).rejects.toMatchObject({
+        status: 401,
+        message: expect.stringContaining("No Google account"),
+      });
+    });
+
+    it("calls prisma.account.findFirst exactly once (no duplicate query)", async () => {
+      mockAuth.mockResolvedValue(mockSession);
+      vi.mocked(prisma.account.findFirst).mockResolvedValue(mockGoogleAccount);
+
+      await requireGoogleTasksSession();
+
+      expect(prisma.account.findFirst).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/lib/auth/helpers.ts
+++ b/src/lib/auth/helpers.ts
@@ -270,14 +270,84 @@ export async function requireGoogleTasksAccessToken(
 }
 
 /**
- * Custom error class for auth-related errors
+ * Custom error class for auth-related errors.
+ *
+ * The optional `requiresReauth` flag lets callers signal to the route's
+ * catch-block whether a "re-authenticate" CTA should be surfaced. When
+ * unset, the existing throw-sites are unchanged — the catch-block falls
+ * back to a `status === 401 || 403` inference. When set explicitly, it
+ * lets the helper distinguish a plain unauthenticated request
+ * (`requiresReauth: false`, no CTA) from a session that needs refreshing
+ * (`requiresReauth: true`).
  */
 export class AuthError extends Error {
   status: number;
+  requiresReauth?: boolean;
 
-  constructor(message: string, status: number = 401) {
+  constructor(
+    message: string,
+    status: number = 401,
+    options?: { requiresReauth?: boolean }
+  ) {
     super(message);
     this.name = "AuthError";
     this.status = status;
+    this.requiresReauth = options?.requiresReauth;
   }
+}
+
+/**
+ * Authenticated-session pre-flight shared by every API route that needs
+ * a signed-in user. Collapses the
+ *
+ *   getSession → !user check → RefreshTokenError check
+ *
+ * three-step preamble (4–10 duplicated lines per route) into one call
+ * that throws structured `AuthError`s carrying the right `requiresReauth`
+ * flag for each failure mode:
+ *
+ *   - no session / no `user.id` → 401, `requiresReauth: false`
+ *   - `session.error === "RefreshTokenError"` → 401, `requiresReauth: true`
+ *
+ * Routes that also need a Google Tasks access token should call
+ * {@link requireGoogleTasksSession} instead, which composes this helper
+ * with {@link requireGoogleTasksAccessToken}.
+ */
+export async function requireAuthenticatedSession(): Promise<{
+  session: Session & { user: { id: string } };
+}> {
+  const session = await getSession();
+  if (!session?.user?.id) {
+    throw new AuthError("Unauthorized", 401, { requiresReauth: false });
+  }
+  if (session.error === "RefreshTokenError") {
+    throw new AuthError("Session expired. Please sign in again.", 401, {
+      requiresReauth: true,
+    });
+  }
+  return { session: session as Session & { user: { id: string } } };
+}
+
+/**
+ * Pre-flight for Google Tasks API routes. Resolves a signed-in session
+ * (via {@link requireAuthenticatedSession}) and the user's decrypted
+ * Google Tasks access token (via {@link requireGoogleTasksAccessToken})
+ * in a single call.
+ *
+ * Failure modes (all `AuthError`):
+ * - 401 `requiresReauth: false` — no session
+ * - 401 `requiresReauth: true` — session has a refresh-token error
+ * - 403 — Google Tasks scope missing from stored grant
+ * - 401 — no Google account linked, or stored token undecryptable
+ *
+ * One Prisma query per call — `getSession()` is the only auth round-trip
+ * outside it.
+ */
+export async function requireGoogleTasksSession(): Promise<{
+  session: Session & { user: { id: string } };
+  accessToken: string;
+}> {
+  const { session } = await requireAuthenticatedSession();
+  const accessToken = await requireGoogleTasksAccessToken(session);
+  return { session, accessToken };
 }

--- a/src/lib/auth/helpers.ts
+++ b/src/lib/auth/helpers.ts
@@ -309,6 +309,12 @@ export class AuthError extends Error {
  *   - no session / no `user.id` → 401, `requiresReauth: false`
  *   - `session.error === "RefreshTokenError"` → 401, `requiresReauth: true`
  *
+ * Guard order: the `user.id` check runs before the `RefreshTokenError`
+ * check, but in practice they never collide — the NextAuth session
+ * callback only sets `RefreshTokenError` on sessions that already have
+ * a populated `user.id` (it short-circuits when the user lookup fails),
+ * so a refresh-error session is always picked up by the second guard.
+ *
  * Routes that also need a Google Tasks access token should call
  * {@link requireGoogleTasksSession} instead, which composes this helper
  * with {@link requireGoogleTasksAccessToken}.

--- a/src/lib/auth/index.ts
+++ b/src/lib/auth/index.ts
@@ -12,6 +12,8 @@ export {
   isAuthenticated,
   needsReauthentication,
   requireAuth,
+  requireAuthenticatedSession,
   requireGoogleTasksAccessToken,
+  requireGoogleTasksSession,
   withAuth,
 } from "./helpers";


### PR DESCRIPTION
## Summary

- Extracts the duplicated `getSession → !user → RefreshTokenError → requireGoogleTasksAccessToken` preamble (15+ lines repeated across 4 Google Tasks routes and 1 auth route) into two new helpers in `@/lib/auth/helpers`:
  - `requireAuthenticatedSession()` — session existence + `RefreshTokenError`, throws `AuthError` tagged with the right `requiresReauth` flag.
  - `requireGoogleTasksSession()` — composes the above with the existing `requireGoogleTasksAccessToken`.
- Extends `AuthError` with an explicit `requiresReauth?: boolean` constructor option so callers can disambiguate "plain unauthenticated" (no CTA) from "session needs refresh" (CTA). Existing `AuthError` throw-sites are unchanged — the route catch-block keeps a `status === 401 || 403` fallback when the flag is unset.
- Migrates `/api/tasks` (GET + POST), `/api/tasks/[taskId]` (PATCH), `/api/tasks/[taskId]/complete` (POST), `/api/tasks/lists` (GET), and `/api/auth/account` (GET) onto the helpers — each route sheds 9-13 lines.

Net diff: **5 routes down 9-13 lines each**, 2 new helpers + tests. Existing public contracts (every 401/403/404/200 response shape) preserved.

## Plan

Linked plan: [`.claude/plans/441-google-tasks-session-helper.md`](https://github.com/BenSeymourODB/next-digital-wall-calendar/blob/claude/elegant-newton-3xjtfr/.claude/plans/441-google-tasks-session-helper.md)
Project: <https://github.com/users/BenSeymourODB/projects/1>

Issue #441 calls out **three** duplications. This PR delivers **slice 1 of 3**; the other two are filed as follow-up issues so each can be reviewed independently:

- Slice 2 → #467 (`withProfileOwnershipCheck` wrapper for PIN routes)
- Slice 3 → #468 (`pinVerificationService` for bcrypt + lockout)

## Test plan

- [x] `pnpm lint:fix && pnpm format:fix && pnpm check-types` — clean (4 pre-existing warnings in unrelated files; one stale warning in `tasks/route.ts` for an unused `GoogleTaskItem` type was cleaned up by the migration)
- [x] `pnpm test` — **2721/2721 pass across 160 files** (no regressions)
- [x] Helper tests added: `requireAuthenticatedSession` happy path + 401/no-session + 401/`RefreshTokenError`; `requireGoogleTasksSession` happy path + each error mode propagation; `AuthError.requiresReauth` shape (default undefined, explicit true/false)
- [x] All route tests pass without assertion changes — only the `vi.mock("@/lib/auth", ...)` factory was updated to wire `requireGoogleTasksSession` through the same `getSession` + `requireGoogleTasksAccessToken` `vi.fn()`s the existing setup already drove

## Behavior preservation

The route catch-block change is observably equivalent for every existing throw-site:

| Failure mode | Today's response | After refactor |
|---|---|---|
| No session | `{ error: "Unauthorized" }`, 401 | `{ error: "Unauthorized" }`, 401 (flag `false` → field omitted) |
| `RefreshTokenError` | `{ error: "Session expired. Please sign in again.", requiresReauth: true }`, 401 | identical |
| Missing Tasks scope | `{ error: "...", requiresReauth: true }`, 403 | identical (catch-block falls back to `status === 403` → `true`) |
| No Google account / no token | `{ error: "...", requiresReauth: true }`, 401 | identical (status fallback) |

The `refresh-token` route's explicit `expect(data.requiresReauth).toBeUndefined()` assertion (for non-401 paths) is preserved because the new catch-block only includes the field in the response body when it's `true`.

## Deferred work (follow-up issues filed)

- #467 — extract `withProfileOwnershipCheck` wrapper for the 3 PIN routes (`set-pin`, `reset-pin`, `verify-pin`)
- #468 — extract `pinVerificationService` (bcrypt + `MAX_FAILED_ATTEMPTS` + `LOCKOUT_DURATION_MS`) out of `verify-pin/route.ts` into `lib/services/`

Both are deliberately out of scope here to keep the auth-helper change isolated from PIN-specific business logic.

Closes #441

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pUX8pk2K3RZDz82EP2Joh

---
_Generated by [Claude Code](https://claude.ai/code/session_017pUX8pk2K3RZDz82EP2Joh)_