### PR TITLE
chore(deps): remove unused re-resizable production dep (#475)

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "next-auth": "5.0.0-beta.30",
     "next-themes": "^0.4.6",
     "pg": "^8.20.0",
-    "re-resizable": "^6.11.2",
     "react": "19.2.4",
     "react-day-picker": "^9.13.0",
     "react-dom": "19.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,9 +149,6 @@ importers:
       pg:
         specifier: ^8.20.0
         version: 8.20.0
-      re-resizable:
-        specifier: ^6.11.2
-        version: 6.11.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -5300,12 +5297,6 @@ packages:
 
   rc9@3.0.1:
     resolution: {integrity: sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==}
-
-  re-resizable@6.11.2:
-    resolution: {integrity: sha512-2xI2P3OHs5qw7K0Ud1aLILK6MQxW50TcO+DetD9eIV58j84TqYeHoZcL9H4GXFXXIh7afhH8mv5iUCXII7OW7A==}
-    peerDependencies:
-      react: ^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   react-day-picker@9.13.0:
     resolution: {integrity: sha512-euzj5Hlq+lOHqI53NiuNhCP8HWgsPf/bBAVijR50hNaY1XwjKjShAnIe8jm8RD2W9IJUvihDIZ+KrmqfFzNhFQ==}
@@ -11604,11 +11595,6 @@ snapshots:
     dependencies:
       defu: 6.1.7
       destr: 2.0.5
-
-  re-resizable@6.11.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
-    dependencies:
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
 
   react-day-picker@9.13.0(react@19.2.4):
     dependencies:


### PR DESCRIPTION
## Summary

- Removes `re-resizable@^6.11.2` from `package.json` production deps — zero imports anywhere in `src/`.
- Updates `pnpm-lock.yaml` accordingly (-14 lines, only the `re-resizable@6.11.2` resolution + snapshot).
- Distinct from `react-resizable-panels` (which remains in active use).

## Verification

```
$ grep -rn "re-resizable" src/
(no matches)

$ grep -r "re-resizable" --include='*.ts' --include='*.tsx' --include='*.js' --include='*.jsx' --include='*.mjs' --include='*.json' \
    --exclude-dir=node_modules --exclude-dir=.next .
./package.json:    "re-resizable": "^6.11.2",    # the only reference outside lockfiles
```

After removal, `pnpm install` reconciles cleanly and `pnpm test` (2708/2708) + `pnpm check-types` + `pnpm lint:fix` all pass.

## Test plan

- [x] `pnpm install --frozen-lockfile` succeeds against the updated `pnpm-lock.yaml`
- [x] `pnpm test` — 2708/2708 tests pass
- [x] `pnpm check-types` clean
- [x] `pnpm lint:fix` reports 0 errors (only pre-existing warnings unrelated to this change)
- [ ] CI build green

Closes #475

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U2HsvxKW5mNMufPmVWHxMr)_