### PR TITLE
refactor(api): extract pure helpers from /api/calendar/events GET (#446)

### DIFF
--- a/.claude/plans/calendar-events-get-extract-446.md
+++ b/.claude/plans/calendar-events-get-extract-446.md
@@ -1,0 +1,228 @@
+# `/api/calendar/events` GET handler — pure-helper extraction (#446)
+
+## Problem
+
+`src/app/api/calendar/events/route.ts:GET` (~lines 169-325, ~156 lines) interleaves
+five responsibilities in one function:
+
+1. session + refresh-token auth checks (`NextResponse.json` returns)
+2. query-string parsing (defaults + comma-split)
+3. parallel `fetchEventsFromCalendar` dispatch
+4. per-calendar result aggregation with embedded auth-error short-circuit and
+   `logger.error` dedupe (`!result.error.logged`)
+5. all-fail vs success response shaping
+
+The first and third stay in the handler (they touch `NextResponse` / `Promise.all`
+of an already-pure helper); the second and fourth are pure data transforms and
+extract cleanly. The fifth is one-liner shaping and stays inline.
+
+## Out of scope
+
+- **`validateEventBody` → Zod.** The issue body lumps "migrate `validateCreateBody`
+  to a Zod schema" into the same ticket, but `validateCreateBody` was already
+  extracted (it's `validateEventBody` in `src/lib/calendar/event-body.ts`) and is
+  a pure, fully-tested function. Migrating its hand-rolled checks to Zod is a
+  separate concern — file a follow-up issue and link from the PR.
+- **`validateGetParams` "throw" pattern.** The issue suggests
+  `validateGetParams(url) → parsed params or throw`. The current handler has no
+  throwing validation in the GET path — defaults swallow every missing input.
+  Adding a throw boundary would be a behaviour change; this slice extracts the
+  data flow only.
+- **Multi-calendar response-shape semantics.** This refactor preserves wire
+  shape byte-for-byte. The existing 1,745-line integration test file is the gate.
+
+## Phases
+
+### Phase 1 — `parseGetParams`
+
+Pure function in a new module
+`src/lib/calendar/events-get-params.ts`:
+
+```ts
+export interface CalendarEventsGetParams {
+  calendarIds: string[]; // never empty; defaults to ["primary"]
+  timeMin: string; // ISO datetime; defaults to new Date().toISOString()
+  timeMax: string | null; // null when caller didn't pass it
+  maxResults: string; // string (matches Google API contract); defaults "250"
+  singleEvents: boolean; // defaults true; `singleEvents=false` flips it
+}
+
+export function parseCalendarEventsGetParams(url: URL): CalendarEventsGetParams;
+```
+
+Tests (`events-get-params.test.ts`):
+
+- empty URL → all defaults; `calendarIds === ["primary"]`, `singleEvents === true`,
+  `timeMax === null`, `timeMin` is a valid ISO string (sentinel: `Date.parse(...)`
+  not NaN), `maxResults === "250"`.
+- `?calendarId=foo` → `calendarIds === ["foo"]`.
+- `?calendarIds=a,b,c` → `calendarIds === ["a", "b", "c"]` (precedence over
+  `calendarId` — matches existing branch).
+- `?calendarIds=a&calendarId=b` → `calendarIds === ["a"]` (params-only wins, no
+  fallback merge).
+- `?singleEvents=false` → `singleEvents === false`.
+- `?singleEvents=true` → `singleEvents === true`.
+- `?singleEvents=foo` → `singleEvents === true` (current code: only literal
+  `"false"` flips it; everything else stays default).
+- `?timeMin=2024-01-01T00:00:00Z&timeMax=2024-02-01T00:00:00Z&maxResults=10`
+  → values pass through.
+
+Time injection: take `now: Date | (() => Date)` as an optional second arg so the
+test for the default-`timeMin` branch can pin a clock. Public API stays
+`parseCalendarEventsGetParams(url)` — the `now` param is internal-default.
+
+### Phase 2 — `aggregateCalendarResults`
+
+> **Revised after parallel-session feedback (issue comment 4785513589):** the
+> original draft of this plan exposed an `authError` short-circuit on the
+> aggregator's return. That would break log emission ordering — today's loop
+> interleaves `logger.error` with iteration, so a `[200, 500, 401]` fan-out
+> logs the 500 envelope first, then the 401 envelope, then returns 401.
+> Aggregating + early-returning on `authError` drops the 500 log. Fix: the
+> aggregator is a strict data transform — walks **every** result, accumulates
+> errors (including 401s) in input order. The handler iterates `errors[]`,
+> short-circuits on the first `.status === 401` after logging any non-auth
+> errors that preceded it. Order is preserved by construction.
+
+Pure function in a new module
+`src/lib/calendar/events-aggregate.ts`:
+
+```ts
+type PerCalendarResult = Awaited<ReturnType<typeof fetchEventsFromCalendar>>;
+
+export interface AggregatedCalendarFetch {
+  events: GoogleCalendarEvent[];
+  errors: InternalCalendarFetchError[]; // input order; preserves `logged`; may contain 401(s)
+  summary: string | undefined; // first successful calendar's summary
+  timeZone: string | undefined;
+}
+
+export function aggregateCalendarResults(results: PerCalendarResult[]): AggregatedCalendarFetch;
+```
+
+Behaviour mirrors the current loop's data side (logging stays in the handler):
+
+- Walks every result in input order. Pushes `result.events` to `events`.
+- Pushes `result.error` (when set) to `errors` — **including 401s**, so the
+  handler can iterate in input order and emit logs in the same sequence the
+  current code does.
+- `summary`/`timeZone` come from the **first** result with a `summary` field
+  set (matches current `if (!summary && result.summary)`).
+
+Co-locate the per-calendar error types and their wire helpers in this module
+since they all describe the same error shape:
+
+- `InternalCalendarFetchError` (was inline in `route.ts`)
+- `CalendarFetchError` (was inline in `route.ts`)
+- `toWireFetchError` (was inline in `route.ts`)
+- `resolveAllFailStatus` (was inline in `route.ts`)
+
+`route.ts` imports them back. The handler keeps the human-readable JSDoc for
+the wire contract.
+
+Tests (`events-aggregate.test.ts`):
+
+- empty input → empty events, empty errors, undefined summary/timezone.
+- all-success → events concatenated in input order; summary/timezone from first
+  successful (and only the first — later non-empty summaries don't override).
+- partial fail (one error, status 500) → that error in `errors`, events from
+  the others.
+- multiple non-401 errors → all collected in input order.
+- **`[non-401, 401]` ordering**: aggregator returns both errors in input
+  order (no early-return). This is the pin against the regression the
+  parallel session called out — without it, the helper looks correct in
+  isolation while breaking the handler's log sequence.
+- first result is 401 → 401 in `errors[0]`; later results still walked.
+- `logged: true` preserved on the returned errors (round-trip).
+- `summary`/`timeZone` come from the first result that has them set, not
+  overridden by later results.
+
+Also add a route-level integration test in `route.test.ts` that asserts the
+log sequence for the `[non-401, 401]` ordering — `logger.error` called with
+"Calendar fetch error" first, then "Google Calendar API auth error", then 401
+returned. None of the current 1,745-line route tests exercise this exact
+ordering.
+
+### Phase 3 — wire helpers into GET handler
+
+Refactor `route.ts:GET` to:
+
+```ts
+const params = parseCalendarEventsGetParams(new URL(request.url));
+const accessToken = await getAccessToken();
+const results = await Promise.all(
+  params.calendarIds.map((id) =>
+    fetchEventsFromCalendar(id, accessToken, params.timeMin, params.timeMax,
+                            params.maxResults, params.singleEvents)
+  )
+);
+const agg = aggregateCalendarResults(results);
+
+for (const err of agg.errors) {
+  if (err.status === 401) {
+    logger.error(new Error("Google Calendar API auth error"), {
+      calendarId: err.calendarId,
+      userId: session.user.id,
+    });
+    return NextResponse.json(
+      { error: "Google authentication failed. Please sign in again.",
+        requiresReauth: true },
+      { status: 401 }
+    );
+  }
+  // Skip the generic envelope when the producer already logged a
+  // richer entry (e.g. `GoogleApiValidationError`).
+  if (!err.logged) {
+    logger.error(new Error("Calendar fetch error"), {
+      calendarId: err.calendarId,
+      errorMessage: err.error,
+      errorStatus: err.status || 0,
+      userId: session.user.id,
+    });
+  }
+}
+
+if (agg.errors.length === params.calendarIds.length) {
+  return NextResponse.json(
+    { error: "Failed to fetch calendar events",
+      events: [],
+      errors: agg.errors.map(toWireFetchError) },
+    { status: resolveAllFailStatus(agg.errors) }
+  );
+}
+
+logger.log("Calendar events fetched", {
+  calendarCount: params.calendarIds.length,
+  eventCount: agg.events.length,
+  errorCount: agg.errors.length,
+  userId: session.user.id,
+});
+
+const response: { ... } = { events: agg.events, summary: agg.summary, timeZone: agg.timeZone };
+if (agg.errors.length > 0) response.errors = agg.errors.map(toWireFetchError);
+return NextResponse.json(response);
+```
+
+GET handler drops from ~156 lines to ~60. Existing route integration tests are
+the regression gate — none of them should require edits.
+
+## Files
+
+- **NEW** `src/lib/calendar/events-get-params.ts`
+- **NEW** `src/lib/calendar/__tests__/events-get-params.test.ts`
+- **NEW** `src/lib/calendar/events-aggregate.ts`
+- **NEW** `src/lib/calendar/__tests__/events-aggregate.test.ts`
+- **EDIT** `src/app/api/calendar/events/route.ts`
+
+Types `InternalCalendarFetchError` / `GoogleCalendarEvent` are shared with the
+route — export `InternalCalendarFetchError` from `events-aggregate.ts` (its
+new home; the route imports it back). `toWireFetchError` /
+`resolveAllFailStatus` stay in `route.ts` — they're closely tied to the wire
+contract.
+
+## Quality gates
+
+`pnpm lint:fix && pnpm format:fix && pnpm check-types && pnpm test`
+
+All four must pass before each commit. The existing 1,745-line
+`route.test.ts` is the integration regression guard.

--- a/src/app/api/calendar/events/__tests__/route.test.ts
+++ b/src/app/api/calendar/events/__tests__/route.test.ts
@@ -489,6 +489,64 @@ describe("/api/calendar/events", () => {
         expect(data.events[1].calendarId).toBe("work@example.com");
       });
 
+      // Regression pin (#446 extraction): on a `[non-401, 401]` fan-out the
+      // pre-extraction handler interleaved per-calendar logging with the
+      // results loop, so the non-401 "Calendar fetch error" envelope was
+      // logged BEFORE the 401 "Google Calendar API auth error" envelope.
+      // An aggregator that early-returned on the first 401 would drop the
+      // non-401 log; this test pins the existing order so a future refactor
+      // can't silently flip it.
+      it("logs the non-401 'Calendar fetch error' before the 401 envelope and returns 401", async () => {
+        vi.mocked(getSession).mockResolvedValue(mockSession);
+        vi.mocked(getAccessToken).mockResolvedValue(
+          mockGoogleAccount.access_token!
+        );
+
+        // 404 is non-transient (per `isTransientHttpError`) so
+        // `fetchWithRetry` returns it untouched on the first call. 401 is
+        // also non-transient. With two mocks queued we get exactly one
+        // outbound fetch per calendar.
+        mockFetch
+          .mockResolvedValueOnce({
+            ok: false,
+            status: 404,
+            json: () =>
+              Promise.resolve({ error: { message: "calendar missing" } }),
+          })
+          .mockResolvedValueOnce({
+            ok: false,
+            status: 401,
+            json: () =>
+              Promise.resolve({ error: { message: "token rejected" } }),
+          });
+
+        const request = createMockRequest(
+          "/api/calendar/events?calendarIds=cal-a,cal-b"
+        );
+        const response = await GET(request);
+
+        expect(response.status).toBe(401);
+        const data = (await response.json()) as ApiErrorResponse;
+        expect(data.error).toBe(
+          "Google authentication failed. Please sign in again."
+        );
+        expect(data.requiresReauth).toBe(true);
+
+        const errorLogs = vi.mocked(logger.error).mock.calls;
+        const messages = errorLogs.map(([err]) => (err as Error).message ?? "");
+        const transportIdx = messages.indexOf("Calendar fetch error");
+        const authIdx = messages.indexOf("Google Calendar API auth error");
+        expect(transportIdx).toBeGreaterThanOrEqual(0);
+        expect(authIdx).toBeGreaterThan(transportIdx);
+        // The non-401 envelope carries the cal-a context.
+        expect(errorLogs[transportIdx][1]).toMatchObject({
+          calendarId: "cal-a",
+          errorStatus: 404,
+        });
+        // The 401 envelope carries cal-b.
+        expect(errorLogs[authIdx][1]).toMatchObject({ calendarId: "cal-b" });
+      });
+
       it("handles partial failure when one calendar fails", async () => {
         vi.mocked(getSession).mockResolvedValue(mockSession);
         vi.mocked(getAccessToken).mockResolvedValue(

--- a/src/app/api/calendar/events/route.ts
+++ b/src/app/api/calendar/events/route.ts
@@ -9,6 +9,14 @@ import {
   validateEventBody,
 } from "@/lib/calendar/event-body";
 import {
+  type CalendarFetchError,
+  type InternalCalendarFetchError,
+  aggregateCalendarResults,
+  resolveAllFailStatus,
+  toWireFetchError,
+} from "@/lib/calendar/events-aggregate";
+import { parseCalendarEventsGetParams } from "@/lib/calendar/events-get-params";
+import {
   type GoogleCalendarEvent,
   normalizeFetchedEvent,
 } from "@/lib/google-calendar-mappers";
@@ -27,52 +35,6 @@ import { logger } from "@/lib/logger";
 import { NextRequest, NextResponse } from "next/server";
 
 const GOOGLE_CALENDAR_API = "https://www.googleapis.com/calendar/v3";
-
-/**
- * Wire shape for per-calendar errors surfaced in the partial-failure response.
- * Mirrors {@link InternalCalendarFetchError} minus the internal `logged` flag,
- * which is a server-side dedupe guard and must not leak to clients.
- */
-interface CalendarFetchError {
-  calendarId: string;
-  error: string;
-  status?: number;
-}
-
-interface InternalCalendarFetchError extends CalendarFetchError {
-  /**
-   * `true` when the producer has already logged a structured `logger.error`
-   * for this failure (e.g. validation errors from `parseGoogleResponse`).
-   * The outer aggregation loop honours this to avoid double-logging the same
-   * failure with a generic "Calendar fetch error" envelope on top of the
-   * rich validation entry. Internal-only — stripped before serialisation.
-   */
-  logged?: boolean;
-}
-
-/**
- * Project an internal per-calendar error onto its public wire shape, dropping
- * the server-only `logged` dedupe flag.
- */
-function toWireFetchError(e: InternalCalendarFetchError): CalendarFetchError {
-  const wire: CalendarFetchError = { calendarId: e.calendarId, error: e.error };
-  if (e.status !== undefined) wire.status = e.status;
-  return wire;
-}
-
-/**
- * Pick the HTTP status to return when every calendar in a multi-calendar
- * GET failed. If all per-calendar statuses agree, bubble that status. On
- * mixed statuses, collapse to a 502 — proxy-style "upstream failures" that
- * signals the overall request couldn't be served without claiming any
- * single upstream status as canonical. Auth (401) errors short-circuit the
- * outer handler so they never reach this function. The caller's guard
- * (`errors.length === calendarIds.length`) ensures `errors` is non-empty.
- */
-function resolveAllFailStatus(errors: InternalCalendarFetchError[]): number {
-  const first = errors[0].status ?? 500;
-  return errors.every((e) => (e.status ?? 500) === first) ? first : 502;
-}
 
 /**
  * Fetch events from a single calendar
@@ -185,79 +147,58 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    // Get query parameters
-    const { searchParams } = new URL(request.url);
-    const calendarIdsParam = searchParams.get("calendarIds");
-    const calendarId = searchParams.get("calendarId") || "primary";
-    const timeMin = searchParams.get("timeMin") || new Date().toISOString();
-    const timeMax = searchParams.get("timeMax");
-    const maxResults = searchParams.get("maxResults") || "250";
-    const singleEvents = searchParams.get("singleEvents") !== "false";
-
+    const params = parseCalendarEventsGetParams(new URL(request.url));
     // Get access token (automatically refreshed if needed)
     const accessToken = await getAccessToken();
 
-    // Determine which calendars to fetch from
-    const calendarIds = calendarIdsParam
-      ? calendarIdsParam.split(",")
-      : [calendarId];
-
     // Fetch events from all calendars in parallel
     const results = await Promise.all(
-      calendarIds.map((id) =>
+      params.calendarIds.map((id) =>
         fetchEventsFromCalendar(
           id,
           accessToken,
-          timeMin,
-          timeMax,
-          maxResults,
-          singleEvents
+          params.timeMin,
+          params.timeMax,
+          params.maxResults,
+          params.singleEvents
         )
       )
     );
 
-    // Collect events and errors
-    const allEvents: GoogleCalendarEvent[] = [];
-    const errors: InternalCalendarFetchError[] = [];
-    let summary: string | undefined;
-    let timeZone: string | undefined;
+    const agg = aggregateCalendarResults(results);
 
-    for (const result of results) {
-      allEvents.push(...result.events);
-      if (result.error) {
-        // Check if it's an auth error that should fail the whole request
-        if (result.error.status === 401) {
-          logger.error(new Error("Google Calendar API auth error"), {
-            calendarId: result.error.calendarId,
-            userId: session.user.id,
-          });
-          return NextResponse.json(
-            {
-              error: "Google authentication failed. Please sign in again.",
-              requiresReauth: true,
-            },
-            { status: 401 }
-          );
-        }
-        errors.push(result.error);
-        // Skip the generic envelope when the producer already logged a
-        // richer entry (e.g. `GoogleApiValidationError` from
-        // `parseGoogleResponse`). Otherwise we'd emit a bare
-        // "Calendar fetch error" alongside the structured one and degrade
-        // the signal in Application Insights.
-        if (!result.error.logged) {
-          logger.error(new Error("Calendar fetch error"), {
-            calendarId: result.error.calendarId,
-            errorMessage: result.error.error,
-            errorStatus: result.error.status || 0,
-            userId: session.user.id,
-          });
-        }
+    // Walk errors in input order so log emission matches the
+    // pre-extraction handler. A `[non-401, 401]` fan-out today logs the
+    // non-401 "Calendar fetch error" envelope first, then the 401
+    // "Google Calendar API auth error" envelope, then returns 401; an
+    // earlier draft that early-returned on a single `authError` field
+    // dropped the non-401 log.
+    for (const err of agg.errors) {
+      if (err.status === 401) {
+        logger.error(new Error("Google Calendar API auth error"), {
+          calendarId: err.calendarId,
+          userId: session.user.id,
+        });
+        return NextResponse.json(
+          {
+            error: "Google authentication failed. Please sign in again.",
+            requiresReauth: true,
+          },
+          { status: 401 }
+        );
       }
-      // Use summary/timezone from first successful calendar
-      if (!summary && result.summary) {
-        summary = result.summary;
-        timeZone = result.timeZone;
+      // Skip the generic envelope when the producer already logged a
+      // richer entry (e.g. `GoogleApiValidationError` from
+      // `parseGoogleResponse`). Otherwise we'd emit a bare
+      // "Calendar fetch error" alongside the structured one and degrade
+      // the signal in Application Insights.
+      if (!err.logged) {
+        logger.error(new Error("Calendar fetch error"), {
+          calendarId: err.calendarId,
+          errorMessage: err.error,
+          errorStatus: err.status || 0,
+          userId: session.user.id,
+        });
       }
     }
 
@@ -266,21 +207,21 @@ export async function GET(request: NextRequest) {
     // status without inspecting `errors[]`. Pre-#386 this was gated on
     // `calendarIds.length === 1` and multi-calendar all-fail leaked a 200
     // with an empty events array.
-    if (errors.length === calendarIds.length) {
+    if (agg.errors.length === params.calendarIds.length) {
       return NextResponse.json(
         {
           error: "Failed to fetch calendar events",
           events: [],
-          errors: errors.map(toWireFetchError),
+          errors: agg.errors.map(toWireFetchError),
         },
-        { status: resolveAllFailStatus(errors) }
+        { status: resolveAllFailStatus(agg.errors) }
       );
     }
 
     logger.log("Calendar events fetched", {
-      calendarCount: calendarIds.length,
-      eventCount: allEvents.length,
-      errorCount: errors.length,
+      calendarCount: params.calendarIds.length,
+      eventCount: agg.events.length,
+      errorCount: agg.errors.length,
       userId: session.user.id,
     });
 
@@ -291,16 +232,16 @@ export async function GET(request: NextRequest) {
       timeZone?: string;
       errors?: CalendarFetchError[];
     } = {
-      events: allEvents,
-      summary,
-      timeZone,
+      events: agg.events,
+      summary: agg.summary,
+      timeZone: agg.timeZone,
     };
 
     // Include errors array if there were partial failures. Strip the
     // server-only `logged` flag so the internal dedupe guard does not leak
     // onto the wire — clients should see only the public error shape.
-    if (errors.length > 0) {
-      response.errors = errors.map(toWireFetchError);
+    if (agg.errors.length > 0) {
+      response.errors = agg.errors.map(toWireFetchError);
     }
 
     return NextResponse.json(response);

--- a/src/lib/calendar/__tests__/events-aggregate.test.ts
+++ b/src/lib/calendar/__tests__/events-aggregate.test.ts
@@ -1,0 +1,182 @@
+import type { GoogleCalendarEvent } from "@/lib/google-calendar-mappers";
+import { describe, expect, it } from "vitest";
+import {
+  type InternalCalendarFetchError,
+  type PerCalendarFetchResult,
+  aggregateCalendarResults,
+  resolveAllFailStatus,
+  toWireFetchError,
+} from "../events-aggregate";
+
+function event(id: string): GoogleCalendarEvent {
+  return {
+    id,
+    calendarId: "cal",
+    summary: id,
+    start: { dateTime: "2024-01-01T00:00:00Z" },
+    end: { dateTime: "2024-01-01T01:00:00Z" },
+  } as GoogleCalendarEvent;
+}
+
+function ok(
+  events: GoogleCalendarEvent[],
+  extras: Partial<PerCalendarFetchResult> = {}
+): PerCalendarFetchResult {
+  return { events, ...extras };
+}
+
+function fail(
+  calendarId: string,
+  error: string,
+  status: number,
+  logged?: true
+): PerCalendarFetchResult {
+  const err: InternalCalendarFetchError = { calendarId, error, status };
+  if (logged) err.logged = true;
+  return { events: [], error: err };
+}
+
+describe("aggregateCalendarResults", () => {
+  it("returns empty defaults when there are no results", () => {
+    const agg = aggregateCalendarResults([]);
+    expect(agg.events).toEqual([]);
+    expect(agg.errors).toEqual([]);
+    expect(agg.summary).toBeUndefined();
+    expect(agg.timeZone).toBeUndefined();
+  });
+
+  it("concatenates events from successful results in input order", () => {
+    const a = event("a");
+    const b = event("b");
+    const c = event("c");
+    const agg = aggregateCalendarResults([ok([a, b]), ok([c])]);
+    expect(agg.events).toEqual([a, b, c]);
+    expect(agg.errors).toEqual([]);
+  });
+
+  it("uses summary/timeZone from the first result that has them", () => {
+    const agg = aggregateCalendarResults([
+      ok([event("a")], { summary: "work", timeZone: "UTC" }),
+      ok([event("b")], { summary: "should-not-override", timeZone: "PST" }),
+    ]);
+    expect(agg.summary).toBe("work");
+    expect(agg.timeZone).toBe("UTC");
+  });
+
+  it("treats the first result lacking a summary as a pass-through and uses the next", () => {
+    const agg = aggregateCalendarResults([
+      ok([event("a")]),
+      ok([event("b")], { summary: "fallback", timeZone: "UTC" }),
+    ]);
+    expect(agg.summary).toBe("fallback");
+    expect(agg.timeZone).toBe("UTC");
+  });
+
+  it("collects a non-401 error and preserves events from the others", () => {
+    const a = event("a");
+    const agg = aggregateCalendarResults([ok([a]), fail("cal-b", "boom", 500)]);
+    expect(agg.events).toEqual([a]);
+    expect(agg.errors).toEqual([
+      { calendarId: "cal-b", error: "boom", status: 500 },
+    ]);
+  });
+
+  it("collects multiple non-401 errors in input order", () => {
+    const agg = aggregateCalendarResults([
+      fail("cal-a", "a-down", 500),
+      fail("cal-b", "b-down", 502),
+    ]);
+    expect(agg.errors.map((e) => e.calendarId)).toEqual(["cal-a", "cal-b"]);
+    expect(agg.errors.map((e) => e.status)).toEqual([500, 502]);
+  });
+
+  it("preserves the `logged` flag on errors round-trip", () => {
+    const agg = aggregateCalendarResults([
+      fail("cal-a", "validation", 502, true),
+      fail("cal-b", "transport", 500),
+    ]);
+    expect(agg.errors[0].logged).toBe(true);
+    expect(agg.errors[1].logged).toBeUndefined();
+  });
+
+  // Regression pin (parallel-session feedback, comment 4785513589):
+  // a `[non-401, 401]` fan-out today logs the non-401 envelope before the
+  // 401 envelope. The aggregator MUST surface both errors in input order
+  // so the handler can iterate and emit logs in the same sequence.
+  it("returns 401 errors alongside non-401 errors in input order", () => {
+    const agg = aggregateCalendarResults([
+      fail("cal-a", "boom", 500),
+      fail("cal-b", "auth", 401),
+    ]);
+    expect(agg.errors.map((e) => e.status)).toEqual([500, 401]);
+    expect(agg.errors.map((e) => e.calendarId)).toEqual(["cal-a", "cal-b"]);
+  });
+
+  // The previous design had the aggregator early-exit on the first 401.
+  // That would drop later results' events and any later errors. The
+  // current contract is "strict data transform" — walk everything.
+  it("keeps walking past a 401 so later results are not dropped", () => {
+    const a = event("a");
+    const b = event("b");
+    const agg = aggregateCalendarResults([
+      ok([a]),
+      fail("cal-b", "auth", 401),
+      ok([b], { summary: "should-not-be-summary" }), // first summary was undefined
+    ]);
+    expect(agg.events).toEqual([a, b]);
+    expect(agg.errors).toEqual([
+      { calendarId: "cal-b", error: "auth", status: 401 },
+    ]);
+    // The earlier successful result had no summary, so we fall through to
+    // the third one — matches the existing `if (!summary && result.summary)`.
+    expect(agg.summary).toBe("should-not-be-summary");
+  });
+});
+
+describe("toWireFetchError", () => {
+  it("strips the internal `logged` flag", () => {
+    const wire = toWireFetchError({
+      calendarId: "cal-a",
+      error: "boom",
+      status: 502,
+      logged: true,
+    });
+    expect(wire).toEqual({ calendarId: "cal-a", error: "boom", status: 502 });
+    expect("logged" in wire).toBe(false);
+  });
+
+  it("omits `status` when the internal error did not carry one", () => {
+    const wire = toWireFetchError({ calendarId: "cal-a", error: "boom" });
+    expect(wire).toEqual({ calendarId: "cal-a", error: "boom" });
+    expect("status" in wire).toBe(false);
+  });
+});
+
+describe("resolveAllFailStatus", () => {
+  it("returns the shared status when every error agrees", () => {
+    expect(
+      resolveAllFailStatus([
+        { calendarId: "a", error: "x", status: 500 },
+        { calendarId: "b", error: "y", status: 500 },
+      ])
+    ).toBe(500);
+  });
+
+  it("collapses mixed statuses to 502", () => {
+    expect(
+      resolveAllFailStatus([
+        { calendarId: "a", error: "x", status: 500 },
+        { calendarId: "b", error: "y", status: 502 },
+      ])
+    ).toBe(502);
+  });
+
+  it("treats a missing status as 500 for the agreement check", () => {
+    expect(
+      resolveAllFailStatus([
+        { calendarId: "a", error: "x" },
+        { calendarId: "b", error: "y", status: 500 },
+      ])
+    ).toBe(500);
+  });
+});

--- a/src/lib/calendar/__tests__/events-get-params.test.ts
+++ b/src/lib/calendar/__tests__/events-get-params.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { parseCalendarEventsGetParams } from "../events-get-params";
+
+const ENDPOINT = "https://example.com/api/calendar/events";
+
+function urlFor(query: string): URL {
+  return new URL(query ? `${ENDPOINT}?${query}` : ENDPOINT);
+}
+
+describe("parseCalendarEventsGetParams", () => {
+  describe("calendarIds", () => {
+    it("defaults to ['primary'] when neither calendarId nor calendarIds is set", () => {
+      const params = parseCalendarEventsGetParams(urlFor(""));
+      expect(params.calendarIds).toEqual(["primary"]);
+    });
+
+    it("uses the single calendarId when only calendarId is set", () => {
+      const params = parseCalendarEventsGetParams(urlFor("calendarId=work"));
+      expect(params.calendarIds).toEqual(["work"]);
+    });
+
+    it("splits calendarIds on commas", () => {
+      const params = parseCalendarEventsGetParams(urlFor("calendarIds=a,b,c"));
+      expect(params.calendarIds).toEqual(["a", "b", "c"]);
+    });
+
+    it("prefers calendarIds over calendarId when both are set", () => {
+      const params = parseCalendarEventsGetParams(
+        urlFor("calendarIds=a,b&calendarId=ignored")
+      );
+      expect(params.calendarIds).toEqual(["a", "b"]);
+    });
+  });
+
+  describe("timeMin / timeMax", () => {
+    it("defaults timeMin to a valid ISO datetime", () => {
+      const params = parseCalendarEventsGetParams(urlFor(""));
+      expect(Number.isNaN(Date.parse(params.timeMin))).toBe(false);
+    });
+
+    it("passes through an explicit timeMin", () => {
+      const params = parseCalendarEventsGetParams(
+        urlFor("timeMin=2024-01-01T00%3A00%3A00Z")
+      );
+      expect(params.timeMin).toBe("2024-01-01T00:00:00Z");
+    });
+
+    it("returns null timeMax when not provided", () => {
+      const params = parseCalendarEventsGetParams(urlFor(""));
+      expect(params.timeMax).toBeNull();
+    });
+
+    it("passes through an explicit timeMax", () => {
+      const params = parseCalendarEventsGetParams(
+        urlFor("timeMax=2024-02-01T00%3A00%3A00Z")
+      );
+      expect(params.timeMax).toBe("2024-02-01T00:00:00Z");
+    });
+  });
+
+  describe("maxResults", () => {
+    it("defaults to '250' (string)", () => {
+      const params = parseCalendarEventsGetParams(urlFor(""));
+      expect(params.maxResults).toBe("250");
+    });
+
+    it("passes through an explicit value as a string", () => {
+      const params = parseCalendarEventsGetParams(urlFor("maxResults=10"));
+      // Preserved as a string — `fetchEventsFromCalendar` writes it straight
+      // to `URLSearchParams.set` which calls `String()` regardless.
+      expect(params.maxResults).toBe("10");
+    });
+  });
+
+  describe("singleEvents", () => {
+    it("defaults to true", () => {
+      const params = parseCalendarEventsGetParams(urlFor(""));
+      expect(params.singleEvents).toBe(true);
+    });
+
+    it("flips to false only when the literal string 'false' is passed", () => {
+      expect(
+        parseCalendarEventsGetParams(urlFor("singleEvents=false")).singleEvents
+      ).toBe(false);
+    });
+
+    it("stays true for 'true'", () => {
+      expect(
+        parseCalendarEventsGetParams(urlFor("singleEvents=true")).singleEvents
+      ).toBe(true);
+    });
+
+    it("stays true for any other value (matches the existing handler)", () => {
+      // The current handler uses `searchParams.get("singleEvents") !== "false"`,
+      // so anything that isn't the literal string "false" leaves singleEvents on.
+      expect(
+        parseCalendarEventsGetParams(urlFor("singleEvents=no")).singleEvents
+      ).toBe(true);
+    });
+  });
+});

--- a/src/lib/calendar/events-aggregate.ts
+++ b/src/lib/calendar/events-aggregate.ts
@@ -1,0 +1,112 @@
+/**
+ * Per-calendar fetch result aggregation for `/api/calendar/events` GET.
+ *
+ * The route fans out one `fetchEventsFromCalendar` call per requested calendar
+ * and then merges the results. This module is the pure data side of that
+ * merge: it walks every result, accumulates events and errors in input order,
+ * picks summary/timeZone from the first successful calendar, and leaves all
+ * logging + `NextResponse` shaping to the handler.
+ *
+ * **Why every error — including 401s — is surfaced in input order:** the
+ * pre-extraction handler interleaved logging with iteration. On a
+ * `[non-401, 401]` fan-out, today's order is the non-401 "Calendar fetch
+ * error" envelope first, then the 401 "Google Calendar API auth error"
+ * envelope, then the 401 response. An aggregator that early-returned on the
+ * first 401 (e.g. via an `authError` field) would drop the preceding
+ * non-401 log. So the contract here is "walk every result"; the handler
+ * iterates `errors[]` and dispatches.
+ */
+import type { GoogleCalendarEvent } from "@/lib/google-calendar-mappers";
+
+/**
+ * Wire shape for per-calendar errors surfaced in the partial-failure
+ * response. Mirrors `InternalCalendarFetchError` minus the internal
+ * `logged` flag, which is a server-side dedupe guard and must not leak
+ * to clients.
+ */
+export interface CalendarFetchError {
+  calendarId: string;
+  error: string;
+  status?: number;
+}
+
+export interface InternalCalendarFetchError extends CalendarFetchError {
+  /**
+   * `true` when the producer has already logged a structured `logger.error`
+   * for this failure (e.g. validation errors from `parseGoogleResponse`).
+   * The handler honours this to avoid double-logging the same failure with
+   * a generic "Calendar fetch error" envelope on top of the rich
+   * validation entry. Internal-only — stripped before serialisation.
+   */
+  logged?: boolean;
+}
+
+/**
+ * Shape of one per-calendar fetch outcome. Matches the return type of
+ * `fetchEventsFromCalendar` in the route handler — kept loose here so the
+ * aggregator is decoupled from that helper's signature evolution.
+ */
+export interface PerCalendarFetchResult {
+  events: GoogleCalendarEvent[];
+  error?: InternalCalendarFetchError;
+  summary?: string;
+  timeZone?: string;
+}
+
+export interface AggregatedCalendarFetch {
+  events: GoogleCalendarEvent[];
+  errors: InternalCalendarFetchError[];
+  summary: string | undefined;
+  timeZone: string | undefined;
+}
+
+export function aggregateCalendarResults(
+  results: PerCalendarFetchResult[]
+): AggregatedCalendarFetch {
+  const events: GoogleCalendarEvent[] = [];
+  const errors: InternalCalendarFetchError[] = [];
+  let summary: string | undefined;
+  let timeZone: string | undefined;
+
+  for (const result of results) {
+    events.push(...result.events);
+    if (result.error) {
+      errors.push(result.error);
+    }
+    if (!summary && result.summary) {
+      summary = result.summary;
+      timeZone = result.timeZone;
+    }
+  }
+
+  return { events, errors, summary, timeZone };
+}
+
+/**
+ * Project an internal per-calendar error onto its public wire shape,
+ * dropping the server-only `logged` dedupe flag.
+ */
+export function toWireFetchError(
+  e: InternalCalendarFetchError
+): CalendarFetchError {
+  const wire: CalendarFetchError = { calendarId: e.calendarId, error: e.error };
+  if (e.status !== undefined) wire.status = e.status;
+  return wire;
+}
+
+/**
+ * Pick the HTTP status to return when every calendar in a multi-calendar
+ * GET failed. If all per-calendar statuses agree, bubble that status. On
+ * mixed statuses, collapse to a 502 — proxy-style "upstream failures" that
+ * signals the overall request couldn't be served without claiming any
+ * single upstream status as canonical. Auth (401) errors short-circuit
+ * the outer handler so they never reach this function (the handler returns
+ * before computing the all-fail response). The caller's guard
+ * (`errors.length === calendarIds.length`) ensures `errors` is non-empty.
+ */
+export function resolveAllFailStatus(
+  errors: InternalCalendarFetchError[]
+): number {
+  const first = errors[0].status ?? 500;
+  return errors.every((e) => (e.status ?? 500) === first) ? first : 502;
+}

--- a/src/lib/calendar/events-get-params.ts
+++ b/src/lib/calendar/events-get-params.ts
@@ -1,0 +1,41 @@
+/**
+ * Pure parser for the `/api/calendar/events` GET query string. Extracted
+ * from the route handler (#446) so the data flow is testable in isolation
+ * and the handler can be a thin orchestrator.
+ *
+ * Defaults exactly match the pre-extraction handler:
+ *   - calendarIds: comma-split when present, else `[calendarId]`, else `["primary"]`
+ *   - timeMin: caller-supplied or `new Date().toISOString()`
+ *   - timeMax: caller-supplied or `null`
+ *   - maxResults: caller-supplied or `"250"` (kept as a string — Google's
+ *     `URLSearchParams.set` coerces anyway, and round-tripping through
+ *     `Number` would add lossy edge cases on huge values)
+ *   - singleEvents: only the literal string `"false"` flips the default `true`
+ */
+
+export interface CalendarEventsGetParams {
+  calendarIds: string[];
+  timeMin: string;
+  timeMax: string | null;
+  maxResults: string;
+  singleEvents: boolean;
+}
+
+export function parseCalendarEventsGetParams(
+  url: URL
+): CalendarEventsGetParams {
+  const { searchParams } = url;
+  const calendarIdsParam = searchParams.get("calendarIds");
+  const calendarId = searchParams.get("calendarId") || "primary";
+  const calendarIds = calendarIdsParam
+    ? calendarIdsParam.split(",")
+    : [calendarId];
+
+  return {
+    calendarIds,
+    timeMin: searchParams.get("timeMin") || new Date().toISOString(),
+    timeMax: searchParams.get("timeMax"),
+    maxResults: searchParams.get("maxResults") || "250",
+    singleEvents: searchParams.get("singleEvents") !== "false",
+  };
+}


### PR DESCRIPTION
## Summary

Splits the `/api/calendar/events` GET handler's two pure data flows out of
the route file, dropping the handler from ~156 lines to ~95.

- **`parseCalendarEventsGetParams(url)`** — query-string parsing +
  defaults (`calendarIds` comma-split, `singleEvents` flips only on the
  literal `"false"`, etc.).
- **`aggregateCalendarResults(results)`** — per-calendar fan-out merge.
  Walks every result, accumulates events and errors in input order
  (including 401s), picks `summary`/`timeZone` from the first
  successful calendar.

Co-locates the per-calendar error types and their wire helpers
(`InternalCalendarFetchError`, `CalendarFetchError`, `toWireFetchError`,
`resolveAllFailStatus`) next to the aggregator since they all describe
the same shape.

## Why the aggregator does NOT expose an `authError` shortcut

Pre-extraction, the handler interleaved per-calendar logging with the
results loop. On a `[non-401, 401]` fan-out the order today is:

1. `logger.error("Calendar fetch error", { calendarId: cal-a, ... })`
2. `logger.error("Google Calendar API auth error", { calendarId: cal-b, ... })`
3. Return 401 / `requiresReauth`.

An aggregator that early-returned on the first 401 (e.g. via an
`authError` field) drops step 1. To keep the log sequence honest the
aggregator stays a strict data transform, and the handler iterates
`agg.errors` in input order — short-circuiting on the first 401 only
after logging any non-auth errors that preceded it. Parallel
implement-issue session [comment 4785513589](https://github.com/BenSeymourODB/next-digital-wall-calendar/issues/446#issuecomment-4785513589)
called this out; thanks!

One new route-level integration test pins the ordering against a future
refactor that might silently flip it.

## Plan

Linked plan: `.claude/plans/calendar-events-get-extract-446.md`

## Out of scope (deferred follow-up)

- **`validateEventBody` → Zod** — filed as #474. The original #446 lumped
  this in as the POST-side complement, but `validateEventBody` is already
  a pure helper in `src/lib/calendar/event-body.ts`; switching its
  internals to Zod is behaviour-equivalent and merits its own ticket.
- **`validateGetParams` "throw" pattern** from the issue body — the
  current GET handler has no thrown validation paths to migrate;
  defaults are inert. Would only make sense alongside actual schema
  validation of query params.

## Test plan

- [x] Unit tests for `parseCalendarEventsGetParams` (14 tests covering
      every documented branch).
- [x] Unit tests for `aggregateCalendarResults`, `toWireFetchError`,
      `resolveAllFailStatus` (14 tests).
- [x] All 52 existing `/api/calendar/events` integration tests pass
      unchanged.
- [x] New route-level integration test pins the `[non-401, 401]` log
      order regression.
- [x] `pnpm lint` — clean for touched files (5 pre-existing warnings on
      unrelated files).
- [x] `pnpm format:fix` — applied.
- [x] `pnpm check-types` — no new errors. The pre-existing errors on
      `display-section.test.tsx` / `settings-form.test.tsx` (MockUserSettings
      drift) and Prisma-generated client lookups are unrelated to this
      diff.

Closes #446
Follow-up: #474 (Zod migration of `validateEventBody`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T8yvKJ41RDvWuAzbcmceTb