### PR TITLE
refactor(components): add missing barrels + extract profiles/types.ts (#443)

### DIFF
--- a/.claude/plans/components-barrels-and-profile-types-443.md
+++ b/.claude/plans/components-barrels-and-profile-types-443.md
@@ -1,0 +1,127 @@
+# Components barrel exports + profile type extraction (#443)
+
+## Issue summary
+
+`src/components/` has 10 feature directories. 4 ship an `index.ts` barrel
+(`profiles`, `recipe`, `settings`, `tasks`); 6 do not (`calendar`,
+`navigation`, `providers`, `rewards`, `scheduler`, `theme`). Inside
+`calendar/`, `analog-clock/` has its own barrel — a one-off "island" inside
+an otherwise non-barreled directory.
+
+Separately, `profiles/` scatters its public types inline across
+`profile-context.tsx` (`Profile`, `ProfileAvatar`, `ViewMode`) and
+`profile-form.tsx` (`ProfileType`, `AgeGroup`). The barrel re-exports
+them through `profile-context`, but the underlying convention in `tasks`,
+`recipe`, `scheduler` is a dedicated `types.ts`.
+
+## Goals
+
+1. Add `index.ts` barrels to the 6 missing directories.
+2. Extract `src/components/profiles/types.ts` with the public profile
+   types and update the in-directory consumers to import from there.
+3. No behavior change. Pre-existing consumers that deep-import a file
+   (`@/components/calendar/DayCalendar`) keep working — barrels are
+   purely additive. The type-checker is the verification gate.
+
+## Non-goals (deferred)
+
+- Migrating existing consumer imports from deep paths to the barrel.
+  That's a much larger diff, low value at this stage, and risks merge
+  conflicts with the many in-flight calendar PRs. Tracked separately if
+  ever wanted.
+- Adding barrels for `__tests__/`, `ui/`, or other nested directories.
+- Refactoring `settings/index.ts`, which is incomplete (missing some
+  section exports) but out of scope here.
+- Promoting component-specific prop types (e.g. `PinSetupModalProps`)
+  into `types.ts` — convention in `recipe`/`tasks` is to keep prop types
+  co-located with their component and re-export through the barrel, so
+  `profiles` already matches.
+
+## Public surface per directory
+
+Following the existing `tasks` / `recipe` patterns: a barrel exports
+components, the hooks they pair with, and the types/constants consumers
+need. Internal helpers (`agenda-helpers.ts`, color buckets, etc.) stay
+deep-importable but are NOT in the barrel.
+
+### `calendar/`
+
+Components: `AccountManager`, `AddEventButton`, `AgendaCalendar`,
+`AgendaList`, `AnalogClockView`, `CalendarFilterPanel`,
+`CalendarSettingsPanel`, `DayCalendar`, `DayOverflowPopover`,
+`EventCreateDialog`, `EventDetailModal`, `MiniCalendarSidebar`,
+`SimpleCalendar`, `ViewSwitcher`, `WeekCalendar`, `YearCalendar`,
+`AnimatedSwap`. Re-export the `analog-clock` sub-barrel.
+
+Types: `AgendaListProps`, `EventEditPatch`, `EventCreateInput`,
+`AnimatedSwapType`, `AnimatedSwapDirection`.
+
+### `navigation/`
+
+Components: `AppShell`, `SideNavigation`.
+
+### `providers/`
+
+Components: `AppInsightsProvider`, `CalendarProvider`, `ErrorBoundary`,
+`MockCalendarProvider`, `SessionProvider`, `TasksProvider`,
+`ThemeProvider`.
+
+Hooks: whatever each provider exposes (`useCalendar`, etc.).
+
+### `rewards/`
+
+Components: `MountedPointsProvider`, `PointsAnimation`, `PointsBadge`.
+Hook + context: `PointsProvider`, `usePoints` from `points-context`.
+
+### `scheduler/`
+
+Components: `NavigationControls`, `SchedulerStatusIndicator`,
+`ScreenScheduler`, `ScreenTransition`.
+
+Hooks: `useInteractionDetector`, `useScreenScheduler`.
+
+Types: existing `types.ts` symbols.
+
+### `theme/`
+
+Components: `ThemeScope`, `ThemeToggle`.
+
+## `profiles/types.ts`
+
+Move from `profile-context.tsx`:
+
+- `interface ProfileAvatar`
+- `interface Profile`
+- `type ViewMode`
+
+Move from `profile-form.tsx` (currently NOT exported — promote them):
+
+- `type ProfileType`
+- `type AgeGroup`
+
+Re-import them in `profile-context.tsx` and `profile-form.tsx`. Update
+`profiles/index.ts` to re-export from `./types` (already re-exports the
+profile-context names; switch the source).
+
+## Verification
+
+The existing unit / component test suite already covers the public
+surface. Mechanical refactor:
+
+1. Add each barrel + the new types file.
+2. `pnpm check-types` after each file group — catches any signature drift.
+3. `pnpm lint:fix && pnpm format:fix` for style.
+4. `pnpm test` for behavior.
+
+No new tests are required — the change is import-graph-only and the
+type-checker proves equivalence.
+
+## Phases
+
+1. **Profiles types extraction.** Create `profiles/types.ts`, update
+   `profile-context.tsx` + `profile-form.tsx`, update `profiles/index.ts`
+   to source types from `./types`. Run `pnpm check-types && pnpm test`.
+2. **Add six barrels.** One commit per directory or one commit total —
+   the diff is mechanical. Run checks after each.
+3. **Final sweep.** `pnpm lint:fix && pnpm format:fix && pnpm check-types && pnpm test`.
+   Push, open draft PR, mark ready-for-review.

--- a/src/components/calendar/index.ts
+++ b/src/components/calendar/index.ts
@@ -1,0 +1,61 @@
+/**
+ * Calendar components barrel exports
+ *
+ * Re-exports the public component surface and the few helpers / constants
+ * that other directories already import directly. The `analog-clock`
+ * sub-barrel is re-exported wholesale so a consumer importing from
+ * `@/components/calendar` reaches both `AnalogClockView` (the wired-up
+ * page-level component) and the underlying `AnalogClock` / `ClockFace`
+ * primitives.
+ */
+
+export { AccountManager } from "./AccountManager";
+export { AddEventButton } from "./AddEventButton";
+
+export {
+  AgendaCalendar,
+  UNCATEGORISED_LABEL,
+  groupEventsByCategory,
+  groupEventsByColor,
+  sortCategoryEntries,
+  sortEventsByStartTime,
+} from "./AgendaCalendar";
+
+export { AgendaList } from "./AgendaList";
+export type { AgendaListProps } from "./AgendaList";
+
+export { AnalogClockView } from "./AnalogClockView";
+
+export { AnimatedSwap } from "./animated-swap";
+export type { AnimatedSwapDirection, AnimatedSwapType } from "./animated-swap";
+
+export { filterEventsBySearch } from "./agenda-helpers";
+
+export { CalendarFilterPanel } from "./CalendarFilterPanel";
+export { CalendarSettingsPanel } from "./CalendarSettingsPanel";
+
+export { DayCalendar } from "./DayCalendar";
+
+export {
+  DayOverflowPopover,
+  EVENT_COLOR_CLASSES,
+  MAX_INLINE_EVENTS,
+} from "./DayOverflowPopover";
+
+export {
+  EventCreateDialog,
+  resolveInitialCalendarId,
+} from "./EventCreateDialog";
+export type { EventCreateInput } from "./EventCreateDialog";
+
+export { EventDetailModal } from "./EventDetailModal";
+export type { EventEditPatch } from "./EventDetailModal";
+
+export { MiniCalendarSidebar } from "./MiniCalendarSidebar";
+export { SimpleCalendar } from "./SimpleCalendar";
+export { ViewSwitcher } from "./ViewSwitcher";
+export { WeekCalendar } from "./WeekCalendar";
+
+export { YearCalendar, bucketEventColorsByDayKey } from "./YearCalendar";
+
+export * from "./analog-clock";

--- a/src/components/navigation/index.ts
+++ b/src/components/navigation/index.ts
@@ -1,0 +1,5 @@
+/**
+ * Navigation components barrel exports
+ */
+export { AppShell } from "./app-shell";
+export { NAV_ITEMS, SideNavigation } from "./side-navigation";

--- a/src/components/profiles/__tests__/give-points-modal.test.tsx
+++ b/src/components/profiles/__tests__/give-points-modal.test.tsx
@@ -6,7 +6,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GivePointsModal } from "../give-points-modal";
-import type { Profile } from "../profile-context";
+import type { Profile } from "../types";
 
 // Mock fetch for API calls
 const mockFetch = vi.fn();

--- a/src/components/profiles/__tests__/profile-avatar.test.tsx
+++ b/src/components/profiles/__tests__/profile-avatar.test.tsx
@@ -4,7 +4,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { ProfileAvatar } from "../profile-avatar";
-import type { Profile } from "../profile-context";
+import type { Profile } from "../types";
 
 // ProfileAvatar's prop type is the narrow subset { name, color, avatar }.
 type ProfileAvatarFixture = Pick<Profile, "name" | "color" | "avatar">;

--- a/src/components/profiles/__tests__/profile-context.test.tsx
+++ b/src/components/profiles/__tests__/profile-context.test.tsx
@@ -5,7 +5,8 @@ import { makeProfile } from "@/test/fixtures/profile";
 import { type ReactNode } from "react";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { type Profile, ProfileProvider, useProfile } from "../profile-context";
+import { ProfileProvider, useProfile } from "../profile-context";
+import { type Profile } from "../types";
 
 // Mock fetch
 const mockFetch = vi.fn();

--- a/src/components/profiles/__tests__/profile-grid.test.tsx
+++ b/src/components/profiles/__tests__/profile-grid.test.tsx
@@ -4,8 +4,8 @@
 import { makeProfile } from "@/test/fixtures/profile";
 import { render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { Profile } from "../profile-context";
 import { ProfileGrid, ProfileGridSkeleton } from "../profile-grid";
+import type { Profile } from "../types";
 
 // Mock fetch for stats API
 const mockFetch = vi.fn();

--- a/src/components/profiles/__tests__/profile-switcher.test.tsx
+++ b/src/components/profiles/__tests__/profile-switcher.test.tsx
@@ -5,8 +5,9 @@ import { makeProfile } from "@/test/fixtures/profile";
 import { type ReactNode } from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { type Profile, ProfileProvider } from "../profile-context";
+import { ProfileProvider } from "../profile-context";
 import { ProfileSwitcher } from "../profile-switcher";
+import { type Profile } from "../types";
 
 // Mock fetch
 const mockFetch = vi.fn();

--- a/src/components/profiles/give-points-modal.tsx
+++ b/src/components/profiles/give-points-modal.tsx
@@ -29,7 +29,7 @@ import {
 } from "@/components/ui/select";
 import { useEffect, useState } from "react";
 import { ProfileAvatar } from "./profile-avatar";
-import type { Profile } from "./profile-context";
+import type { Profile } from "./types";
 
 export interface GivePointsModalProps {
   /** Whether the modal is open */

--- a/src/components/profiles/index.ts
+++ b/src/components/profiles/index.ts
@@ -1,8 +1,24 @@
 /**
  * Profile components barrel exports
  */
-export { ProfileProvider, useProfile } from "./profile-context";
-export type { Profile, ProfileAvatar, ViewMode } from "./profile-context";
+export {
+  ProfileProvider,
+  useProfile,
+  useProfileOptional,
+} from "./profile-context";
+
+// Domain types live in ./types — re-exported here so consumers can write
+// `import { Profile } from "@/components/profiles"` without reaching into
+// the internal module layout. Matches the `tasks` / `recipe` / `scheduler`
+// pattern.
+export type {
+  AgeGroup,
+  Profile,
+  ProfileAvatar,
+  ProfileType,
+  ViewMode,
+} from "./types";
+
 export { ProfileAvatar as ProfileAvatarComponent } from "./profile-avatar";
 export { ProfileSwitcher } from "./profile-switcher";
 export { ProfileCard, ProfileCardSkeleton } from "./profile-card";

--- a/src/components/profiles/pin-entry-modal.tsx
+++ b/src/components/profiles/pin-entry-modal.tsx
@@ -22,7 +22,7 @@ import { useEffect, useState } from "react";
 import { NumericKeypad } from "./numeric-keypad";
 import { PinDisplay } from "./pin-display";
 import { ProfileAvatar } from "./profile-avatar";
-import type { ProfileAvatar as ProfileAvatarType } from "./profile-context";
+import type { ProfileAvatar as ProfileAvatarType } from "./types";
 
 export interface PinEntryModalProfile {
   id: string;

--- a/src/components/profiles/pin-settings.tsx
+++ b/src/components/profiles/pin-settings.tsx
@@ -32,7 +32,7 @@ import { Key, Lock, RefreshCw, Unlock } from "lucide-react";
 import { NumericKeypad } from "./numeric-keypad";
 import { PinDisplay } from "./pin-display";
 import { PinSetupModal } from "./pin-setup-modal";
-import type { ProfileAvatar } from "./profile-context";
+import type { ProfileAvatar } from "./types";
 
 export interface PinSettingsProfile {
   id: string;

--- a/src/components/profiles/profile-avatar.tsx
+++ b/src/components/profiles/profile-avatar.tsx
@@ -6,7 +6,7 @@
  * - emoji: Shows an emoji character
  * - photo: Shows a profile photo
  */
-import { ProfileAvatar as ProfileAvatarType } from "./profile-context";
+import type { ProfileAvatar as ProfileAvatarType } from "./types";
 
 interface ProfileAvatarProps {
   profile: {

--- a/src/components/profiles/profile-card.tsx
+++ b/src/components/profiles/profile-card.tsx
@@ -17,7 +17,7 @@ import { cn } from "@/lib/utils";
 import { useEffect, useState } from "react";
 import { Trophy } from "lucide-react";
 import { ProfileAvatar } from "./profile-avatar";
-import type { Profile } from "./profile-context";
+import type { Profile } from "./types";
 
 /**
  * Profile stats from API

--- a/src/components/profiles/profile-context.tsx
+++ b/src/components/profiles/profile-context.tsx
@@ -16,37 +16,7 @@ import {
   useEffect,
   useState,
 } from "react";
-
-/**
- * Profile avatar configuration
- */
-export interface ProfileAvatar {
-  type: "initials" | "photo" | "emoji";
-  value: string;
-  backgroundColor?: string;
-}
-
-/**
- * Profile data structure
- */
-export interface Profile {
-  id: string;
-  userId: string;
-  name: string;
-  type: "admin" | "standard";
-  ageGroup: "adult" | "teen" | "child";
-  color: string;
-  avatar: ProfileAvatar;
-  pinEnabled: boolean;
-  isActive: boolean;
-  createdAt?: string;
-  updatedAt?: string;
-}
-
-/**
- * View mode for the calendar
- */
-export type ViewMode = "profile" | "family";
+import type { Profile, ViewMode } from "./types";
 
 /**
  * Profile context value

--- a/src/components/profiles/profile-form.tsx
+++ b/src/components/profiles/profile-form.tsx
@@ -25,12 +25,7 @@ import { cn } from "@/lib/utils";
 import { useState } from "react";
 import { Info, Loader2 } from "lucide-react";
 import { ColorPicker, PROFILE_COLORS } from "./color-picker";
-
-/**
- * Profile type options
- */
-type ProfileType = "admin" | "standard";
-type AgeGroup = "adult" | "teen" | "child";
+import type { AgeGroup, ProfileType } from "./types";
 
 /**
  * Profile form props

--- a/src/components/profiles/profile-grid.tsx
+++ b/src/components/profiles/profile-grid.tsx
@@ -10,7 +10,7 @@
  * - Indicates active profile
  */
 import { ProfileCard, ProfileCardSkeleton } from "./profile-card";
-import type { Profile } from "./profile-context";
+import type { Profile } from "./types";
 
 interface ProfileGridProps {
   profiles: Profile[];

--- a/src/components/profiles/profile-switcher.tsx
+++ b/src/components/profiles/profile-switcher.tsx
@@ -15,7 +15,8 @@ import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { PinEntryModal } from "./pin-entry-modal";
 import { ProfileAvatar } from "./profile-avatar";
-import { Profile, useProfile } from "./profile-context";
+import { useProfile } from "./profile-context";
+import type { Profile } from "./types";
 
 export function ProfileSwitcher() {
   const { activeProfile, allProfiles, setActiveProfile, setViewMode } =

--- a/src/components/profiles/types.ts
+++ b/src/components/profiles/types.ts
@@ -1,0 +1,48 @@
+/**
+ * Profile component types
+ *
+ * Centralized type definitions shared across the profiles surface.
+ * Matches the per-directory `types.ts` pattern used by `tasks`, `recipe`,
+ * and `scheduler`.
+ */
+
+/**
+ * Privilege level for a profile.
+ */
+export type ProfileType = "admin" | "standard";
+
+/**
+ * Age cohort for a profile. Drives display / interaction defaults.
+ */
+export type AgeGroup = "adult" | "teen" | "child";
+
+/**
+ * Profile avatar configuration.
+ */
+export interface ProfileAvatar {
+  type: "initials" | "photo" | "emoji";
+  value: string;
+  backgroundColor?: string;
+}
+
+/**
+ * Profile data structure.
+ */
+export interface Profile {
+  id: string;
+  userId: string;
+  name: string;
+  type: ProfileType;
+  ageGroup: AgeGroup;
+  color: string;
+  avatar: ProfileAvatar;
+  pinEnabled: boolean;
+  isActive: boolean;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+/**
+ * View mode for the calendar — single-profile vs whole-family view.
+ */
+export type ViewMode = "profile" | "family";

--- a/src/components/providers/index.ts
+++ b/src/components/providers/index.ts
@@ -1,0 +1,40 @@
+/**
+ * Provider components barrel exports
+ *
+ * `MockCalendarProvider` is intentionally re-exported alongside the
+ * production providers — it is consumed by `/test/calendar` fixtures
+ * and by the `e2e/` Playwright specs in addition to unit tests, so it
+ * is part of the public surface of this directory.
+ */
+export { AppInsightsProvider } from "./AppInsightsProvider";
+
+export {
+  CalendarContext,
+  CalendarProvider,
+  useCalendar,
+} from "./CalendarProvider";
+export type {
+  CreateEventInput,
+  EditEventInput,
+  ICalendarContext,
+} from "./CalendarProvider";
+
+export { ErrorBoundary, useErrorHandler } from "./ErrorBoundary";
+
+export { MockCalendarProvider } from "./MockCalendarProvider";
+
+export { SessionProvider } from "./SessionProvider";
+
+export {
+  TASKS_ACTIVE_CONFIG_LS_KEY,
+  TASKS_VIEW_MODE_LS_KEY,
+  TasksProvider,
+  useTasksContext,
+} from "./TasksProvider";
+export type {
+  ITasksContext,
+  TasksProviderProps,
+  TasksViewMode,
+} from "./TasksProvider";
+
+export { ThemeProvider } from "./ThemeProvider";

--- a/src/components/rewards/index.ts
+++ b/src/components/rewards/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Rewards components barrel exports
+ */
+export { MountedPointsProvider } from "./mounted-points-provider";
+export { PointsAnimation } from "./points-animation";
+export type { PointsAnimationProps } from "./points-animation";
+export { PointsBadge } from "./points-badge";
+export { PointsProvider, usePoints, usePointsOptional } from "./points-context";
+export type {
+  AwardPointsMetadata,
+  AwardPointsResult,
+  PointAwardReason,
+} from "./points-context";

--- a/src/components/scheduler/index.ts
+++ b/src/components/scheduler/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Scheduler components barrel exports
+ */
+export { NavigationControls } from "./navigation-controls";
+export { SchedulerStatusIndicator } from "./scheduler-status-indicator";
+export { ScreenScheduler } from "./screen-scheduler";
+export { ScreenTransition } from "./screen-transition";
+export { useInteractionDetector } from "./use-interaction-detector";
+export { useScreenScheduler } from "./use-screen-scheduler";
+
+// Types live in ./types — see the same pattern in `tasks` and `recipe`.
+export type {
+  ScheduleConfig,
+  SchedulerControls,
+  SchedulerState,
+  ScreenSequence,
+  TimeSpecificNavigation,
+  TransitionConfig,
+  TransitionDirection,
+  TransitionType,
+} from "./types";

--- a/src/components/tasks/__tests__/profile-scoped-task-list.test.tsx
+++ b/src/components/tasks/__tests__/profile-scoped-task-list.test.tsx
@@ -3,10 +3,10 @@
  * surrounding ProfileContext into a TaskList's per-profile filter.
  */
 import {
-  type Profile,
   ProfileProvider,
   useProfile,
 } from "@/components/profiles/profile-context";
+import { type Profile } from "@/components/profiles/types";
 import { makeProfile } from "@/test/fixtures/profile";
 import { type ReactNode } from "react";
 import { act, fireEvent, render, waitFor } from "@testing-library/react";

--- a/src/components/theme/index.ts
+++ b/src/components/theme/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Theme components barrel exports
+ */
+export { ThemeScope } from "./theme-scope";
+export type { ThemeScopeMode } from "./theme-scope";
+export { ThemeToggle } from "./theme-toggle";

--- a/src/test/fixtures/__tests__/profile.test.ts
+++ b/src/test/fixtures/__tests__/profile.test.ts
@@ -1,4 +1,4 @@
-import type { Profile as AppProfile } from "@/components/profiles/profile-context";
+import type { Profile as AppProfile } from "@/components/profiles/types";
 import type {
   Profile as PrismaProfile,
   ProfileSettings as PrismaProfileSettings,

--- a/src/test/fixtures/profile.ts
+++ b/src/test/fixtures/profile.ts
@@ -25,7 +25,7 @@
 import type {
   Profile as AppProfile,
   ProfileAvatar,
-} from "@/components/profiles/profile-context";
+} from "@/components/profiles/types";
 import type {
   Profile as PrismaProfile,
   ProfileSettings as PrismaProfileSettings,


### PR DESCRIPTION
## Summary

- Add `index.ts` barrels to the 6 component directories that were missing them — `calendar`, `navigation`, `providers`, `rewards`, `scheduler`, `theme` — bringing them in line with the existing pattern in `profiles`, `recipe`, `settings`, `tasks`.
- Extract `src/components/profiles/types.ts` with `Profile`, `ProfileAvatar`, `ViewMode`, `ProfileType`, `AgeGroup`. Switch in-directory consumers (and a few external imports in `tasks` tests / `test/fixtures`) to import from there. The public surface through `@/components/profiles` is unchanged.
- No behavior change. Existing deep-import call sites (e.g. `@/components/calendar/DayCalendar`) keep working — barrels are purely additive.

## Plan

Linked plan: `.claude/plans/components-barrels-and-profile-types-443.md`
Project: https://github.com/users/BenSeymourODB/projects/1

## Verification

- `pnpm check-types` — clean against all files touched by this PR. (The 38 baseline errors that show up are pre-existing on `main`: Prisma client isn't generated in this remote env, and a handful of unrelated `display-section` / `settings-form` test fixtures drift from a recent settings refactor — same set of errors with the diff stashed.)
- `pnpm lint` — 0 errors, 5 warnings, all pre-existing.
- `pnpm format:fix` — clean.
- `pnpm test` — 2702 / 2708 pass. The 6 failing tests are all in `scripts/__tests__/rotate-token-encryption-key.test.ts`, fail identically on `main`, and all stem from the missing `src/generated/prisma/client.js` (Prisma binaries download blocked by this env's egress allowlist). CI runs `prisma generate` before tests and is expected to pass.

## Test plan

- [ ] CI green on `claude/elegant-newton-v8ckyq` (`lint` + `check-types` + `vitest`).
- [ ] Spot-check that an external consumer can import via the new barrel:
  ```ts
  import { DayCalendar, AgendaList, type EventEditPatch } from "@/components/calendar";
  import { ThemeToggle } from "@/components/theme";
  import { PointsBadge, usePoints } from "@/components/rewards";
  import { Profile, ProfileType } from "@/components/profiles";
  ```
- [ ] No regressions in `pnpm test` (locally confirmed: profiles + tasks + test/fixtures suites all green; only the Prisma-binding script tests fail, and they fail on `main` for the same reason).

## Scope notes

Deliberately deferred (not in this PR):

- Migrating existing deep-import call sites to the barrel. That's a much larger and noisier diff with low value at this stage — the issue is "consistent barrels exist", not "every importer is migrated". If wanted, easy follow-up.
- Filling in `settings/index.ts` (currently missing a few section exports). Pre-existing and out of scope; tracked in #443's "future direction" note rather than this PR.
- Promoting component-specific prop types (e.g. `PinSetupModalProps`) into `types.ts`. Convention in `recipe` / `tasks` is to keep prop types co-located with their component and re-export through the barrel, so `profiles` already matches that pattern — only the cross-component domain types moved.

Closes #443

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HpUP5kxDBsae1uSvTrX6PC)_