### PR TITLE
chore(calendar-helpers): drop dead exports surfaced by #428

### DIFF
--- a/.claude/plans/calendar-helpers-dead-code-428.md
+++ b/.claude/plans/calendar-helpers-dead-code-428.md
@@ -1,0 +1,71 @@
+# Plan: drop dead exports from `src/lib/calendar-helpers.ts` (#428)
+
+GitHub Issue: https://github.com/BenSeymourODB/next-digital-wall-calendar/issues/428
+Branch: `claude/elegant-newton-aw0vr2`
+
+## Context
+
+#428 lists four helpers in `src/lib/calendar-helpers.ts` as having no
+production callers: `rangeText`, `getEventsCount`, `getCalendarCells`,
+`getEventsByMode`. The issue explicitly says to re-check after PR #407
+(adopts `rangeText`) merges. #407 landed today as `e7ebbf7`, so the
+table is partly stale: `rangeText` now has three production callers
+(`WeekCalendar.tsx`, `YearCalendar.tsx`, `SimpleCalendar.tsx`).
+
+The remaining three are still dead on `origin/main` per
+`git grep` over `src/**/*.{ts,tsx}` minus tests and the helper file
+itself: zero production callers.
+
+Issue also calls for an **audit pass** over the rest of
+`calendar-helpers.ts`. A full grep produced a longer list of zero-caller
+exports than the issue names; the scope split is below.
+
+## Scope (this PR)
+
+Delete and remove tests for:
+
+1. `getEventsCount` (line 182) — zero callers, zero internal users.
+2. `getCalendarCells` (line 228) — zero callers, zero internal users.
+3. `getEventsByMode` (line 513) — zero callers; switch over `getEventsForX`.
+4. **Transitive:** `getEventsForMonth` (line 451) — only consumer is
+   `getEventsByMode` (line 526). Once `getEventsByMode` goes, this is
+   dead too; its `describe` block at line 603 is the only test caller.
+
+Each removal pairs with the corresponding `describe` block in
+`src/lib/__tests__/calendar-helpers.test.ts`:
+
+- `describe("getEventsCount", ...)` line 143
+- `describe("getCalendarCells", ...)` line 237
+- `describe("getEventsByMode (clock)", ...)` line 954
+- `describe("getEventsForMonth", ...)` line 603
+
+Import lists at the top of the test file need to drop the four names.
+
+## Out of scope (follow-up issue)
+
+A broader audit surfaced six more zero-caller exports the issue does
+not name. They are deliberately left for a follow-up so this PR stays
+focused on the criteria in #428 and the transitive consequence:
+
+- `calculateMonthEventPositions`
+- `getBgColor`
+- `getFirstLetters`
+- `getMonthCellEvents`
+- `navigateDate`
+- `toCapitalize`
+
+A new GitHub issue will track these and be linked from the PR.
+
+## Verification
+
+- `pnpm test:run src/lib/__tests__/calendar-helpers.test.ts` — focused.
+- `pnpm test:run` — full suite (regressions / unrelated breakage).
+- `pnpm lint:fix && pnpm format:fix && pnpm check-types`.
+
+Type-check matters most: TypeScript will flag any importer of a removed
+symbol the grep missed (e.g. a barrel re-export).
+
+## Commits
+
+One commit on `claude/elegant-newton-aw0vr2`, then push and open a
+draft PR. Single phase — the changes are mechanical and small.

--- a/src/lib/__tests__/calendar-helpers.test.ts
+++ b/src/lib/__tests__/calendar-helpers.test.ts
@@ -9,14 +9,10 @@ import {
   computeEventColumns,
   formatTime,
   getBgColor,
-  getCalendarCells,
   getColorClass,
   getCurrentTimePosition,
   getEventTimePosition,
-  getEventsByMode,
-  getEventsCount,
   getEventsForDay,
-  getEventsForMonth,
   getEventsForWeek,
   getEventsForYear,
   getFirstLetters,
@@ -140,56 +136,6 @@ describe("navigateDate", () => {
   });
 });
 
-describe("getEventsCount", () => {
-  const testDate = new Date(2024, 2, 15);
-  const events: IEvent[] = [
-    createMockEvent({ id: "1", startDate: "2024-03-15T10:00:00" }),
-    createMockEvent({ id: "2", startDate: "2024-03-15T14:00:00" }),
-    createMockEvent({ id: "3", startDate: "2024-03-20T10:00:00" }),
-  ];
-
-  it("counts events for the same day", () => {
-    const count = getEventsCount(events, testDate, "day", WEEK_STARTS_ON);
-    expect(count).toBe(2);
-  });
-
-  it("counts events for the same month", () => {
-    const count = getEventsCount(events, testDate, "month", WEEK_STARTS_ON);
-    expect(count).toBe(3);
-  });
-
-  it("counts events for the same day in clock view", () => {
-    const count = getEventsCount(events, testDate, "clock", WEEK_STARTS_ON);
-    expect(count).toBe(2);
-  });
-
-  it("counts events for the same week using WEEK_STARTS_ON", () => {
-    // testDate = Fri Mar 15 2024. With WEEK_STARTS_ON = 0 (Sunday), the week
-    // runs Sun Mar 10 – Sat Mar 16. Sun Mar 17 falls into the next week.
-    const weekEvents: IEvent[] = [
-      createMockEvent({ id: "same-week", startDate: "2024-03-10T10:00:00" }),
-      createMockEvent({ id: "next-week", startDate: "2024-03-17T10:00:00" }),
-    ];
-    expect(getEventsCount(weekEvents, testDate, "week", WEEK_STARTS_ON)).toBe(
-      1
-    );
-  });
-
-  it("counts events for the same week with Monday-first weekStartsOn=1", () => {
-    // testDate = Fri Mar 15 2024. With weekStartsOn = 1 (Monday), the week
-    // runs Mon Mar 11 – Sun Mar 17. Mar 10 falls into the prior week.
-    // Note: getEventsCount uses isSameWeek, which is boundary-safe (compares
-    // calendar-week membership, not raw timestamps), so unlike
-    // getEventsForWeek this test isn't affected by the midnight-boundary
-    // bug discussed in #201/PR #228.
-    const weekEvents: IEvent[] = [
-      createMockEvent({ id: "prior-week", startDate: "2024-03-10T10:00:00" }),
-      createMockEvent({ id: "same-week", startDate: "2024-03-17T10:00:00" }),
-    ];
-    expect(getEventsCount(weekEvents, testDate, "week", 1)).toBe(1);
-  });
-});
-
 describe("groupEvents", () => {
   it("groups non-overlapping events together", () => {
     const events: IEvent[] = [
@@ -231,75 +177,6 @@ describe("groupEvents", () => {
   it("handles empty array", () => {
     const groups = groupEvents([]);
     expect(groups).toEqual([]);
-  });
-});
-
-describe("getCalendarCells", () => {
-  it("returns cells for a full month grid", () => {
-    const date = new Date(2024, 2, 15); // March 2024
-    const cells = getCalendarCells(date, WEEK_STARTS_ON);
-
-    // Should always be a complete grid (multiple of 7)
-    expect(cells.length % 7).toBe(0);
-
-    // Should have cells from current month
-    const currentMonthCells = cells.filter((c) => c.currentMonth);
-    expect(currentMonthCells.length).toBe(31); // March has 31 days
-  });
-
-  it("marks current month cells correctly", () => {
-    const date = new Date(2024, 2, 15);
-    const cells = getCalendarCells(date, WEEK_STARTS_ON);
-
-    const currentMonthCells = cells.filter((c) => c.currentMonth);
-    currentMonthCells.forEach((cell) => {
-      expect(cell.date.getMonth()).toBe(2); // March
-    });
-  });
-
-  it("includes previous month cells", () => {
-    const date = new Date(2024, 2, 1); // March 2024 starts on Friday
-    const cells = getCalendarCells(date, WEEK_STARTS_ON);
-
-    // First cell should be from previous month (if March doesn't start on WEEK_STARTS_ON)
-    const prevMonthCells = cells.filter(
-      (c) => !c.currentMonth && c.date.getMonth() === 1
-    );
-    expect(prevMonthCells.length).toBeGreaterThan(0);
-  });
-
-  it("starts the grid on WEEK_STARTS_ON", () => {
-    const date = new Date(2024, 2, 15); // March 2024
-    const cells = getCalendarCells(date, WEEK_STARTS_ON);
-    expect(cells[0].date.getDay()).toBe(WEEK_STARTS_ON);
-  });
-
-  it("starts the grid on Monday when weekStartsOn=1", () => {
-    // March 2024 starts on Friday. Sunday-first → leading padding 5 (Sun–Thu
-    // of Feb). Monday-first → leading padding 4 (Mon–Thu of Feb).
-    const date = new Date(2024, 2, 15);
-    const cells = getCalendarCells(date, 1);
-    expect(cells[0].date.getDay()).toBe(1);
-
-    // Spot check: the grid should still cover all 31 days of March and pad
-    // to a multiple of 7.
-    expect(cells.length % 7).toBe(0);
-    expect(cells.filter((c) => c.currentMonth).length).toBe(31);
-  });
-
-  it("aligns the leading padding correctly for Monday-first when month starts on Sunday", () => {
-    // September 2024 starts on Sunday.
-    // - Sunday-first: 0 leading cells.
-    // - Monday-first: 6 leading cells (Mon Aug 26 – Sat Aug 31).
-    const date = new Date(2024, 8, 15);
-    const sundayFirst = getCalendarCells(date, 0);
-    const mondayFirst = getCalendarCells(date, 1);
-
-    expect(sundayFirst[0].date.getDay()).toBe(0);
-    expect(sundayFirst[0].currentMonth).toBe(true); // Sun Sep 1
-    expect(mondayFirst[0].date.getDay()).toBe(1);
-    expect(mondayFirst[0].currentMonth).toBe(false); // Mon Aug 26
-    expect(mondayFirst[6].date.getDay()).toBe(0); // Sun Sep 1
   });
 });
 
@@ -600,31 +477,6 @@ describe("getEventsForWeek", () => {
   });
 });
 
-describe("getEventsForMonth", () => {
-  it("returns events within the month", () => {
-    const events: IEvent[] = [
-      createMockEvent({
-        id: "1",
-        startDate: "2024-03-01T10:00:00",
-        endDate: "2024-03-01T11:00:00",
-      }),
-      createMockEvent({
-        id: "2",
-        startDate: "2024-03-31T10:00:00",
-        endDate: "2024-03-31T11:00:00",
-      }),
-      createMockEvent({
-        id: "3",
-        startDate: "2024-04-01T10:00:00",
-        endDate: "2024-04-01T11:00:00",
-      }),
-    ];
-
-    const result = getEventsForMonth(events, new Date(2024, 2, 15));
-    expect(result.length).toBe(2);
-  });
-});
-
 describe("getEventsForYear", () => {
   it("returns events within the year", () => {
     const events: IEvent[] = [
@@ -764,36 +616,6 @@ describe("getEventsForX bare-date inclusion (#375)", () => {
     const result = getEventsForYear(events, new Date(2026, 5, 15));
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe("bare-dec-31");
-  });
-
-  it("includes a bare-date first-of-month event in getEventsForMonth", () => {
-    const events: IEvent[] = [
-      createMockEvent({
-        id: "bare-mar-1",
-        startDate: "2026-03-01",
-        endDate: "2026-03-01",
-        isAllDay: true,
-      }),
-    ];
-
-    const result = getEventsForMonth(events, new Date(2026, 2, 15));
-    expect(result).toHaveLength(1);
-    expect(result[0].id).toBe("bare-mar-1");
-  });
-
-  it("includes a bare-date last-of-month event in getEventsForMonth", () => {
-    const events: IEvent[] = [
-      createMockEvent({
-        id: "bare-mar-31",
-        startDate: "2026-03-31",
-        endDate: "2026-03-31",
-        isAllDay: true,
-      }),
-    ];
-
-    const result = getEventsForMonth(events, new Date(2026, 2, 1));
-    expect(result).toHaveLength(1);
-    expect(result[0].id).toBe("bare-mar-31");
   });
 
   it("includes a bare-date first-of-week event in getEventsForWeek", () => {
@@ -948,33 +770,6 @@ describe("getBgColor", () => {
 
   it("returns empty string for unknown color", () => {
     expect(getBgColor("unknown")).toBe("");
-  });
-});
-
-describe("getEventsByMode (clock)", () => {
-  const testDate = new Date(2024, 2, 15);
-  const events: IEvent[] = [
-    createMockEvent({
-      id: "today-1",
-      startDate: "2024-03-15T10:00:00",
-      endDate: "2024-03-15T11:00:00",
-    }),
-    createMockEvent({
-      id: "today-2",
-      startDate: "2024-03-15T14:00:00",
-      endDate: "2024-03-15T15:00:00",
-    }),
-    createMockEvent({
-      id: "tomorrow",
-      startDate: "2024-03-16T10:00:00",
-      endDate: "2024-03-16T11:00:00",
-    }),
-  ];
-
-  it("returns events for the selected day in clock view", () => {
-    const result = getEventsByMode(events, "clock", testDate, WEEK_STARTS_ON);
-    const ids = result.map((e) => e.id).sort();
-    expect(ids).toEqual(["today-1", "today-2"]);
   });
 });
 

--- a/src/lib/calendar-helpers.ts
+++ b/src/lib/calendar-helpers.ts
@@ -1,9 +1,4 @@
-import type {
-  ICalendarCell,
-  IEvent,
-  TCalendarView,
-  TEventColor,
-} from "@/types/calendar";
+import type { IEvent, TCalendarView, TEventColor } from "@/types/calendar";
 import type { Day } from "date-fns";
 import {
   addDays,
@@ -18,9 +13,6 @@ import {
   endOfYear,
   format,
   isSameDay,
-  isSameMonth,
-  isSameWeek,
-  isSameYear,
   isValid,
   parseISO,
   startOfDay,
@@ -179,25 +171,6 @@ export function navigateDate(
   return operations[view](date, 1);
 }
 
-export function getEventsCount(
-  events: IEvent[],
-  date: Date,
-  view: TCalendarView,
-  weekStartsOn: Day
-): number {
-  const compareFns: Record<TCalendarView, (d1: Date, d2: Date) => boolean> = {
-    day: isSameDay,
-    week: (d1, d2) => isSameWeek(d1, d2, { weekStartsOn }),
-    month: isSameMonth,
-    year: isSameYear,
-    clock: isSameDay,
-  };
-
-  const compareFn = compareFns[view];
-  return events.filter((event) => compareFn(parseISO(event.startDate), date))
-    .length;
-}
-
 export function groupEvents(dayEvents: IEvent[]): IEvent[][] {
   const sortedEvents = dayEvents.sort(
     (a, b) => parseISO(a.startDate).getTime() - parseISO(b.startDate).getTime()
@@ -223,44 +196,6 @@ export function groupEvents(dayEvents: IEvent[]): IEvent[][] {
   }
 
   return groups;
-}
-
-export function getCalendarCells(
-  selectedDate: Date,
-  weekStartsOn: Day
-): ICalendarCell[] {
-  const year = selectedDate.getFullYear();
-  const month = selectedDate.getMonth();
-
-  const daysInMonth = endOfMonth(selectedDate).getDate(); // Faster than new Date(year, month + 1, 0)
-  // Offset of the 1st relative to weekStartsOn (0..6).
-  const firstDayOffset =
-    (startOfMonth(selectedDate).getDay() - weekStartsOn + 7) % 7;
-  const daysInPrevMonth = endOfMonth(new Date(year, month - 1)).getDate();
-  const totalDays = firstDayOffset + daysInMonth;
-
-  const prevMonthCells = Array.from({ length: firstDayOffset }, (_, i) => ({
-    day: daysInPrevMonth - firstDayOffset + i + 1,
-    currentMonth: false,
-    date: new Date(year, month - 1, daysInPrevMonth - firstDayOffset + i + 1),
-  }));
-
-  const currentMonthCells = Array.from({ length: daysInMonth }, (_, i) => ({
-    day: i + 1,
-    currentMonth: true,
-    date: new Date(year, month, i + 1),
-  }));
-
-  const nextMonthCells = Array.from(
-    { length: (7 - (totalDays % 7)) % 7 },
-    (_, i) => ({
-      day: i + 1,
-      currentMonth: false,
-      date: new Date(year, month + 1, i + 1),
-    })
-  );
-
-  return [...prevMonthCells, ...currentMonthCells, ...nextMonthCells];
 }
 
 export function calculateMonthEventPositions(
@@ -448,22 +383,6 @@ export const getEventsForWeek = (
   });
 };
 
-export const getEventsForMonth = (events: IEvent[], date: Date): IEvent[] => {
-  const startOfMonthDate = startOfMonth(date);
-  const endOfMonthDate = endOfMonth(date);
-
-  return events.filter((event) => {
-    const eventStart = parseEventStart(event);
-    const eventEnd = parseEventEnd(event);
-    return (
-      isValid(eventStart) &&
-      isValid(eventEnd) &&
-      eventStart <= endOfMonthDate &&
-      eventEnd >= startOfMonthDate
-    );
-  });
-};
-
 export const getEventsForYear = (events: IEvent[], date: Date): IEvent[] => {
   if (!events || !Array.isArray(events) || !isValid(date)) return [];
 
@@ -508,27 +427,6 @@ export const getBgColor = (color: string): string => {
     purple: "bg-purple-400 dark:bg-purple-600",
   };
   return colorClasses[color as TEventColor] || "";
-};
-
-export const getEventsByMode = (
-  events: IEvent[],
-  view: TCalendarView,
-  selectedDate: Date,
-  weekStartsOn: Day
-) => {
-  switch (view) {
-    case "day":
-    case "clock":
-      return getEventsForDay(events, selectedDate);
-    case "week":
-      return getEventsForWeek(events, selectedDate, weekStartsOn);
-    case "month":
-      return getEventsForMonth(events, selectedDate);
-    case "year":
-      return getEventsForYear(events, selectedDate);
-    default:
-      return [];
-  }
 };
 
 export const toCapitalize = (str: string): string => {


### PR DESCRIPTION
## Summary

- Removes three helpers in `src/lib/calendar-helpers.ts` named in #428 as having no production callers — `getEventsCount`, `getCalendarCells`, `getEventsByMode` — plus the transitive `getEventsForMonth` (whose only consumer was the `case "month":` branch of `getEventsByMode`).
- `rangeText` is the fourth helper in #428's table; it now has three production callers in `WeekCalendar.tsx` / `YearCalendar.tsx` / `SimpleCalendar.tsx` thanks to PR #407 (`chore(calendar): adopt rangeText in view headers`, merged today). #428 explicitly asked to re-check after #407 landed.
- Drops the corresponding `describe` blocks from `src/lib/__tests__/calendar-helpers.test.ts` and the two `getEventsForMonth` assertions inside the bare-date `getEventsForX` block (#375).
- Tidies up the now-unused `date-fns` imports (`isSameMonth`, `isSameYear`, `isSameWeek`) and the `ICalendarCell` type import.

Net diff: -308 lines, +1.

## Plan

Linked plan: `.claude/plans/calendar-helpers-dead-code-428.md`
Project: https://github.com/users/BenSeymourODB/projects/1

## Deferred work

A broader audit of `src/lib/calendar-helpers.ts` surfaced **six more** zero-caller exports not named in #428: `calculateMonthEventPositions`, `getBgColor`, `getFirstLetters`, `getMonthCellEvents`, `navigateDate`, `toCapitalize`. Those are out of scope here to keep the PR focused on the helpers #428 explicitly names. Tracked in **#471** (filed by this run).

## Test plan

- [x] `pnpm exec vitest run src/lib/__tests__/calendar-helpers.test.ts` — 1 file / 84 tests pass
- [x] `pnpm exec vitest run` — full suite: 2687 pass / 6 fail
  - All 6 failures are in `scripts/__tests__/rotate-token-encryption-key.test.ts`, which imports `@/generated/prisma/client.js`. They fail in this remote env because `prisma generate` cannot reach `binaries.prisma.sh` through the egress proxy — a pre-existing env limitation unrelated to this diff. CI is unaffected.
- [x] `pnpm lint:fix` on the two changed files — clean
- [x] `pnpm format:fix` — clean
- [ ] `pnpm check-types` — fails on pre-existing errors only:
  - `src/lib/db.ts` and several `src/lib/services/**`, `src/test/fixtures/**`, `src/lib/test-utils/**` files report `Cannot find module '@/generated/prisma/client'` (same `prisma generate` env block as above).
  - `src/components/settings/__tests__/{display-section,settings-form}.test.tsx` report a `MockUserSettings` shape mismatch (`theme`, `defaultZoomLevel`, etc.) — unrelated to this diff; likely a recent `UserSettings` schema addition that hasn't propagated to the test fixture.
  - None of the type errors touch files in this diff.
- [ ] CI on `claude/elegant-newton-aw0vr2` to confirm the env-specific failures don't reproduce there.

Closes #428.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JfgWUGsuvjhnsNhWqceeun)_